### PR TITLE
Add conditional AMD GPU VFIO UI for Intel macOS Metal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+2026-07-23 Chronic Engineering — Intel macOS AMD GPU passthrough UI + software defaults
+
+	Conditional AMD Metal / VFIO UI (community)
+	* Detect host GPUs (Linux sysfs; Windows Win32_VideoController).
+	* Hide AMD passthrough controls when no AMD display GPU is present.
+	* Grey out when AMD is present but host cannot VFIO (Windows/WSL); enable on
+	  bare-metal Linux. Passthrough stays off by default (install with software VGA).
+	* Persist GPU_Passthrough / PCI BDFs / optional ROM; emit vfio-pci (+ HDMI audio).
+	* Refuse start when passthrough is on under Windows/WSL — WSLg ≠ PCIe assignment.
+	* Docs: docs/intel-macos-gpu.md
+
+	Software path (global default)
+	* Intel macOS continues to use vmware-svga,vgamem_mb=128 when not passthrough.
+
 2026-07-23 Chronic Engineering — Intel macOS on Windows (WSL/KVM) + installer pipeline
 
 	Intel macOS guest support (OpenCore + AppleSMC OSK)

--- a/docs/intel-macos-gpu.md
+++ b/docs/intel-macos-gpu.md
@@ -1,0 +1,27 @@
+# Intel macOS graphics in AQEMU
+
+## Defaults (everyone)
+
+Intel macOS VMs default to **VMware SVGA** (`vmware-svga` with 128 MB VRAM). This works on Windows, WSL/KVM, and Linux without a passthrough GPU. It is software-accelerated guest graphics — not Metal.
+
+## Metal / AMD GPU passthrough
+
+Apple’s Metal stack in a QEMU guest needs a **real AMD PCIe dGPU** assigned with Linux **VFIO** (`-device vfio-pci,host=BB:DD.F`).
+
+| Host | What you get |
+|------|----------------|
+| **Bare-metal Linux + AMD dGPU** | AMD GPU picker enabled (off by default). Bind the card to `vfio-pci`, then enable passthrough after install. |
+| **Windows / WSL2 (any GPU)** | If an AMD GPU is detected, the picker is **shown greyed-out** with an explanation. WSLg/GPU-PV accelerates Linux apps; it does **not** PCIe-assign the GPU into QEMU. |
+| **No AMD GPU** | Passthrough UI is **hidden**. Use VMware SVGA. |
+
+Modern **NVIDIA** GPUs do not provide macOS Metal drivers. Do not expect Metal from an RTX card.
+
+### Linux host prep (short)
+
+1. Enable IOMMU in firmware (`intel_iommu=on` / `amd_iommu=on`).
+2. Bind the AMD VGA (+ HDMI audio) to `vfio-pci` (see OSX-KVM `scripts/vfio-group.sh` and `notes.md`).
+3. Create/install the VM with **passthrough off**.
+4. In AQEMU → Intel macOS settings, select the AMD GPU and enable passthrough.
+5. Attach a display to the passed-through GPU (or use Looking Glass / similar); emulated VGA is disabled while passthrough is on.
+
+AQEMU does **not** automatically rebind drivers or edit kernel cmdline in this version.

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -84,6 +84,7 @@ QMap<QString, Available_Devices> System_Info::Emulator_QEMU_2_0;
 
 QList<VM_USB> System_Info::All_Host_USB;
 QList<VM_USB> System_Info::Used_Host_USB;
+QList<Host_GPU> System_Info::All_Host_GPU;
 
 Main_Window::Main_Window( QWidget *parent )
 	: QMainWindow( parent )
@@ -548,7 +549,21 @@ void Main_Window::Connect_Signals()
 	connect( ui.Edit_Intel_Mac_OSK_Main, SIGNAL(textEdited(const QString &)),
 			 this, SLOT(VM_Changed()) );
 	connect( ui.CH_Intel_Mac_WSL_Main, SIGNAL(toggled(bool)),
+			 this, SLOT(Update_Intel_Mac_GPU_Passthrough_Ui()) );
+	connect( ui.CH_Intel_Mac_WSL_Main, SIGNAL(toggled(bool)),
 			 this, SLOT(VM_Changed()) );
+	connect( ui.CH_Intel_Mac_GPU_Passthrough, SIGNAL(toggled(bool)),
+			 this, SLOT(VM_Changed()) );
+	connect( ui.Edit_Intel_Mac_GPU_Audio, SIGNAL(textEdited(const QString &)),
+			 this, SLOT(VM_Changed()) );
+	connect( ui.Edit_Intel_Mac_GPU_ROM, SIGNAL(textEdited(const QString &)),
+			 this, SLOT(VM_Changed()) );
+	connect( ui.TB_Intel_Mac_GPU_Refresh, SIGNAL(clicked()),
+			 this, SLOT(on_TB_Intel_Mac_GPU_Refresh_clicked()) );
+	connect( ui.TB_Intel_Mac_GPU_ROM_Browse, SIGNAL(clicked()),
+			 this, SLOT(on_TB_Intel_Mac_GPU_ROM_Browse_clicked()) );
+	connect( ui.CB_Intel_Mac_GPU, SIGNAL(currentIndexChanged(int)),
+			 this, SLOT(on_CB_Intel_Mac_GPU_currentIndexChanged(int)) );
 
 	connect( ui.CH_Fullscreen, SIGNAL(clicked()),
 			 this, SLOT(VM_Changed()) );
@@ -1265,6 +1280,25 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 		tmp_vm->Use_Apple_SMC( tmp_vm->Use_Intel_MacOS_Profile() && ! osk.trimmed().isEmpty() );
 		tmp_vm->Use_Launch_Via_WSL( wsl );
 
