### PR TITLE
Automate Intel macOS resolution to match host screen

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2026-07-23 Chronic Engineering — Intel macOS match host / 4K resolution via OpenCore
+
+	* Enable General → Resolution for Intel macOS (not only VirtIO-GPU).
+	* Default new Intel macOS VMs to Native (host physical pixels, DPI-aware).
+	* On start, patch OpenCore FAT config.plist Resolution (+ ForceResolution) via mtools.
+	* Add 3840x2160 / 4096x2160 presets; raise vmware-svga VRAM to 256MB for ≥1440p.
+	* Docs updated in docs/intel-macos-gpu.md.
+
 2026-07-23 Chronic Engineering — Intel macOS AMD GPU passthrough UI + software defaults
 
 	Conditional AMD Metal / VFIO UI (community)

--- a/docs/intel-macos-gpu.md
+++ b/docs/intel-macos-gpu.md
@@ -2,7 +2,18 @@
 
 ## Defaults (everyone)
 
-Intel macOS VMs default to **VMware SVGA** (`vmware-svga` with 128 MB VRAM). This works on Windows, WSL/KVM, and Linux without a passthrough GPU. It is software-accelerated guest graphics — not Metal.
+Intel macOS VMs default to **VMware SVGA** (`vmware-svga`) and **Native (host screen)** resolution.
+
+On each start, AQEMU patches OpenCore’s `UEFI → Output → Resolution` inside the prepared OpenCore BOOT image to match:
+
+- **Native** — primary monitor **physical** pixels (`logical size × devicePixelRatio`), clamped to 1024×768 … 4096×2160  
+- Or an explicit preset (1080p / 1440p / 4K UHD / 4K DCI)
+
+macOS **System Settings → Displays** often still shows a single “Unknown Display” mode; that is normal. The OpenCore patch is what actually sets the framebuffer.
+
+VRAM uses 128 MB VRAM, or 256 MB when the target is ≥ 2560×1440.
+
+Change **Resolution** on the General tab, Apply/auto-save, then **fully reboot** the guest (not just log out).
 
 ## Metal / AMD GPU passthrough
 

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -2887,6 +2887,8 @@ void Main_Window::Fill_Display_Resolution_Combo()
 	ui.CB_Display_Resolution->addItem( QStringLiteral( "1600 × 900" ), QStringLiteral( "1600x900" ) );
 	ui.CB_Display_Resolution->addItem( QStringLiteral( "1920 × 1080" ), QStringLiteral( "1920x1080" ) );
 	ui.CB_Display_Resolution->addItem( QStringLiteral( "2560 × 1440" ), QStringLiteral( "2560x1440" ) );
+	ui.CB_Display_Resolution->addItem( QStringLiteral( "3840 × 2160 (4K UHD)" ), QStringLiteral( "3840x2160" ) );
+	ui.CB_Display_Resolution->addItem( QStringLiteral( "4096 × 2160 (4K DCI)" ), QStringLiteral( "4096x2160" ) );
 	ui.CB_Display_Resolution->setCurrentIndex( 0 );
 	ui.CB_Display_Resolution->blockSignals( false );
 }
@@ -3055,10 +3057,24 @@ void Main_Window::Update_Display_Resolution_Enabled()
 	}
 
 	const bool virtio = video.contains( QStringLiteral( "virtio-gpu" ), Qt::CaseInsensitive );
+	Virtual_Machine *vm = Get_Current_VM();
+	const bool intel_mac = vm && vm->Use_Intel_MacOS_Profile();
+	const bool mac_vga = intel_mac && (
+		video.contains( QStringLiteral( "vmware" ), Qt::CaseInsensitive ) ||
+		video.contains( QStringLiteral( "std" ), Qt::CaseInsensitive ) ||
+		video.isEmpty() );
 	// Respect parent tab enablement (disabled while VM is running).
 	const bool parent_ok = ui.Tab_General->isEnabled();
-	ui.CB_Display_Resolution->setEnabled( virtio && parent_ok );
-	ui.Label_Display_Resolution->setEnabled( virtio && parent_ok );
+	const bool enable = ( virtio || mac_vga ) && parent_ok;
+	ui.CB_Display_Resolution->setEnabled( enable );
+	ui.Label_Display_Resolution->setEnabled( enable );
+	if( intel_mac )
+	{
+		ui.CB_Display_Resolution->setToolTip( tr(
+			"Intel macOS: AQEMU patches OpenCore UEFI Resolution to this size on start "
+			"(System Settings rarely lists modes). Native uses your host physical pixels "
+			"(DPI-aware), up to 4096×2160. Reboot the guest after changing." ) );
+	}
 }
 
 void Main_Window::VM_Changed()

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -689,7 +689,7 @@
                     </sizepolicy>
                    </property>
                    <property name="toolTip">
-                    <string>Guest display size for VirtIO GPU (EDID). Lower resolutions are faster on ARM/TCG. Windows on ARM often cannot change this from inside the guest.</string>
+                    <string>Guest display size. VirtIO GPU: EDID xres/yres. Intel macOS: patches OpenCore Resolution on start (Native = host physical pixels, up to 4096×2160).</string>
                    </property>
                    <property name="sizeAdjustPolicy">
                     <enum>QComboBox::AdjustToMinimumContentsLength</enum>

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,14 +28,18 @@
 #include <QDateTime>
 #include <QMessageBox>
 #include <QApplication>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QCoreApplication>
 #include <QSettings>
 #include <QRegExp>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QStringList>
 #include <QTextStream>
 #include <QObject>
 #include <QSysInfo>
+#include <QTemporaryDir>
 
 #include <cmath>
 