+		if( ui.GB_Intel_Mac_GPU_Passthrough->isVisible() )
+		{
+			const bool can_pass = ui.CH_Intel_Mac_GPU_Passthrough->isEnabled();
+			tmp_vm->Use_GPU_Passthrough( can_pass && ui.CH_Intel_Mac_GPU_Passthrough->isChecked() );
+			tmp_vm->Set_GPU_PCI_Address( ui.CB_Intel_Mac_GPU->currentData().toString() );
+			tmp_vm->Set_GPU_Audio_PCI_Address( ui.Edit_Intel_Mac_GPU_Audio->text() );
+			tmp_vm->Set_GPU_ROM_File( ui.Edit_Intel_Mac_GPU_ROM->text() );
+			tmp_vm->Use_GPU_Passthrough_Multifunction( true );
+		}
+		else
+		{
+			// No AMD on this host — preserve settings from another machine / prior save
+			tmp_vm->Use_GPU_Passthrough( old_vm->Use_GPU_Passthrough() );
+			tmp_vm->Set_GPU_PCI_Address( old_vm->Get_GPU_PCI_Address() );
+			tmp_vm->Set_GPU_Audio_PCI_Address( old_vm->Get_GPU_Audio_PCI_Address() );
+			tmp_vm->Set_GPU_ROM_File( old_vm->Get_GPU_ROM_File() );
+			tmp_vm->Use_GPU_Passthrough_Multifunction( old_vm->Use_GPU_Passthrough_Multifunction() );
+		}
+
 		// Keep Advanced Options widgets in sync
 		ui_ao.Edit_Apple_SMC_OSK->setText( osk );
 		ui_ao.Edit_OpenCore_Boot_Path->setText( oc );
@@ -1842,7 +1876,16 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	ui.Edit_Intel_Mac_Recovery_Main->setText( tmp_vm->Get_Mac_Recovery_Image_Path() );
 	ui.Edit_Intel_Mac_OSK_Main->setText( tmp_vm->Get_Apple_SMC_OSK() );
 	ui.CH_Intel_Mac_WSL_Main->setChecked( tmp_vm->Use_Launch_Via_WSL() );
+	ui.CH_Intel_Mac_GPU_Passthrough->setChecked( tmp_vm->Use_GPU_Passthrough() );
+	ui.Edit_Intel_Mac_GPU_Audio->setText( tmp_vm->Get_GPU_Audio_PCI_Address() );
+	ui.Edit_Intel_Mac_GPU_ROM->setText( tmp_vm->Get_GPU_ROM_File() );
 	Update_Intel_MacOS_Settings_Ui();
+	// Select saved GPU BDF after combo is populated
+	{
+		const int ix = ui.CB_Intel_Mac_GPU->findData( tmp_vm->Get_GPU_PCI_Address() );
+		if( ix >= 0 )
+			ui.CB_Intel_Mac_GPU->setCurrentIndex( ix );
+	}
 
 	// Repair blank/generic icons for Intel macOS VMs created before macOS icon support
 	if( tmp_vm->Use_Intel_MacOS_Profile() )
@@ -5531,6 +5574,102 @@ void Main_Window::Update_Intel_MacOS_Settings_Ui()
 	ui.verticalSpacer_intel_macos->changeSize(
 		20, show ? 16 : 0, QSizePolicy::Minimum, show ? QSizePolicy::Fixed : QSizePolicy::Ignored );
 	ui.verticalSpacer_intel_macos->invalidate();
+
+	if( show )
+		Update_Intel_Mac_GPU_Passthrough_Ui();
+	else
+		ui.GB_Intel_Mac_GPU_Passthrough->setVisible( false );
+}
+
+void Main_Window::Update_Intel_Mac_GPU_Passthrough_Ui()
+{
+	System_Info::Update_Host_GPU();
+	const bool has_amd = System_Info::Has_AMD_Display_GPU();
+	ui.GB_Intel_Mac_GPU_Passthrough->setVisible( has_amd );
+	if( ! has_amd )
+		return;
+
+	const bool can_pass = System_Info::Host_Supports_PCI_Passthrough() &&
+	                      ! ui.CH_Intel_Mac_WSL_Main->isChecked();
+
+	ui.CH_Intel_Mac_GPU_Passthrough->setEnabled( can_pass );
+	ui.CB_Intel_Mac_GPU->setEnabled( can_pass );
+	ui.Edit_Intel_Mac_GPU_Audio->setEnabled( can_pass );
+	ui.Edit_Intel_Mac_GPU_ROM->setEnabled( can_pass );
+	ui.TB_Intel_Mac_GPU_ROM_Browse->setEnabled( can_pass );
+	ui.TB_Intel_Mac_GPU_Refresh->setEnabled( true );
+
+	const QString saved_bdf = ui.CB_Intel_Mac_GPU->currentData().toString();
+	ui.CB_Intel_Mac_GPU->blockSignals( true );
+	ui.CB_Intel_Mac_GPU->clear();
+	const QList<Host_GPU> &gpus = System_Info::Get_Host_GPU_List();
+	for( int i = 0; i < gpus.count(); ++i )
+	{
+		if( ! gpus[i].Is_Display || gpus[i].Vendor != QLatin1String( "AMD" ) )
+			continue;
+		const QString label = gpus[i].PCI_Address.isEmpty()
+			? gpus[i].Name
+			: QString( "%1 (%2)" ).arg( gpus[i].Name, gpus[i].PCI_Address );
+		ui.CB_Intel_Mac_GPU->addItem( label, gpus[i].PCI_Address );
+	}
+	const int restore = ui.CB_Intel_Mac_GPU->findData( saved_bdf );
+	if( restore >= 0 )
+		ui.CB_Intel_Mac_GPU->setCurrentIndex( restore );
+	else if( ui.CB_Intel_Mac_GPU->count() > 0 )
+		ui.CB_Intel_Mac_GPU->setCurrentIndex( 0 );
+	ui.CB_Intel_Mac_GPU->blockSignals( false );
+
+	if( can_pass )
+	{
+		ui.Label_Intel_Mac_GPU_Status->setText( tr(
+			"Native Linux VFIO available. Keep passthrough off until macOS is installed; "
+			"then bind the AMD GPU to vfio-pci and enable this option." ) );
+	}
+	else
+	{
+#ifdef Q_OS_WIN32
+		ui.Label_Intel_Mac_GPU_Status->setText( tr(
+			"AMD GPU detected. Metal passthrough needs QEMU on bare-metal Linux with VFIO — "
+			"WSLg can accelerate Linux apps but cannot PCIe-assign this GPU into the guest. "
+			"Software VMware SVGA remains the working default here." ) );
+#else
+		ui.Label_Intel_Mac_GPU_Status->setText( tr(
+			"AMD GPU detected, but PCIe passthrough is not available in this environment "
+			"(WSL or no host PCI). Use bare-metal Linux for Metal." ) );
+#endif
+		ui.CH_Intel_Mac_GPU_Passthrough->setChecked( false );
+	}
+}
+
+void Main_Window::on_TB_Intel_Mac_GPU_Refresh_clicked()
+{
+	Update_Intel_Mac_GPU_Passthrough_Ui();
+	VM_Changed();
+}
+
+void Main_Window::on_TB_Intel_Mac_GPU_ROM_Browse_clicked()
+{
+	QString file = QFileDialog::getOpenFileName( this, tr( "Select GPU ROM / VBIOS" ),
+		Get_Last_Dir_Path( ui.Edit_Intel_Mac_GPU_ROM->text() ),
+		tr( "ROM (*.rom *.bin);;All Files (*)" ) );
+	if( file.isEmpty() )
+		return;
+	ui.Edit_Intel_Mac_GPU_ROM->setText( QDir::toNativeSeparators( file ) );
+	VM_Changed();
+}
+
+void Main_Window::on_CB_Intel_Mac_GPU_currentIndexChanged( int index )
+{
+	if( index < 0 )
+		return;
+	const QString bdf = ui.CB_Intel_Mac_GPU->itemData( index ).toString();
+	if( ui.Edit_Intel_Mac_GPU_Audio->text().trimmed().isEmpty() && ! bdf.isEmpty() )
+	{
+		const QString audio = System_Info::Suggest_AMD_Audio_For( bdf );
+		if( ! audio.isEmpty() )
+			ui.Edit_Intel_Mac_GPU_Audio->setText( audio );
+	}
+	VM_Changed();
 }
 
 void Main_Window::on_TB_Intel_Mac_OpenCore_Browse_Main_clicked()

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -161,8 +161,12 @@ class Main_Window: public QMainWindow
 		void Apply_Win11_Lifecycle_Mode( VM::Win11_Lifecycle_Mode mode );
 		void Update_Win11_Lifecycle_Ui();
 		void Update_Intel_MacOS_Settings_Ui();