@@ -692,6 +696,187 @@ QString AQ_Ensure_OpenCore_Boot_With_PartitionDxe( const QString &opencore_iso,
 #endif
 
 	return QFile::exists( dest ) ? dest : QString();
+}
+
+bool AQ_Resolve_Display_Size( const QString &mode, int *out_w, int *out_h )
+{
+	if( ! out_w || ! out_h )
+		return false;
+	*out_w = 0;
+	*out_h = 0;
+
+	const QString m = mode.trimmed().toLower();
+	if( m.isEmpty() || m == QLatin1String( "auto" ) )
+		return false;
+
+	int rw = 0, rh = 0;
+	if( m == QLatin1String( "native" ) )
+	{
+		QScreen *screen = QGuiApplication::primaryScreen();
+		if( ! screen )
+			return false;
+		const qreal dpr = screen->devicePixelRatio();
+		const QSize logical = screen->size();
+		rw = qRound( logical.width() * dpr );
+		rh = qRound( logical.height() * dpr );
+	}
+	else
+	{
+		const QStringList parts = mode.split( QLatin1Char( 'x' ), QString::SkipEmptyParts );
+		if( parts.size() != 2 )
+			return false;
+		bool okw = false, okh = false;
+		rw = parts.at( 0 ).trimmed().toInt( &okw );
+		rh = parts.at( 1 ).trimmed().toInt( &okh );
+		if( ! okw || ! okh )
+			return false;
+	}
+
+	// Soft clamp — extreme modes often fall back to 1280x800 in macOS guests.
+	if( rw < 1024 ) rw = 1024;
+	if( rh < 768 ) rh = 768;
+	if( rw > 4096 ) rw = 4096;
+	if( rh > 2160 ) rh = 2160;
+
+	*out_w = rw;
+	*out_h = rh;
+	return true;
+}
+
+static bool AQ_Rewrite_OpenCore_Plist_Resolution( const QString &plist_path,
+                                                   const QString &resolution_wxh )
+{
+	QFile f( plist_path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return false;
+	QByteArray data = f.readAll();
+	f.close();
+	if( data.isEmpty() )
+		return false;
+
+	const QByteArray res = resolution_wxh.toUtf8();
+	QRegExp re_res( QStringLiteral( "(<key>Resolution</key>\\s*<string>)[^<]*(</string>)" ) );
+	re_res.setMinimal( true );
+	QString text = QString::fromUtf8( data );
+	if( re_res.indexIn( text ) < 0 )
+		return false;
+	{
+		const QString replaced = re_res.cap( 1 ) + QString::fromUtf8( res ) + re_res.cap( 2 );
+		text.replace( re_res.pos( 0 ), re_res.matchedLength(), replaced );
+	}
+
+	// Prefer ForceResolution so OC does not silently pick Max/empty.
+	QRegExp re_force( QStringLiteral(
+		"(<key>ForceResolution</key>\\s*)<(true|false)\\s*/>" ) );
+	re_force.setMinimal( true );
+	if( re_force.indexIn( text ) >= 0 )
+	{
+		const QString replaced = re_force.cap( 1 ) + QStringLiteral( "<true/>" );
+		text.replace( re_force.pos( 0 ), re_force.matchedLength(), replaced );
+	}
+
+	if( ! f.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+		return false;
+	const QByteArray out = text.toUtf8();
+	const bool ok = f.write( out ) == out.size();
+	f.close();
+	return ok;
+}
+
+bool AQ_Patch_OpenCore_FAT_Resolution( const QString &fat_img, const QString &resolution_wxh )
+{
+	const QString img = AQ_Normalize_File_Path( fat_img );
+	const QString res = resolution_wxh.trimmed();
+	if( img.isEmpty() || res.isEmpty() || ! QFile::exists( img ) )
+		return false;
+
+	const QString stamp = img + QStringLiteral( ".aqemu-resolution" );
+	{
+		QFile sf( stamp );
+		if( sf.open( QIODevice::ReadOnly ) &&
+		    QString::fromUtf8( sf.readAll() ).trimmed() == res )
+			return true;
+	}
+
+#ifdef Q_OS_WIN32
+	QTemporaryDir tmp;
+	if( ! tmp.isValid() )
+		return false;
+	const QString host_plist = tmp.filePath( QStringLiteral( "config.plist" ) );
+	const QString wsl_img = QStringLiteral( "/mnt/%1%2" )
+		.arg( img.at( 0 ).toLower() )
+		.arg( QDir::fromNativeSeparators( img.mid( 2 ) ) );
+	const QString wsl_plist = QStringLiteral( "/mnt/%1%2" )
+		.arg( host_plist.at( 0 ).toLower() )
+		.arg( QDir::fromNativeSeparators( host_plist.mid( 2 ) ) );
+
+	QProcess extract;
+	extract.setProgram( QStringLiteral( "wsl" ) );
+	extract.setArguments( QStringList()
+		<< QStringLiteral( "-e" ) << QStringLiteral( "bash" ) << QStringLiteral( "-lc" )
+		<< QStringLiteral(
+			"set -e; export MTOOLS_SKIP_CHECK=1; "
+			"mcopy -n -i \"%1\" ::/EFI/OC/config.plist \"%2\"" )
+			.arg( wsl_img, wsl_plist ) );
+	extract.start();
+	if( ! extract.waitForFinished( 60000 ) || extract.exitCode() != 0 )
+		return false;
+
+	if( ! AQ_Rewrite_OpenCore_Plist_Resolution( host_plist, res ) )
+		return false;
+
+	QProcess inject;
+	inject.setProgram( QStringLiteral( "wsl" ) );
+	inject.setArguments( QStringList()
+		<< QStringLiteral( "-e" ) << QStringLiteral( "bash" ) << QStringLiteral( "-lc" )
+		<< QStringLiteral(
+			"set -e; export MTOOLS_SKIP_CHECK=1; "
+			"mcopy -o -i \"%1\" \"%2\" ::/EFI/OC/config.plist" )
+			.arg( wsl_img, wsl_plist ) );
+	inject.start();
+	if( ! inject.waitForFinished( 60000 ) || inject.exitCode() != 0 )
+		return false;
+#else
+	QTemporaryDir tmp;
+	if( ! tmp.isValid() )
+		return false;
+	const QString host_plist = tmp.filePath( QStringLiteral( "config.plist" ) );
+	QProcess extract;
+	extract.start( QStringLiteral( "mcopy" ), QStringList()
+		<< QStringLiteral( "-n" ) << QStringLiteral( "-i" ) << img
+		<< QStringLiteral( "::/EFI/OC/config.plist" ) << host_plist );
+	if( ! extract.waitForFinished( 60000 ) || extract.exitCode() != 0 )
+	{
+		// mtools may need MTOOLS_SKIP_CHECK
+		QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+		env.insert( QStringLiteral( "MTOOLS_SKIP_CHECK" ), QStringLiteral( "1" ) );
+		extract.setProcessEnvironment( env );
+		extract.start( QStringLiteral( "mcopy" ), QStringList()
+			<< QStringLiteral( "-n" ) << QStringLiteral( "-i" ) << img
+			<< QStringLiteral( "::/EFI/OC/config.plist" ) << host_plist );
+		if( ! extract.waitForFinished( 60000 ) || extract.exitCode() != 0 )
+			return false;
+	}
+	if( ! AQ_Rewrite_OpenCore_Plist_Resolution( host_plist, res ) )
+		return false;
+	QProcess inject;
+	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+	env.insert( QStringLiteral( "MTOOLS_SKIP_CHECK" ), QStringLiteral( "1" ) );
+	inject.setProcessEnvironment( env );
+	inject.start( QStringLiteral( "mcopy" ), QStringList()
+		<< QStringLiteral( "-o" ) << QStringLiteral( "-i" ) << img
+		<< host_plist << QStringLiteral( "::/EFI/OC/config.plist" ) );
+	if( ! inject.waitForFinished( 60000 ) || inject.exitCode() != 0 )
+		return false;
+#endif
+
+	QFile stamp_out( stamp );
+	if( stamp_out.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+	{
+		stamp_out.write( res.toUtf8() );
+		stamp_out.close();
+	}
+	return true;
 }
 
 bool AQ_Is_Plausible_Apple_SMC_OSK( const QString &osk )

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -104,6 +104,19 @@ qint64 AQ_Apple_HFS_Partition_Offset( const QString &path );
 QString AQ_Ensure_OpenCore_Boot_With_PartitionDxe( const QString &opencore_iso,
                                                    const QString &dest_boot_img );
 
+/**
+ * Resolve Display_Resolution setting to pixel size.
+ * "native" = primary screen physical pixels (logical × devicePixelRatio).
+ * "auto"/empty = false. "WxH" = parsed. Clamped to 1024x768 … 4096x2160.
+ */
+bool AQ_Resolve_Display_Size( const QString &mode, int *out_w, int *out_h );
+
+/**
+ * Patch UEFI/Output/Resolution (and ForceResolution) inside an OpenCore FAT image
+ * (BOOT.img). Uses WSL+mtools on Windows. Returns true on success.
+ */
+bool AQ_Patch_OpenCore_FAT_Resolution( const QString &fat_img, const QString &resolution_wxh );
+
 bool It_Host_Device( const QString &path );
 
 void Check_AQEMU_Permissions();

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -6057,23 +6057,22 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 
 			if( mode.isEmpty() || mode == "native" )
 			{
-				if( QGuiApplication::primaryScreen() )
+				int nrw = 0, nrh = 0;
+				if( AQ_Resolve_Display_Size( QStringLiteral( "native" ), &nrw, &nrh ) )
 				{
-					const QSize sz = QGuiApplication::primaryScreen()->size();
-					rw = sz.width();
-					rh = sz.height();
-					have_size = ( rw >= 640 && rh >= 480 );
+					rw = nrw;
+					rh = nrh;
+					have_size = true;
 				}
 			}
 			else if( mode != "auto" )
 			{
-				const QStringList parts = mode.split( QLatin1Char( 'x' ) );
-				if( parts.size() == 2 )
+				int nrw = 0, nrh = 0;
+				if( AQ_Resolve_Display_Size( mode, &nrw, &nrh ) )
 				{
-					bool okw = false, okh = false;
-					rw = parts.at( 0 ).toInt( &okw );
-					rh = parts.at( 1 ).toInt( &okh );
-					have_size = okw && okh && rw >= 640 && rh >= 480;
+					rw = nrw;
+					rh = nrh;
+					have_size = true;
 				}
 			}
 
@@ -6108,8 +6107,14 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		           effective_video == QLatin1String( "std" ) ) )
 		{
 			// std VGA tops out ~2560x1440. vmware-svga + large VRAM unlocks 4K modes.
+			// Guest mode list comes from OpenCore Resolution (patched below), not xres/yres.
+			int vram_mb = 128;
+			int rw = 0, rh = 0;
+			if( AQ_Resolve_Display_Size( Display_Resolution, &rw, &rh ) &&
+			    ( rw * rh ) >= ( 2560 * 1440 ) )
+				vram_mb = 256;
 			Args << "-vga" << "none";
-			Args << "-device" << "vmware-svga,vgamem_mb=128";
+			Args << "-device" << QStringLiteral( "vmware-svga,vgamem_mb=%1" ).arg( vram_mb );
 		}
 		else
 			Args << "-vga" << effective_video;
@@ -6474,6 +6479,38 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				{
 					oc_file = prepared;
 					mac_oc_has_partition_dxe = true;
+				}
+			}
+
+			// Match host / chosen resolution into OpenCore (macOS Displays menu is mostly useless).
+			if( ! Build_QEMU_Args_for_Tab_Info && QFile::exists( oc_file ) )
+			{
+				int rw = 0, rh = 0;
+				QString res_mode = Display_Resolution.trimmed();
+				if( res_mode.isEmpty() || res_mode.compare( QLatin1String( "auto" ), Qt::CaseInsensitive ) == 0 )
+					res_mode = QStringLiteral( "native" );
+				if( AQ_Resolve_Display_Size( res_mode, &rw, &rh ) )
+				{
+					const QString wxh = QStringLiteral( "%1x%2" ).arg( rw ).arg( rh );
+					const QString lower_oc = oc_file.toLower();
+					const bool looks_fat =
+						lower_oc.endsWith( QLatin1String( ".img" ) ) ||
+						lower_oc.endsWith( QLatin1String( ".raw" ) ) ||
+						lower_oc.contains( QLatin1String( "_opencore_boot" ) );
+					if( looks_fat )
+					{
+						if( ! AQ_Patch_OpenCore_FAT_Resolution( oc_file, wxh ) )
+						{
+							AQWarning( "Virtual_Machine::Build_QEMU_Args()",
+								QStringLiteral( "Could not patch OpenCore Resolution to %1 in %2" )
+									.arg( wxh, oc_file ) );
+						}
+						else
+						{
+							AQDebug( "Virtual_Machine::Build_QEMU_Args()",
+								QStringLiteral( "OpenCore Resolution set to %1" ).arg( wxh ) );
+						}
+					}
 				}
 			}
 

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -2405,6 +2405,7 @@ void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )
 	if( New_VM->Get_Memory_Size() < 4096 )
 		New_VM->Set_Memory_Size( 4096 );
 	New_VM->Set_Video_Card( QStringLiteral( "vmware" ) ); // vmware-svga — HiDPI/4K friendly vs std VGA