+		void Update_Intel_Mac_GPU_Passthrough_Ui();
 		void on_TB_Intel_Mac_OpenCore_Browse_Main_clicked();
 		void on_TB_Intel_Mac_Recovery_Browse_Main_clicked();
+		void on_TB_Intel_Mac_GPU_Refresh_clicked();
+		void on_TB_Intel_Mac_GPU_ROM_Browse_clicked();
+		void on_CB_Intel_Mac_GPU_currentIndexChanged( int index );
 		
 		// Memory
 		void on_Memory_Size_valueChanged( int value );

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -1775,6 +1775,102 @@
                  </property>
                 </widget>
                </item>
+               <item row="4" column="0" colspan="3">
+                <widget class="QWidget" name="GB_Intel_Mac_GPU_Passthrough" native="true">
+                 <layout class="QGridLayout" name="gridLayout_intel_macos_gpu">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>6</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QCheckBox" name="CH_Intel_Mac_GPU_Passthrough">
+                    <property name="toolTip">
+                     <string>Pass an AMD dGPU into the guest with vfio-pci for Metal. Requires bare-metal Linux (not Windows/WSL). Install macOS with software graphics first.</string>
+                    </property>
+                    <property name="text">
+                     <string>Pass through AMD GPU (VFIO / Metal)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="Label_Intel_Mac_GPU">
+                    <property name="text">
+                     <string>AMD GPU:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="CB_Intel_Mac_GPU">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QToolButton" name="TB_Intel_Mac_GPU_Refresh">
+                    <property name="text">
+                     <string>Refresh</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="Label_Intel_Mac_GPU_Audio">
+                    <property name="text">
+                     <string>HDMI audio BDF:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1" colspan="2">
+                   <widget class="QLineEdit" name="Edit_Intel_Mac_GPU_Audio">
+                    <property name="placeholderText">
+                     <string>optional — auto if empty (e.g. 01:00.1)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="Label_Intel_Mac_GPU_ROM">
+                    <property name="text">
+                     <string>GPU ROM (optional):</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QLineEdit" name="Edit_Intel_Mac_GPU_ROM"/>
+                  </item>
+                  <item row="3" column="2">
+                   <widget class="QToolButton" name="TB_Intel_Mac_GPU_ROM_Browse">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0" colspan="3">
+                   <widget class="QLabel" name="Label_Intel_Mac_GPU_Status">
+                    <property name="wordWrap">
+                     <bool>true</bool>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -25,8 +25,12 @@
 #include <QRegExp>
 #include <QProcess>
 #include <QFile>
+#include <QFileInfo>
 #include <QDir>
 #include <QTextStream>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
 
 #include "Utils.h"
 #include "System_Info.h"
@@ -3363,6 +3367,283 @@ bool System_Info::Update_Host_USB()
 }
 
 #endif // Q_OS_WIN32
+
+Host_GPU::Host_GPU()
+	: Is_Display( false )
+	, Is_Audio( false )
+{
+}
+
+QString System_Info::Vendor_Name_From_ID( const QString &vendor_id )
+{
+	const QString v = vendor_id.toLower().trimmed();
+	if( v == QLatin1String( "1002" ) || v == QLatin1String( "0x1002" ) )
+		return QStringLiteral( "AMD" );
+	if( v == QLatin1String( "10de" ) || v == QLatin1String( "0x10de" ) )
+		return QStringLiteral( "NVIDIA" );
+	if( v == QLatin1String( "8086" ) || v == QLatin1String( "0x8086" ) )
+		return QStringLiteral( "Intel" );
+	return QStringLiteral( "Other" );
+}
+
+bool System_Info::Host_Is_WSL()
+{
+#ifdef Q_OS_WIN32
+	return false; // AQEMU itself is a native Windows process; WSL is a launch backend
+#else
+	if( QFile::exists( QStringLiteral( "/proc/sys/fs/binfmt_misc/WSLInterop" ) ) )
+		return true;
+	QFile ver( QStringLiteral( "/proc/version" ) );
+	if( ver.open( QIODevice::ReadOnly | QIODevice::Text ) )
+	{
+		const QByteArray line = ver.readAll().toLower();
+		if( line.contains( "microsoft" ) || line.contains( "wsl" ) )
+			return true;
+	}
+	return false;
+#endif
+}
+
+bool System_Info::Host_Supports_PCI_Passthrough()
+{
+#ifdef Q_OS_WIN32
+	return false;
+#else
+	if( Host_Is_WSL() )
+		return false;
+	return QDir( QStringLiteral( "/sys/bus/pci/devices" ) ).exists();
+#endif
+}
+
+const QList<Host_GPU> &System_Info::Get_Host_GPU_List()
+{
+	if( All_Host_GPU.isEmpty() )
+		Update_Host_GPU();
+	return All_Host_GPU;
+}
+
+bool System_Info::Has_AMD_Display_GPU()
+{
+	const QList<Host_GPU> &list = Get_Host_GPU_List();
+	for( int i = 0; i < list.count(); ++i )
+	{
+		if( list[i].Is_Display && list[i].Vendor == QLatin1String( "AMD" ) )
+			return true;
+	}
+	return false;
+}
+
+QString System_Info::Suggest_AMD_Audio_For( const QString &display_pci_address )
+{
+	const QString bdf = display_pci_address.trimmed();
+	if( bdf.isEmpty() )
+		return QString();
+
+	const QList<Host_GPU> &list = Get_Host_GPU_List();
+	QString display_group;
+	for( int i = 0; i < list.count(); ++i )
+	{
+		if( list[i].PCI_Address == bdf && list[i].Is_Display )
+		{
+			display_group = list[i].IOMMU_Group;
+			break;
+		}
+	}
+
+	// Prefer function .1 on the same slot (typical AMD HDMI audio)
+	QRegExp re( QStringLiteral( "^([0-9a-fA-F]{2}:[0-9a-fA-F]{2})\\.([0-9a-fA-F])$" ) );
+	QString sibling;
+	if( re.exactMatch( bdf ) )
+		sibling = re.cap( 1 ) + QLatin1String( ".1" );
+
+	for( int i = 0; i < list.count(); ++i )
+	{
+		if( ! list[i].Is_Audio || list[i].Vendor != QLatin1String( "AMD" ) )
+			continue;
+		if( ! sibling.isEmpty() && list[i].PCI_Address == sibling )
+			return list[i].PCI_Address;
+	}
+	if( ! display_group.isEmpty() )
+	{
+		for( int i = 0; i < list.count(); ++i )
+		{
+			if( list[i].Is_Audio && list[i].Vendor == QLatin1String( "AMD" ) &&
+			    list[i].IOMMU_Group == display_group )
+				return list[i].PCI_Address;
+		}
+	}
+	return QString();
+}
+
+#ifdef Q_OS_LINUX
+bool System_Info::Scan_Host_GPU_Sysfs( QList<Host_GPU> &list )
+{
+	list.clear();
+	QDir dir( QStringLiteral( "/sys/bus/pci/devices" ) );
+	if( ! dir.exists() )
+		return false;
+
+	const QStringList entries = dir.entryList( QDir::Dirs | QDir::NoDotAndDotDot );
+	for( int i = 0; i < entries.count(); ++i )
+	{
+		const QString full = entries[i]; // 0000:01:00.0
+		const QString base = QStringLiteral( "/sys/bus/pci/devices/" ) + full + QLatin1Char( '/' );
+
+		QString class_str;
+		if( ! Read_SysFS_File( base + QLatin1String( "class" ), class_str ) )
+			continue;
+		class_str = class_str.trimmed().toLower();
+		if( class_str.startsWith( QLatin1String( "0x" ) ) )
+			class_str = class_str.mid( 2 );
+		bool ok = false;
+		const quint32 class_val = class_str.toUInt( &ok, 16 );
+		if( ! ok )
+			continue;
+		const quint32 base_class = ( class_val >> 16 ) & 0xff;
+		const quint32 sub_class = ( class_val >> 8 ) & 0xff;
+		const bool is_display = ( base_class == 0x03 ); // VGA / 3D / display
+		const bool is_audio = ( base_class == 0x04 && sub_class == 0x03 ); // HD Audio
+		if( ! is_display && ! is_audio )
+			continue;
+
+		QString vendor_str, device_str;
+		Read_SysFS_File( base + QLatin1String( "vendor" ), vendor_str );
+		Read_SysFS_File( base + QLatin1String( "device" ), device_str );
+		vendor_str = vendor_str.trimmed().toLower();
+		device_str = device_str.trimmed().toLower();
+		if( vendor_str.startsWith( QLatin1String( "0x" ) ) )
+			vendor_str = vendor_str.mid( 2 );
+		if( device_str.startsWith( QLatin1String( "0x" ) ) )
+			device_str = device_str.mid( 2 );
+
+		Host_GPU gpu;
+		gpu.Vendor_ID = vendor_str;
+		gpu.Device_ID = device_str;
+		gpu.Vendor = Vendor_Name_From_ID( vendor_str );
+		gpu.Is_Display = is_display;
+		gpu.Is_Audio = is_audio;
+
+		// Strip domain prefix 0000:
+		gpu.PCI_Address = full;
+		if( gpu.PCI_Address.count( QLatin1Char( ':' ) ) >= 2 )
+			gpu.PCI_Address = gpu.PCI_Address.section( QLatin1Char( ':' ), 1 );
+
+		QFile uevent( base + QLatin1String( "uevent" ) );
+		if( uevent.open( QIODevice::ReadOnly | QIODevice::Text ) )
+		{
+			while( ! uevent.atEnd() )
+			{
+				const QByteArray line = uevent.readLine().trimmed();
+				if( line.startsWith( "DRIVER=" ) )
+					gpu.Driver = QString::fromUtf8( line.mid( 7 ) );
+			}
+		}
+
+		QFileInfo iommu( base + QLatin1String( "iommu_group" ) );
+		if( iommu.exists() )
+			gpu.IOMMU_Group = iommu.symLinkTarget().section( QLatin1Char( '/' ), -1 );
+
+		if( is_display )
+			gpu.Name = QString( "%1 GPU [%2:%3] @ %4" )
+				.arg( gpu.Vendor ).arg( vendor_str ).arg( device_str ).arg( gpu.PCI_Address );
+		else
+			gpu.Name = QString( "%1 HDMI Audio [%2:%3] @ %4" )
+				.arg( gpu.Vendor ).arg( vendor_str ).arg( device_str ).arg( gpu.PCI_Address );
+
+		list << gpu;
+	}
+	return ! list.isEmpty();
+}
+#endif
+
+#ifdef Q_OS_WIN32
+bool System_Info::Scan_Host_GPU_Windows( QList<Host_GPU> &list )
+{
+	list.clear();
+	QProcess proc;
+	proc.start( QStringLiteral( "powershell.exe" ), QStringList()
+		<< QStringLiteral( "-NoProfile" )
+		<< QStringLiteral( "-NonInteractive" )
+		<< QStringLiteral( "-Command" )
+		<< QStringLiteral(
+			"Get-CimInstance Win32_VideoController | "
+			"Select-Object Name,PNPDeviceID | ConvertTo-Json -Compress" ) );
+	if( ! proc.waitForFinished( 15000 ) )
+		return false;
+
+	const QByteArray out = proc.readAllStandardOutput().trimmed();
+	if( out.isEmpty() )
+		return false;
+
+	QJsonParseError err;
+	const QJsonDocument doc = QJsonDocument::fromJson( out, &err );
+	if( err.error != QJsonParseError::NoError )
+		return false;
+
+	QJsonArray arr;
+	if( doc.isArray() )
+		arr = doc.array();
+	else if( doc.isObject() )
+		arr.append( doc.object() );
+	else
+		return false;
+
+	for( int i = 0; i < arr.count(); ++i )
+	{
+		const QJsonObject o = arr[i].toObject();
+		const QString name = o.value( QStringLiteral( "Name" ) ).toString();
+		const QString pnp = o.value( QStringLiteral( "PNPDeviceID" ) ).toString();
+		if( name.isEmpty() )
+			continue;
+
+		Host_GPU gpu;
+		gpu.Is_Display = true;
+		gpu.Is_Audio = false;
+		gpu.Name = name;
+
+		QRegExp ven( QStringLiteral( "VEN_([0-9A-Fa-f]{4})" ) );
+		QRegExp dev( QStringLiteral( "DEV_([0-9A-Fa-f]{4})" ) );
+		if( ven.indexIn( pnp ) >= 0 )
+			gpu.Vendor_ID = ven.cap( 1 ).toLower();
+		if( dev.indexIn( pnp ) >= 0 )
+			gpu.Device_ID = dev.cap( 1 ).toLower();
+		gpu.Vendor = Vendor_Name_From_ID( gpu.Vendor_ID );
+		if( gpu.Vendor == QLatin1String( "Other" ) )
+		{
+			const QString nl = name.toLower();
+			if( nl.contains( "amd" ) || nl.contains( "radeon" ) || nl.contains( "rx " ) )
+				gpu.Vendor = QStringLiteral( "AMD" );
+			else if( nl.contains( "nvidia" ) || nl.contains( "geforce" ) || nl.contains( "rtx" ) )
+				gpu.Vendor = QStringLiteral( "NVIDIA" );
+			else if( nl.contains( "intel" ) )
+				gpu.Vendor = QStringLiteral( "Intel" );
+		}
+		list << gpu;
+	}
+	return ! list.isEmpty();
+}
+#endif
+
+bool System_Info::Update_Host_GPU()
+{
+	QList<Host_GPU> list;
+#ifdef Q_OS_LINUX
+	if( Scan_Host_GPU_Sysfs( list ) )
+	{
+		All_Host_GPU = list;
+		return true;
+	}
+#endif
+#ifdef Q_OS_WIN32
+	if( Scan_Host_GPU_Windows( list ) )
+	{
+		All_Host_GPU = list;
+		return true;
+	}
+#endif
+	All_Host_GPU = list;
+	return false;
+}
 
 bool System_Info::Auto_Find_And_Save_Emulators()
 {

--- a/src/System_Info.h
+++ b/src/System_Info.h
@@ -26,6 +26,23 @@
 #include "Utils.h"
 #include "VM_Devices.h"
 
+/** Host PCI display / HDMI-audio GPU info for AMD Metal / VFIO UI. */
+class Host_GPU
+{
+	public:
+		Host_GPU();
+
+		QString Name;
+		QString Vendor;       // "AMD", "NVIDIA", "Intel", "Other"
+		QString PCI_Address;  // BB:DD.F (empty on Windows when unknown)
+		QString Vendor_ID;    // e.g. "1002"
+		QString Device_ID;
+		bool Is_Display;
+		bool Is_Audio;
+		QString IOMMU_Group;
+		QString Driver;
+};
+
 class System_Info
 {
 	public:
@@ -56,6 +73,15 @@ class System_Info
 		static bool Add_To_Used_USB_List( const VM_USB &device );
 		static bool Delete_From_Used_USB_List( const VM_USB &device );
 		static bool Update_Host_USB();
+
+		static bool Update_Host_GPU();
+		static const QList<Host_GPU> &Get_Host_GPU_List();
+		static bool Has_AMD_Display_GPU();
+		/** Native Linux with PCI (not Windows, not WSL). Required for vfio-pci into QEMU. */
+		static bool Host_Supports_PCI_Passthrough();
+		static bool Host_Is_WSL();
+		/** Suggest AMD HDMI audio BDF for a display GPU (same slot .1 or IOMMU group). */
+		static QString Suggest_AMD_Audio_For( const QString &display_pci_address );
 		
 		static void Get_Free_Memory_Size( int &allRAM, int &freeRAM );
 		
@@ -70,10 +96,16 @@ class System_Info
 		static bool Scan_USB_Sys( QList<VM_USB> &list );
 		static bool Scan_USB_Proc( QList<VM_USB> &list );
 		static bool Read_SysFS_File( const QString &path, QString &data );
+		static bool Scan_Host_GPU_Sysfs( QList<Host_GPU> &list );
 		#endif
+		#ifdef Q_OS_WIN32
+		static bool Scan_Host_GPU_Windows( QList<Host_GPU> &list );
+		#endif
+		static QString Vendor_Name_From_ID( const QString &vendor_id );
 		
 		static QList<VM_USB> All_Host_USB;
 		static QList<VM_USB> Used_Host_USB;
+		static QList<Host_GPU> All_Host_GPU;
 };
 
 #endif

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -254,6 +254,11 @@ Virtual_Machine::Virtual_Machine( const Virtual_Machine &vm )
 	this->OpenCore_Boot_Path = vm.Get_OpenCore_Boot_Path();
 	this->Mac_Recovery_Image_Path = vm.Get_Mac_Recovery_Image_Path();
 	this->Launch_Via_WSL = vm.Use_Launch_Via_WSL();
+	this->GPU_Passthrough = vm.Use_GPU_Passthrough();
+	this->GPU_PCI_Address = vm.Get_GPU_PCI_Address();
+	this->GPU_Audio_PCI_Address = vm.Get_GPU_Audio_PCI_Address();
+	this->GPU_ROM_File = vm.Get_GPU_ROM_File();
+	this->GPU_Passthrough_Multifunction = vm.Use_GPU_Passthrough_Multifunction();
 
 	this->Enable_KVM = vm.Use_KVM();
 	this->KVM_IRQChip = vm.Use_KVM_IRQChip();
@@ -473,6 +478,11 @@ void Virtual_Machine::Shared_Constructor()
 	OpenCore_Boot_Path = "";
 	Mac_Recovery_Image_Path = "";
 	Launch_Via_WSL = false;
+	GPU_Passthrough = false;
+	GPU_PCI_Address = "";
+	GPU_Audio_PCI_Address = "";
+	GPU_ROM_File = "";
+	GPU_Passthrough_Multifunction = true;
 
 	Enable_KVM = true;
 	KVM_IRQChip = false;
@@ -595,6 +605,11 @@ bool Virtual_Machine::operator==( const Virtual_Machine &vm ) const
 		this->OpenCore_Boot_Path == vm.Get_OpenCore_Boot_Path() &&
 		this->Mac_Recovery_Image_Path == vm.Get_Mac_Recovery_Image_Path() &&
 		this->Launch_Via_WSL == vm.Use_Launch_Via_WSL() &&
+		this->GPU_Passthrough == vm.Use_GPU_Passthrough() &&
+		this->GPU_PCI_Address == vm.Get_GPU_PCI_Address() &&
+		this->GPU_Audio_PCI_Address == vm.Get_GPU_Audio_PCI_Address() &&
+		this->GPU_ROM_File == vm.Get_GPU_ROM_File() &&
+		this->GPU_Passthrough_Multifunction == vm.Use_GPU_Passthrough_Multifunction() &&
 		this->Enable_KVM == vm.Use_KVM() &&
 		this->KVM_IRQChip == vm.Use_KVM_IRQChip() &&
 		this->No_KVM_Pit == vm.Use_No_KVM_Pit() &&
@@ -852,6 +867,11 @@ Virtual_Machine &Virtual_Machine::operator=( const Virtual_Machine &vm )
 	OpenCore_Boot_Path = vm.Get_OpenCore_Boot_Path();
 	Mac_Recovery_Image_Path = vm.Get_Mac_Recovery_Image_Path();
 	Launch_Via_WSL = vm.Use_Launch_Via_WSL();
+	GPU_Passthrough = vm.Use_GPU_Passthrough();
+	GPU_PCI_Address = vm.Get_GPU_PCI_Address();
+	GPU_Audio_PCI_Address = vm.Get_GPU_Audio_PCI_Address();
+	GPU_ROM_File = vm.Get_GPU_ROM_File();
+	GPU_Passthrough_Multifunction = vm.Use_GPU_Passthrough_Multifunction();
 
 	Enable_KVM = vm.Use_KVM();
 	KVM_IRQChip = vm.Use_KVM_IRQChip();
@@ -3083,6 +3103,31 @@ bool Virtual_Machine::Create_VM_File( const QString &file_name, bool template_mo
 	VM_Element.appendChild( Dom_Element );
 	Dom_Text = New_Dom_Document.createTextNode( Launch_Via_WSL ? "true" : "false" );
 	Dom_Element.appendChild( Dom_Text );
+
+	Dom_Element = New_Dom_Document.createElement( "GPU_Passthrough" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( GPU_Passthrough ? "true" : "false" );
+	Dom_Element.appendChild( Dom_Text );
+
+	Dom_Element = New_Dom_Document.createElement( "GPU_PCI_Address" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( GPU_PCI_Address );
+	Dom_Element.appendChild( Dom_Text );
+
+	Dom_Element = New_Dom_Document.createElement( "GPU_Audio_PCI_Address" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( GPU_Audio_PCI_Address );
+	Dom_Element.appendChild( Dom_Text );
+
+	Dom_Element = New_Dom_Document.createElement( "GPU_ROM_File" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( GPU_ROM_File );
+	Dom_Element.appendChild( Dom_Text );
+
+	Dom_Element = New_Dom_Document.createElement( "GPU_Passthrough_Multifunction" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( GPU_Passthrough_Multifunction ? "true" : "false" );
+	Dom_Element.appendChild( Dom_Text );
 	
 	// Additional Arguments
 	Dom_Element = New_Dom_Document.createElement( "Additional_Args" );
@@ -4819,6 +4864,14 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 			OpenCore_Boot_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "OpenCore_Boot_Path" ).text() );
 			Mac_Recovery_Image_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Mac_Recovery_Image_Path" ).text() );
 			Launch_Via_WSL = ( Child_Element.firstChildElement( "Launch_Via_WSL" ).text() == "true" );
+			GPU_Passthrough = ( Child_Element.firstChildElement( "GPU_Passthrough" ).text() == "true" );
+			GPU_PCI_Address = Child_Element.firstChildElement( "GPU_PCI_Address" ).text().trimmed();
+			GPU_Audio_PCI_Address = Child_Element.firstChildElement( "GPU_Audio_PCI_Address" ).text().trimmed();
+			GPU_ROM_File = AQ_Normalize_File_Path( Child_Element.firstChildElement( "GPU_ROM_File" ).text() );
+			{
+				const QString mf = Child_Element.firstChildElement( "GPU_Passthrough_Multifunction" ).text();
+				GPU_Passthrough_Multifunction = ( mf.isEmpty() || mf == QLatin1String( "true" ) );
+			}
 			
 			// Enable KVM
 			Enable_KVM = ! (Child_Element.firstChildElement("Enable_KVM").text() == "false" );
@@ -6044,6 +6097,20 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	{
 		if( effective_video == "none" )
 			Args << "-vga" << "none";
+		else if( Intel_MacOS_Profile && GPU_Passthrough && ! GPU_PCI_Address.trimmed().isEmpty() )
+		{
+			// Real AMD dGPU via VFIO — no emulated VGA.
+			Args << "-vga" << "none";
+		}
+		else if( Intel_MacOS_Profile &&
+		         ( effective_video == QLatin1String( "vmware" ) ||
+		           effective_video == QLatin1String( "vmware-svga" ) ||
+		           effective_video == QLatin1String( "std" ) ) )
+		{
+			// std VGA tops out ~2560x1440. vmware-svga + large VRAM unlocks 4K modes.
+			Args << "-vga" << "none";
+			Args << "-device" << "vmware-svga,vgamem_mb=128";
+		}
 		else
 			Args << "-vga" << effective_video;
 	}
@@ -7641,6 +7708,29 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	if( Intel_MacOS_Profile )
 		Args << "-smbios" << "type=2";
 
+	// AMD GPU VFIO passthrough (Metal) — native Linux only; gated at Start_vm()
+	if( Intel_MacOS_Profile && GPU_Passthrough && ! GPU_PCI_Address.trimmed().isEmpty() )
+	{
+		QString gpu_dev = QStringLiteral( "vfio-pci,host=%1" ).arg( GPU_PCI_Address.trimmed() );
+		if( GPU_Passthrough_Multifunction )
+			gpu_dev += QLatin1String( ",multifunction=on" );
+		const QString rom = AQ_Normalize_File_Path( GPU_ROM_File );
+		if( ! rom.isEmpty() )
+		{
+			if( Build_QEMU_Args_for_Script_Mode )
+				gpu_dev += QStringLiteral( ",romfile=\"%1\"" ).arg( rom );
+			else
+				gpu_dev += QStringLiteral( ",romfile=%1" ).arg( rom );
+		}
+		Args << "-device" << gpu_dev;
+
+		QString audio_bdf = GPU_Audio_PCI_Address.trimmed();
+		if( audio_bdf.isEmpty() )
+			audio_bdf = System_Info::Suggest_AMD_Audio_For( GPU_PCI_Address );
+		if( ! audio_bdf.isEmpty() )
+			Args << "-device" << QStringLiteral( "vfio-pci,host=%1" ).arg( audio_bdf );
+	}
+
 	// Recovery / installer is attached earlier with OpenCore on AHCI
 	// (ide-hd for MIST APM+HFS; ide-cd for true ISO9660).
 	
@@ -8322,6 +8412,32 @@ bool Virtual_Machine::Start_impl()
 			return false;
 		}
 		Use_Apple_SMC_Flag = true;
+
+		if( GPU_Passthrough )
+		{
+			const bool via_wsl = Launch_Via_WSL;
+#ifdef Q_OS_WIN32
+			const bool host_ok = false;
+#else
+			const bool host_ok = System_Info::Host_Supports_PCI_Passthrough();
+#endif
+			if( via_wsl || ! host_ok )
+			{
+				AQGraphic_Warning( tr( "AMD GPU passthrough" ),
+					tr( "GPU passthrough (Metal) needs QEMU on bare-metal Linux with VFIO.\n\n"
+					    "WSLg can accelerate Linux apps, but cannot PCIe-assign a dGPU into the "
+					    "macOS guest. Disable GPU passthrough or run AQEMU on native Linux with "
+					    "an AMD GPU bound to vfio-pci." ) );
+				return false;
+			}
+			if( GPU_PCI_Address.trimmed().isEmpty() )
+			{
+				AQGraphic_Warning( tr( "AMD GPU passthrough" ),
+					tr( "GPU passthrough is enabled but no PCI address is set.\n"
+					    "Select an AMD GPU in the Intel macOS settings." ) );
+				return false;
+			}
+		}
 	}
 
 	#ifdef Q_OS_WIN32
@@ -10487,6 +10603,56 @@ bool Virtual_Machine::Use_Launch_Via_WSL() const
 void Virtual_Machine::Use_Launch_Via_WSL( bool use )
 {
 	Launch_Via_WSL = use;
+}
+
+bool Virtual_Machine::Use_GPU_Passthrough() const
+{
+	return GPU_Passthrough;
+}
+
+void Virtual_Machine::Use_GPU_Passthrough( bool use )
+{
+	GPU_Passthrough = use;
+}
+
+const QString &Virtual_Machine::Get_GPU_PCI_Address() const
+{
+	return GPU_PCI_Address;
+}
+
+void Virtual_Machine::Set_GPU_PCI_Address( const QString &bdf )
+{
+	GPU_PCI_Address = bdf.trimmed();
+}
+
+const QString &Virtual_Machine::Get_GPU_Audio_PCI_Address() const
+{
+	return GPU_Audio_PCI_Address;
+}
+
+void Virtual_Machine::Set_GPU_Audio_PCI_Address( const QString &bdf )
+{
+	GPU_Audio_PCI_Address = bdf.trimmed();
+}
+
+const QString &Virtual_Machine::Get_GPU_ROM_File() const
+{
+	return GPU_ROM_File;
+}
+
+void Virtual_Machine::Set_GPU_ROM_File( const QString &path )
+{
+	GPU_ROM_File = AQ_Normalize_File_Path( path );
+}
+
+bool Virtual_Machine::Use_GPU_Passthrough_Multifunction() const
+{
+	return GPU_Passthrough_Multifunction;
+}
+
+void Virtual_Machine::Use_GPU_Passthrough_Multifunction( bool use )
+{
+	GPU_Passthrough_Multifunction = use;
 }
 
 bool Virtual_Machine::Use_KVM() const

--- a/src/VM.h
+++ b/src/VM.h
@@ -414,6 +414,18 @@ class Virtual_Machine: public QObject
 		/** Launch this VM via wsl.exe + Linux QEMU (KVM) on Windows. */
 		bool Use_Launch_Via_WSL() const;
 		void Use_Launch_Via_WSL( bool use );
+
+		/** AMD GPU VFIO passthrough for Intel macOS Metal (native Linux only). */
+		bool Use_GPU_Passthrough() const;
+		void Use_GPU_Passthrough( bool use );
+		const QString &Get_GPU_PCI_Address() const;
+		void Set_GPU_PCI_Address( const QString &bdf );
+		const QString &Get_GPU_Audio_PCI_Address() const;
+		void Set_GPU_Audio_PCI_Address( const QString &bdf );
+		const QString &Get_GPU_ROM_File() const;
+		void Set_GPU_ROM_File( const QString &path );
+		bool Use_GPU_Passthrough_Multifunction() const;
+		void Use_GPU_Passthrough_Multifunction( bool use );
 		
 		bool Use_KVM() const;
 		void Use_KVM( bool use );
@@ -692,6 +704,12 @@ class Virtual_Machine: public QObject
 		QString OpenCore_Boot_Path;
 		QString Mac_Recovery_Image_Path;
 		bool Launch_Via_WSL;
+
+		bool GPU_Passthrough;
+		QString GPU_PCI_Address;
+		QString GPU_Audio_PCI_Address;
+		QString GPU_ROM_File;
+		bool GPU_Passthrough_Multifunction;
 
 		bool Enable_KVM;
 		bool KVM_IRQChip;

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -936,7 +936,10 @@ void VM_Wizard_Window::Build_Intel_MacOS_Page()
 	QLabel *intro = new QLabel( tr(
 		"<b>Intel macOS (experimental)</b> — AQEMU does not ship OpenCore, OVMF, OSK, or Apple OS images. "
 		"Uses <code>qemu-system-x86_64</code> + <code>q35</code> + OVMF. "
-		"OpenCore <b>.iso</b> files attach as CD/DVD." ) );
+		"OpenCore <b>.iso</b> files attach as CD/DVD.<br/>"
+		"Default display is VMware SVGA (software). "
+		"<b>AMD Metal</b> passthrough appears only when an AMD GPU is detected, and only works on "
+		"bare-metal Linux with VFIO — not Windows/WSL. Install macOS first, then enable passthrough." ) );
 	intro->setWordWrap( true );
 	intro->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Minimum );
 	mainLay->addWidget( intro );