+	New_VM->Set_Display_Resolution( QStringLiteral( "native" ) ); // match host; OpenCore patched on start
 	New_VM->Use_USB_Hub( true );
 	New_VM->Set_Mouse_Type( QStringLiteral( "usb-tablet" ) );
 	New_VM->Set_Mouse_USB_Controller( QStringLiteral( "xhci" ) );


### PR DESCRIPTION
## Summary
- Enable **General → Resolution** for Intel macOS (not only VirtIO-GPU) and default new VMs to **Native (host screen)**.
- On start, patch OpenCore `UEFI/Output/Resolution` (+ `ForceResolution`) in the prepared BOOT FAT image via mtools/WSL.
- Native uses **physical** pixels (logical × devicePixelRatio), clamped to 1024×768…4096×2160; presets include 4K UHD/DCI; `vmware-svga` VRAM rises to 256MB for ≥1440p.

## Why
macOS System Settings often shows only **1280×800** on emulated GPUs. Community guidance (OSX-KVM) is to set OpenCore Resolution — AQEMU now does that automatically so users get host-matching (or chosen) modes without hand-editing plists.

## Test plan
- [ ] Rebuild/start Intel macOS VM with Resolution = Native; confirm OpenCore BOOT `.aqemu-resolution` stamp and guest boots larger than 1280×800 when host is larger.
- [ ] Set Resolution to `1920x1080` or `3840x2160`, restart guest, confirm stamp updates.
- [ ] Resolution combo enabled for Intel macOS + vmware video; still works for VirtIO-GPU as before.

Made with [Cursor](https://cursor.com)