@@ -2401,7 +2404,7 @@ void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )
 	New_VM->Set_SMP_CPU_Count( 2 );
 	if( New_VM->Get_Memory_Size() < 4096 )
 		New_VM->Set_Memory_Size( 4096 );
-	New_VM->Set_Video_Card( QString() ); // machine/VGA defaults; avoid cirrus for OpenCore
+	New_VM->Set_Video_Card( QStringLiteral( "vmware" ) ); // vmware-svga — HiDPI/4K friendly vs std VGA
 	New_VM->Use_USB_Hub( true );
 	New_VM->Set_Mouse_Type( QStringLiteral( "usb-tablet" ) );
 	New_VM->Set_Mouse_USB_Controller( QStringLiteral( "xhci" ) );


### PR DESCRIPTION
## Summary
- Add host GPU detection and a conditional AMD Metal/VFIO picker for Intel macOS: hidden with no AMD GPU, greyed on Windows/WSL, enabled on bare-metal Linux (off by default).
- Persist passthrough settings, emit `vfio-pci` (+ HDMI audio) when enabled, and refuse start under Windows/WSL where PCIe assignment is impossible.
- Keep VMware SVGA as the working global software default; document the paths in `docs/intel-macos-gpu.md`.

## Test plan
- [ ] On NVIDIA-only Windows: Intel macOS settings show no AMD passthrough block; VM still uses vmware-svga.
- [ ] On Windows with an AMD GPU: picker appears greyed with WSLg/VFIO explanation; enabling is not possible / start refuses if forced on.
- [ ] On bare-metal Linux + AMD: picker enabled, default off; after selecting GPU and enabling, QEMU args include `-vga none` and `vfio-pci,host=...`.
- [ ] Wizard text mentions install-first + Metal Linux-only limits.
- [ ] Save/reload VM preserves GPU_Passthrough fields in the `.aqemu` file.

Made with [Cursor](https://cursor.com)