### PR TITLE
Fix Qodo PR #13 review bugs + shared UI chrome

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ SET( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/resources/cmake/modules )
 SET( aqemu_headers
     src/No_Boot_Device.h
     src/Highlighted_Label.h
+    src/AQ_UI_Style.h
     src/Service.h
     src/Run_Guard.h
     src/QEMU_Docopt.h
@@ -108,6 +109,7 @@ SET( aqemu_headers
 SET( aqemu_sources
     src/No_Boot_Device.cpp
     src/Highlighted_Label.cpp
+    src/AQ_UI_Style.cpp
     src/Service.cpp
     src/Run_Guard.cpp
     src/QEMU_Docopt.cpp

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -1,0 +1,318 @@
+/****************************************************************************
+** Shared AQEMU UI look: cards, tabs, group boxes (app-wide).
+****************************************************************************/
+
+#include "AQ_UI_Style.h"
+
+#include <QApplication>
+#include <QWidget>
+#include <QLayout>
+#include <QLayoutItem>
+#include <QSpacerItem>
+#include <QVBoxLayout>
+#include <QGridLayout>
+#include <QScrollArea>
+#include <QFrame>
+#include <QSizePolicy>
+#include <QGroupBox>
+#include <QTabWidget>
+#include <QListWidget>
+
+void AQ_Apply_App_Style( QApplication *app )
+{
+	if( ! app )
+		return;
+
+	app->setStyleSheet( QStringLiteral( R"(
+/* —— Global chrome —— */
+QMainWindow, QDialog {
+	background-color: palette(window);
+}
+
+QGroupBox {
+	font-weight: 600;
+	border: 1px solid palette(mid);
+	border-radius: 6px;
+	margin-top: 12px;
+	padding: 10px 8px 8px 8px;
+	background-color: palette(base);
+}
+QGroupBox::title {
+	subcontrol-origin: margin;
+	subcontrol-position: top left;
+	left: 10px;
+	padding: 0 6px;
+	color: palette(window-text);
+}
+
+QTabWidget::pane {
+	border: 1px solid palette(mid);
+	border-radius: 4px;
+	top: -1px;
+	background: palette(window);
+	padding: 4px;
+}
+QTabBar::tab {
+	padding: 6px 14px;
+	margin-right: 2px;
+	border: 1px solid transparent;
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	background: transparent;
+}
+QTabBar::tab:selected {
+	background: palette(base);
+	border: 1px solid palette(mid);
+	border-bottom-color: palette(base);
+	font-weight: 600;
+}
+QTabBar::tab:hover:!selected {
+	background: palette(alternate-base);
+}
+
+QListWidget, QTreeWidget, QTableWidget {
+	border: 1px solid palette(mid);
+	border-radius: 4px;
+	background: palette(base);
+	padding: 2px;
+	outline: 0;
+}
+QListWidget::item, QTreeWidget::item {
+	padding: 4px 6px;
+	border-radius: 3px;
+}
+QListWidget::item:selected, QTreeWidget::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+}
+
+QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
+	padding: 3px 6px;
+	border: 1px solid palette(mid);
+	border-radius: 4px;
+	background: palette(base);
+	min-height: 22px;
+	selection-background-color: palette(highlight);
+}
+QComboBox::drop-down {
+	border: none;
+	width: 20px;
+}
+QComboBox QAbstractItemView {
+	border: 1px solid palette(mid);
+	selection-background-color: palette(highlight);
+}
+
+QPushButton {
+	padding: 5px 14px;
+	border: 1px solid palette(mid);
+	border-radius: 4px;
+	background: palette(button);
+	min-height: 22px;
+}
+QPushButton:hover {
+	background: palette(light);
+}
+QPushButton:pressed {
+	background: palette(midlight);
+}
+QPushButton:default {
+	font-weight: 600;
+	border-color: palette(highlight);
+}
+QToolButton {
+	padding: 3px 8px;
+	border-radius: 4px;
+}
+
+QCheckBox, QRadioButton {
+	spacing: 6px;
+	padding: 2px 0;
+}
+
+QSlider::groove:horizontal {
+	height: 6px;
+	border-radius: 3px;
+	background: palette(mid);
+}
+QSlider::handle:horizontal {
+	width: 14px;
+	margin: -5px 0;
+	border-radius: 7px;
+	background: palette(highlight);
+}
+
+QScrollArea {
+	border: none;
+	background: transparent;
+}
+QScrollBar:vertical {
+	width: 10px;
+	background: transparent;
+	margin: 0;
+}
+QScrollBar::handle:vertical {
+	background: palette(mid);
+	border-radius: 4px;
+	min-height: 24px;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+	height: 0;
+}
+
+QStatusBar {
+	border-top: 1px solid palette(mid);
+}
+QMenuBar {
+	background: palette(window);
+	border-bottom: 1px solid palette(mid);
+	padding: 2px;
+}
+QMenuBar::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+	border-radius: 3px;
+}
+QSplitter::handle {
+	background: palette(mid);
+	width: 1px;
+	height: 1px;
+}
+
+/* Section headers used on the VM page */
+Highlighted_Label {
+	font-size: 13px;
+	font-weight: 600;
+	color: palette(link);
+	padding: 8px 10px 4px 10px;
+	border-bottom: 1px solid palette(mid);
+	margin-top: 2px;
+	background: transparent;
+}
+)" ) );
+}
+
+void AQ_Style_Card( QWidget *w, int max_width )
+{
+	if( ! w || w->objectName().isEmpty() )
+		return;
+	w->setStyleSheet(
+		QStringLiteral(
+			"QWidget#%1 {"
+			"  background-color: palette(base);"
+			"  border: 1px solid palette(mid);"
+			"  border-radius: 6px;"
+			"  margin: 0px 4px 6px 4px;"
+			"  padding: 4px;"
+			"}"
+		).arg( w->objectName() ) );
+	if( max_width > 0 )
+		w->setMaximumWidth( max_width );
+}
+
+void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px )
+{
+	if( ! layout )
+		return;
+	for( int i = 0; i < layout->count(); ++i )
+	{
+		QLayoutItem *it = layout->itemAt( i );
+		if( ! it )
+			continue;
+		if( QSpacerItem *sp = it->spacerItem() )
+		{
+			QSizePolicy::Policy vp = sp->sizePolicy().verticalPolicy();
+			if( vp == QSizePolicy::Expanding || vp == QSizePolicy::MinimumExpanding ||
+			    sp->sizeHint().height() > gap_px + 4 )
+			{
+				sp->changeSize( 20, gap_px, QSizePolicy::Minimum, QSizePolicy::Fixed );
+			}
+		}
+		else if( QLayout *sub = it->layout() )
+		{
+			AQ_Tighten_Layout_Spacers( sub, gap_px );
+		}
+	}
+}
+
+void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name )
+{
+	if( ! tab )
+		return;
+	QLayout *old = tab->layout();
+	if( ! old )
+		return;
+	// Already wrapped?
+	if( tab->findChild<QScrollArea*>( QStringLiteral( "AQ_Tab_Scroll" ),
+	                                  Qt::FindDirectChildrenOnly ) )
+		return;
+
+	QWidget *inner = new QWidget();
+	inner->setObjectName( inner_object_name.isEmpty()
+		? QStringLiteral( "AQ_Tab_Inner" ) : inner_object_name );
+
+	QVBoxLayout *innerLay = new QVBoxLayout( inner );
+	innerLay->setContentsMargins( 10, 8, 14, 12 );
+	innerLay->setSpacing( 6 );
+
+	if( QVBoxLayout *vold = qobject_cast<QVBoxLayout*>( old ) )
+	{
+		while( vold->count() > 0 )
+		{
+			QLayoutItem *it = vold->takeAt( 0 );
+			if( ! it )
+				continue;
+			if( QSpacerItem *sp = it->spacerItem() )
+				sp->changeSize( 20, 6, QSizePolicy::Minimum, QSizePolicy::Fixed );
+			innerLay->addItem( it );
+		}
+		delete vold;
+	}
+	else if( QGridLayout *gold = qobject_cast<QGridLayout*>( old ) )
+	{
+		// Lift the single primary child (usually a nested tab widget) into the scroll page.
+		QList<QLayoutItem*> items;
+		while( gold->count() > 0 )
+			items.append( gold->takeAt( 0 ) );
+		delete gold;
+		for( QLayoutItem *it : items )
+		{
+			if( ! it )
+				continue;
+			if( QSpacerItem *sp = it->spacerItem() )
+				sp->changeSize( 20, 6, QSizePolicy::Minimum, QSizePolicy::Fixed );
+			innerLay->addItem( it );
+		}
+	}
+	else
+	{
+		delete inner;
+		return;
+	}
+
+	innerLay->addStretch( 1 );
+
+	QScrollArea *scroll = new QScrollArea( tab );
+	scroll->setObjectName( QStringLiteral( "AQ_Tab_Scroll" ) );
+	scroll->setWidgetResizable( true );
+	scroll->setFrameShape( QFrame::NoFrame );
+	scroll->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+	scroll->setWidget( inner );
+
+	QVBoxLayout *outer = new QVBoxLayout( tab );
+	outer->setContentsMargins( 0, 0, 0, 0 );
+	outer->setSpacing( 0 );
+	outer->addWidget( scroll );
+}
+
+void AQ_Cap_Content_Width( QWidget *root, int max_width )
+{
+	if( ! root )
+		return;
+	const auto boxes = root->findChildren<QGroupBox*>();
+	for( QGroupBox *gb : boxes )
+	{
+		if( gb && gb->maximumWidth() > max_width )
+			gb->setMaximumWidth( max_width );
+	}
+}

--- a/src/AQ_UI_Style.h
+++ b/src/AQ_UI_Style.h
@@ -1,0 +1,28 @@
+/****************************************************************************
+** Shared AQEMU UI look: cards, tabs, group boxes (app-wide).
+****************************************************************************/
+#ifndef AQ_UI_STYLE_H
+#define AQ_UI_STYLE_H
+
+#include <QString>
+
+class QApplication;
+class QWidget;
+class QLayout;
+
+/** Install the global AQEMU chrome (group boxes, tabs, lists, inputs). */
+void AQ_Apply_App_Style( QApplication *app );
+
+/** Style a flat QWidget as a bordered content card (objectName required). */
+void AQ_Style_Card( QWidget *w, int max_width = 0 );
+
+/** Move an existing layout into a scrollable inner page (packs to top). */
+void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name = QString() );
+
+/** Collapse large expanding vertical spacers to small fixed gaps. */
+void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px = 6 );
+
+/** Cap readable content width on common panels under root. */
+void AQ_Cap_Content_Width( QWidget *root, int max_width = 960 );
+
+#endif

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -37,6 +37,7 @@
 #include <QRadioButton>
 
 #include "Advanced_Settings_Window.h"
+#include "AQ_UI_Style.h"
 #include "System_Info.h"
 #include "Utils.h"
 #include "WSL_Launch.h"
@@ -49,6 +50,8 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	: QDialog( parent )
 {
 	ui.setupUi( this );
+
+	AQ_Cap_Content_Width( this, 980 );
 
     settings_widget = new Settings_Widget( ui.All_Tabs, QBoxLayout::TopToBottom, true, false );
 

--- a/src/Emulator_Control_Window.cpp
+++ b/src/Emulator_Control_Window.cpp
@@ -49,11 +49,13 @@
 #include "QMP_Client.h"
 #include "Migrate_Progress_Dialog.h"
 #include "Migrate_URI_Dialog.h"
+#include "AQ_UI_Style.h"
 
 Emulator_Control_Window::Emulator_Control_Window( QWidget *parent )
 	: QMainWindow( parent )
 {
 	ui.setupUi( this );
+	AQ_Cap_Content_Width( this, 900 );
 	
 	First_Start = true;
 	Fullscreen_Menu_Added = false;

--- a/src/First_Start_Wizard.cpp
+++ b/src/First_Start_Wizard.cpp
@@ -31,6 +31,7 @@
 #include <QVBoxLayout>
 
 #include "First_Start_Wizard.h"
+#include "AQ_UI_Style.h"
 #include "Utils.h"
 #include "System_Info.h"
 #include "Advanced_Settings_Window.h"
@@ -41,6 +42,7 @@ First_Start_Wizard::First_Start_Wizard( QWidget *parent )
 	: QDialog( parent )
 {
 	ui.setupUi( this );
+	AQ_Cap_Content_Width( this, 720 );
 
 	RB_FS_QEMU_Built_In = nullptr;
 	RB_FS_QEMU_Custom = nullptr;

--- a/src/Highlighted_Label.cpp
+++ b/src/Highlighted_Label.cpp
@@ -36,9 +36,12 @@ Highlighted_Label::Highlighted_Label(QWidget* parent) : QLabel(parent)
         setStyleSheet(R"(
         Highlighted_Label
             {
-                font-size: medium;
+                font-size: 13px;
                 font-weight: 600;
                 color: palette(link);
+                padding: 8px 10px 4px 10px;
+                border-bottom: 1px solid palette(mid);
+                margin-top: 2px;
             }
         )");
     }
@@ -47,8 +50,11 @@ Highlighted_Label::Highlighted_Label(QWidget* parent) : QLabel(parent)
         setStyleSheet(R"(
         Highlighted_Label
             {
-                font-size: medium;
+                font-size: 13px;
                 font-weight: 600;
+                padding: 8px 10px 4px 10px;
+                border-bottom: 1px solid palette(mid);
+                margin-top: 2px;
             }
         )");
     }

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -50,9 +50,15 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QGridLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QClipboard>
+#include <QScrollArea>
+#include <QFrame>
+#include <QSizePolicy>
+#include <QSpacerItem>
+#include <QGroupBox>
 #ifndef Q_OS_WIN32
 #include <QtDBus>
 #endif
@@ -84,6 +90,7 @@
 #include "Settings_Widget.h"
 #include "Storage_Browser_Window.h"
 #include "Remote_Host_Window.h"
+#include "AQ_UI_Style.h"
 #include "Utils.h"
 #include "Blockdev_Graph_Window.h"
 #include "Service.h"
@@ -213,6 +220,8 @@ Main_Window::Main_Window( QWidget *parent )
 	fixComboElide( ui.CB_Disk_Interface );
 	fixComboElide( ui_arch.CB_Machine_Type );
 	fixComboElide( ui_arch.CB_CPU_Type );
+
+	Polish_Settings_Tabs_Layout();
 
 	Fill_Display_Resolution_Combo();
 	Update_Display_Resolution_Enabled();
@@ -570,6 +579,103 @@ Virtual_Machine *Main_Window::Get_Current_VM()
         return NULL;
 
 	return Get_VM_By_UID( ui.Machines_List->currentItem()->data(256).toString() );
+}
+
+void Main_Window::Polish_Settings_Tabs_Layout()
+{
+	// Scrollable pages with stacked sections; nested-tab pages get chrome only.
+	AQ_Make_Tab_Scrollable( ui.Tab_General, QStringLiteral( "VM_Tab_Inner" ) );
+	AQ_Make_Tab_Scrollable( ui.Tab_Display, QStringLiteral( "Display_Tab_Inner" ) );
+
+	AQ_Style_Card( ui.widget, 980 ); // Machine
+	AQ_Style_Card( ui.GB_Memory, 920 );
+	AQ_Style_Card( ui.GB_Audio, 920 );
+	AQ_Style_Card( ui.GB_Disk_Bus, 920 );
+	AQ_Style_Card( ui.GB_Win11_Lifecycle, 920 );
+	AQ_Style_Card( ui.GB_Intel_MacOS_Settings, 920 );
+	AQ_Style_Card( ui.GB_Options, 920 );
+	AQ_Style_Card( ui.Widget_Use_Network, 960 );
+
+	if( ui.Memory_Size )
+	{
+		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+		ui.Memory_Size->setMaximumHeight( 28 );
+		ui.Memory_Size->setMinimumHeight( 22 );
+	}
+	if( ui.CB_RAM_Size )
+		ui.CB_RAM_Size->setMinimumWidth( 110 );
+
+	if( ui.TB_Show_Advanced_Options_Window )
+	{
+		ui.TB_Show_Advanced_Options_Window->setSizePolicy(
+			QSizePolicy::Maximum, QSizePolicy::Fixed );
+		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( 120 );
+	}
+
+	if( ui.GB_Options )
+	{
+		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.GB_Options->layout() ) )
+			gl->setColumnStretch( 3, 1 );
+	}
+
+	if( ui.GB_Guest_Display_Mode )
+		ui.GB_Guest_Display_Mode->setMaximumWidth( 960 );
+
+	auto polish_nested_tabs = []( QTabWidget *tw ) {
+		if( ! tw ) return;
+		tw->setDocumentMode( true );
+		tw->setElideMode( Qt::ElideRight );
+		AQ_Cap_Content_Width( tw, 960 );
+		if( QWidget *parent = tw->parentWidget() )
+		{
+			if( QLayout *lay = parent->layout() )
+			{
+				lay->setContentsMargins( 8, 8, 8, 8 );
+				AQ_Tighten_Layout_Spacers( lay, 6 );
+			}
+		}
+	};
+	polish_nested_tabs( ui.TabWidget_Media );
+	polish_nested_tabs( ui.TabWidget_Display );
+	polish_nested_tabs( ui.Network_Cards_Tabs );
+
+	if( ui.Tab_Media && ui.Tab_Media->layout() )
+	{
+		ui.Tab_Media->layout()->setContentsMargins( 8, 8, 8, 8 );
+		ui.Tab_Media->layout()->setSpacing( 6 );
+	}
+	if( ui.Tab_Network && ui.Tab_Network->layout() )
+	{
+		ui.Tab_Network->layout()->setContentsMargins( 8, 8, 8, 8 );
+		ui.Tab_Network->layout()->setSpacing( 6 );
+	}
+	if( ui.Tab_Info && ui.Tab_Info->layout() )
+	{
+		ui.Tab_Info->layout()->setContentsMargins( 8, 8, 8, 8 );
+		if( ui.VM_Information_Text )
+		{
+			ui.VM_Information_Text->setFrameShape( QFrame::StyledPanel );
+			ui.VM_Information_Text->setStyleSheet(
+				QStringLiteral(
+					"QTextEdit {"
+					"  border: 1px solid palette(mid);"
+					"  border-radius: 6px;"
+					"  background: palette(base);"
+					"  padding: 8px;"
+					"}" ) );
+		}
+	}
+
+	if( ui.Machines_List )
+	{
+		ui.Machines_List->setSpacing( 2 );
+		ui.Machines_List->setUniformItemSizes( true );
+	}
+
+	if( ui.Tabs )
+		ui.Tabs->setDocumentMode( true );
+
+	AQ_Cap_Content_Width( this, 980 );
 }
 
 void Main_Window::Connect_Signals()

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -246,6 +246,7 @@ class Main_Window: public QMainWindow
         void init_dbus();
 		
 		void Connect_Signals();
+		void Polish_Settings_Tabs_Layout();
 		
 		const QMap<QString, Available_Devices> Get_Devices_Info( bool *ok ) const;
 		Available_Devices Get_Current_Machine_Devices( bool *ok ) const;

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -1015,10 +1015,16 @@
                  <item row="0" column="1" colspan="2">
                   <widget class="QPushButton" name="TB_Show_Advanced_Options_Window">
                    <property name="sizePolicy">
-                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
                      <verstretch>0</verstretch>
                     </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>120</width>
+                     <height>0</height>
+                    </size>
                    </property>
                    <property name="text">
                     <string>Advanced</string>
@@ -1055,10 +1061,13 @@
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>6</height>
                </size>
               </property>
              </spacer>
@@ -1214,10 +1223,16 @@
                  <item>
                   <widget class="QSlider" name="Memory_Size">
                    <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
                      <verstretch>0</verstretch>
                     </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>28</height>
+                    </size>
                    </property>
                    <property name="minimum">
                     <number>2</number>
@@ -1347,10 +1362,13 @@
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>6</height>
                </size>
               </property>
              </spacer>
@@ -1787,10 +1805,13 @@
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>6</height>
                </size>
               </property>
              </spacer>

--- a/src/Remote_Host_Window.cpp
+++ b/src/Remote_Host_Window.cpp
@@ -22,6 +22,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QInputDialog>
+#include <QIntValidator>
 
 Remote_Host_Window::Remote_Host_Window( QWidget *parent )
 	: QDialog( parent )
@@ -52,6 +53,10 @@ Remote_Host_Window::Remote_Host_Window( QWidget *parent )
 	Edit_Ssh_Port = new QLineEdit( QStringLiteral( "22" ) );
 	Edit_Qmp_Port = new QLineEdit( QStringLiteral( "4444" ) );
 	Edit_Spice_Port = new QLineEdit( QStringLiteral( "5930" ) );
+	auto *port_val = new QIntValidator( 1, 65535, this );
+	Edit_Ssh_Port->setValidator( port_val );
+	Edit_Qmp_Port->setValidator( port_val );
+	Edit_Spice_Port->setValidator( port_val );
 	Edit_Libvirt_Uri = new QLineEdit();
 	Edit_Libvirt_Uri->setPlaceholderText( QStringLiteral( "qemu+ssh://user@host/system" ) );
 	form->addRow( tr( "Name" ), Edit_Name );
@@ -198,18 +203,42 @@ void Remote_Host_Window::Open_Ssh_Tunnels()
 	}
 	const QString user = Edit_User->text().trimmed().isEmpty()
 		? QStringLiteral( "root" ) : Edit_User->text().trimmed();
-	const QString ssh_port = Edit_Ssh_Port->text().trimmed().isEmpty()
-		? QStringLiteral( "22" ) : Edit_Ssh_Port->text().trimmed();
-	const QString qmp = Edit_Qmp_Port->text().trimmed().isEmpty()
-		? QStringLiteral( "4444" ) : Edit_Qmp_Port->text().trimmed();
-	const QString spice = Edit_Spice_Port->text().trimmed().isEmpty()
-		? QStringLiteral( "5930" ) : Edit_Spice_Port->text().trimmed();
+
+	auto parse_port = [this]( QLineEdit *edit, const QString &label, int fallback, int *out ) -> bool {
+		const QString t = edit->text().trimmed();
+		const QString use = t.isEmpty() ? QString::number( fallback ) : t;
+		bool ok = false;
+		const int p = use.toInt( &ok );
+		if( ! ok || p < 1 || p > 65535 )
+		{
+			QMessageBox::warning( this, tr( "SSH" ),
+				tr( "%1 must be a TCP port between 1 and 65535." ).arg( label ) );
+			return false;
+		}
+		*out = p;
+		return true;
+	};
+
+	int ssh_port = 22, qmp = 4444, spice = 5930;
+	if( ! parse_port( Edit_Ssh_Port, tr( "SSH port" ), 22, &ssh_port ) )
+		return;
+	if( ! parse_port( Edit_Qmp_Port, tr( "Remote QMP port" ), 4444, &qmp ) )
+		return;
+	if( ! parse_port( Edit_Spice_Port, tr( "Remote SPICE port" ), 5930, &spice ) )
+		return;
+
+	// Canonical decimal strings for the SSH command line.
+	Edit_Ssh_Port->setText( QString::number( ssh_port ) );
+	Edit_Qmp_Port->setText( QString::number( qmp ) );
+	Edit_Spice_Port->setText( QString::number( spice ) );
 
 	const QStringList args = QStringList()
 		<< QStringLiteral( "-N" )
-		<< QStringLiteral( "-p" ) << ssh_port
-		<< QStringLiteral( "-L" ) << QString( "127.0.0.1:%1:127.0.0.1:%1" ).arg( qmp )
-		<< QStringLiteral( "-L" ) << QString( "127.0.0.1:%1:127.0.0.1:%1" ).arg( spice )
+		<< QStringLiteral( "-p" ) << QString::number( ssh_port )
+		<< QStringLiteral( "-L" )
+		<< QStringLiteral( "127.0.0.1:%1:127.0.0.1:%1" ).arg( qmp )
+		<< QStringLiteral( "-L" )
+		<< QStringLiteral( "127.0.0.1:%1:127.0.0.1:%1" ).arg( spice )
 		<< ( user + QLatin1Char( '@' ) + host );
 
 	const bool ok = QProcess::startDetached( QStringLiteral( "ssh" ), args );
@@ -218,14 +247,14 @@ void Remote_Host_Window::Open_Ssh_Tunnels()
 		QMessageBox::information( this, tr( "SSH tunnels" ),
 			tr( "Could not start ssh. Run manually:\n\nssh -N -p %1 -L 127.0.0.1:%2:127.0.0.1:%2 "
 			    "-L 127.0.0.1:%3:127.0.0.1:%3 %4@%5" )
-				.arg( ssh_port, qmp, spice, user, host ) );
+				.arg( ssh_port ).arg( qmp ).arg( spice ).arg( user, host ) );
 		return;
 	}
 	QMessageBox::information( this, tr( "SSH tunnels" ),
 		tr( "SSH tunnel started (background).\n"
 		    "Local QMP: 127.0.0.1:%1\nLocal SPICE: 127.0.0.1:%2\n"
 		    "Point a remote viewer / future AQEMU remote session at those ports." )
-			.arg( qmp, spice ) );
+			.arg( qmp ).arg( spice ) );
 }
 
 void Remote_Host_Window::Launch_Libvirt_Helper()

--- a/src/Settings_Widget.cpp
+++ b/src/Settings_Widget.cpp
@@ -29,6 +29,7 @@
 #include <QSplitter>
 
 #include "Settings_Widget.h"
+#include "AQ_UI_Style.h"
 #include "Utils.h"
 
 #include <iostream>
@@ -150,7 +151,11 @@ Settings_Widget::Settings_Widget(QTabWidget* tab_widget, QBoxLayout::Direction d
     {
         if ( erase_margins )
             stack->setContentsMargins(0,0,0,0);
+        list->setSpacing( 3 );
+        list->setUniformItemSizes( true );
     }
+
+    AQ_Cap_Content_Width( this, 980 );
 }
 
 void Settings_Widget::setCurrentIndex(int i)

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -2690,6 +2690,11 @@ const QList<VM_USB> &System_Info::Get_Cached_Host_USB()
 	return All_Host_USB;
 }
 
+void System_Info::Set_Cached_Host_USB( const QList<VM_USB> &list )
+{
+	All_Host_USB = list;
+}
+
 const QList<VM_USB> &System_Info::Get_Used_USB_List()
 {
 	return Used_Host_USB;
@@ -2712,32 +2717,34 @@ bool System_Info::Delete_From_Used_USB_List( const VM_USB &device )
 
 #ifdef Q_OS_LINUX
 
+bool System_Info::Scan_Host_USB_Snapshot( QList<VM_USB> &out )
+{
+	out.clear();
+
+	if( QFile::exists("/sys/bus/usb") )
+	{
+		if( Scan_USB_Sys(out) )
+			return true;
+	}
+
+	if( QFile::exists("/proc/bus/usb/devices") )
+	{
+		if( Scan_USB_Proc(out) )
+			return true;
+	}
+
+	AQError( "bool System_Info::Scan_Host_USB_Snapshot()",
+			 "Cannot read USB information from /sys, /proc, /dev!" );
+	return false;
+}
+
 bool System_Info::Update_Host_USB()
 {
 	QList<VM_USB> list;
-	
-	if( QFile::exists("/sys/bus/usb") )
-	{
-		if( Scan_USB_Sys(list) )
-		{
-			All_Host_USB = list;
-			return true;
-		}
-	}
-	
-	if( QFile::exists("/proc/bus/usb/devices") )
-	{
-		if( Scan_USB_Proc(list) )
-		{
-			All_Host_USB = list;
-			return true;
-		}
-	}
-	
-	// Error...
-	AQError( "bool System_Info::Update_Host_USB()",
-			 "Cannot read USB information from /sys, /proc, /dev!" );
-	return false;
+	if( ! Scan_Host_USB_Snapshot( list ) )
+		return false;
+	All_Host_USB = list;
+	return true;
 }
 
 bool System_Info::Scan_USB_Sys( QList<VM_USB> &list )
@@ -3335,6 +3342,14 @@ QStringList System_Info::Get_Host_CDROM_List()
 	return tmp_list;
 }
 
+bool System_Info::Scan_Host_USB_Snapshot( QList<VM_USB> &out )
+{
+	out.clear();
+	AQError( "System_Info::Scan_Host_USB_Snapshot()",
+			 "Not implemented!" );
+	return false;
+}
+
 bool System_Info::Update_Host_USB()
 {
 	AQError( "System_Info::Update_Host_USB()",
@@ -3425,9 +3440,9 @@ QStringList System_Info::Get_Host_CDROM_List()
 	return ret_list;
 }
 
-bool System_Info::Update_Host_USB()
+bool System_Info::Scan_Host_USB_Snapshot( QList<VM_USB> &out )
 {
-	All_Host_USB.clear();
+	out.clear();
 
 	// Enumerate present USB PnP devices via PowerShell (SetupAPI-free, works on Win10+)
 	QProcess ps;
@@ -3443,7 +3458,8 @@ bool System_Info::Update_Host_USB()
 			"  if ($_.InstanceId -match 'VID_([0-9A-Fa-f]{4}).*PID_([0-9A-Fa-f]{4})') { "
 			"    $vid=$matches[1].ToLower(); $pid=$matches[2].ToLower(); "
 			"    $name=($_.FriendlyName -replace '[\\|\\r\\n]',' '); "
-			"    Write-Output ($vid + '|' + $pid + '|' + $name) "
+			"    $iid=($_.InstanceId -replace '[\\|\\r\\n]',' '); "
+			"    Write-Output ($vid + '|' + $pid + '|' + $name + '|' + $iid) "
 			"  } "
 			"}"
 		) );
@@ -3451,13 +3467,13 @@ bool System_Info::Update_Host_USB()
 	ps.start();
 	if( ! ps.waitForFinished( 15000 ) )
 	{
-		AQError( "System_Info::Update_Host_USB()", "PowerShell USB enumeration timed out" );
+		AQError( "System_Info::Scan_Host_USB_Snapshot()", "PowerShell USB enumeration timed out" );
 		return false;
 	}
 
-	const QString out = QString::fromLocal8Bit( ps.readAllStandardOutput() );
-	QSet<QString> seen;
-	const QStringList lines = out.split( QRegExp( "[\\r\\n]+" ), QString::SkipEmptyParts );
+	const QString ps_out = QString::fromLocal8Bit( ps.readAllStandardOutput() );
+	QSet<QString> seen_instance;
+	const QStringList lines = ps_out.split( QRegExp( "[\\r\\n]+" ), QString::SkipEmptyParts );
 	for( int i = 0; i < lines.count(); ++i )
 	{
 		const QStringList parts = lines[i].split( QLatin1Char( '|' ) );
@@ -3467,27 +3483,45 @@ bool System_Info::Update_Host_USB()
 		const QString pid = parts[1].trimmed().toLower();
 		if( vid.size() != 4 || pid.size() != 4 )
 			continue;
-		const QString key = vid + QLatin1Char( ':' ) + pid;
-		if( seen.contains( key ) )
+		const QString instance = parts.size() >= 4 ? parts[3].trimmed() : QString();
+		const QString dedupe = instance.isEmpty()
+			? ( vid + QLatin1Char( ':' ) + pid + QLatin1Char( '#' ) + QString::number( i ) )
+			: instance;
+		if( seen_instance.contains( dedupe ) )
 			continue;
-		seen.insert( key );
+		seen_instance.insert( dedupe );
 
 		VM_USB u;
 		u.Set_Use_Host_Device( true );
 		u.Set_Vendor_ID( vid );
 		u.Set_Product_ID( pid );
 		u.Set_Manufacturer_Name( QStringLiteral( "USB" ) );
-		u.Set_Product_Name( parts.size() >= 3 ? parts[2].trimmed() : key );
+		u.Set_Product_Name( parts.size() >= 3 ? parts[2].trimmed()
+			: ( vid + QLatin1Char( ':' ) + pid ) );
+		if( ! instance.isEmpty() )
+			u.Set_DevPath( instance );
 		u.Set_Speed( QStringLiteral( "480" ) );
-		All_Host_USB << u;
+		out << u;
 	}
 
-	if( All_Host_USB.isEmpty() )
+	if( out.isEmpty() )
 	{
-		AQDebug( "System_Info::Update_Host_USB()",
+		AQDebug( "System_Info::Scan_Host_USB_Snapshot()",
 			 "No USB PnP devices found (or PowerShell blocked)." );
 		return false;
 	}
+	return true;
+}
+
+bool System_Info::Update_Host_USB()
+{
+	QList<VM_USB> list;
+	if( ! Scan_Host_USB_Snapshot( list ) )
+	{
+		All_Host_USB.clear();
+		return false;
+	}
+	All_Host_USB = list;
 	return true;
 }
 

--- a/src/System_Info.h
+++ b/src/System_Info.h
@@ -83,6 +83,10 @@ class System_Info
 		static const QList<VM_USB> &Get_All_Host_USB();
 		/** Cached list only — never blocks on host enumeration. */
 		static const QList<VM_USB> &Get_Cached_Host_USB();
+		/** Replace the USB cache (call only from the UI thread). */
+		static void Set_Cached_Host_USB( const QList<VM_USB> &list );
+		/** Enumerate host USB into `out` without touching the shared cache (thread-safe for the cache). */
+		static bool Scan_Host_USB_Snapshot( QList<VM_USB> &out );
 		static const QList<VM_USB> &Get_Used_USB_List();
 		static bool Add_To_Used_USB_List( const VM_USB &device );
 		static bool Delete_From_Used_USB_List( const VM_USB &device );

--- a/src/URL_Fetch.cpp
+++ b/src/URL_Fetch.cpp
@@ -8,7 +8,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QEventLoop>
-#include <QFile>
+#include <QSaveFile>
 #include <QFileInfo>
 #include <QDir>
 #include <QProgressDialog>
@@ -40,6 +40,14 @@ QString AQ_Download_URL_To_File( QWidget *parent,
 	                  QNetworkRequest::NoLessSafeRedirectPolicy );
 #endif
 
+	QSaveFile out( dest_path );
+	if( ! out.open( QIODevice::WriteOnly ) )
+	{
+		QMessageBox::warning( parent, QObject::tr( "Download" ),
+			QObject::tr( "Cannot write:\n%1" ).arg( dest_path ) );
+		return QString();
+	}
+
 	QNetworkReply *reply = nam.get( req );
 	QProgressDialog prog( title.isEmpty()
 		? QObject::tr( "Downloading %1…" ).arg( qurl.fileName() )
@@ -49,9 +57,29 @@ QString AQ_Download_URL_To_File( QWidget *parent,
 	prog.setMinimumDuration( 0 );
 	prog.setValue( 0 );
 
+	bool write_ok = true;
+	QString write_err;
+
 	QEventLoop loop;
 	QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
 	QObject::connect( &prog, &QProgressDialog::canceled, reply, &QNetworkReply::abort );
+	QObject::connect( reply, &QNetworkReply::readyRead, &prog, [reply, &out, &write_ok, &write_err, &loop]() {
+		if( ! write_ok )
+			return;
+		const QByteArray chunk = reply->readAll();
+		if( chunk.isEmpty() )
+			return;
+		const qint64 n = out.write( chunk );
+		if( n != chunk.size() )
+		{
+			write_ok = false;
+			write_err = out.errorString().isEmpty()
+				? QObject::tr( "Short write (disk full?)" )
+				: out.errorString();
+			reply->abort();
+			loop.quit();
+		}
+	} );
 	QObject::connect( reply, &QNetworkReply::downloadProgress,
 		&prog, [&prog]( qint64 rec, qint64 total ) {
 			if( total > 0 )
@@ -65,30 +93,69 @@ QString AQ_Download_URL_To_File( QWidget *parent,
 			}
 		} );
 
+	// Overall idle timeout: abort if no progress for 10 minutes.
+	QTimer watchdog;
+	watchdog.setInterval( 10 * 60 * 1000 );
+	watchdog.setSingleShot( true );
+	QObject::connect( &watchdog, &QTimer::timeout, &prog, [reply, &loop]() {
+		reply->abort();
+		loop.quit();
+	} );
+	QObject::connect( reply, &QNetworkReply::downloadProgress, &watchdog, [&watchdog]( qint64, qint64 ) {
+		watchdog.start();
+	} );
+	watchdog.start();
+
 	loop.exec();
 	prog.reset();
 
-	if( reply->error() != QNetworkReply::NoError )
+	// Drain any remaining buffered data after finished.
+	if( write_ok && reply->error() == QNetworkReply::NoError && reply->bytesAvailable() > 0 )
 	{
-		if( reply->error() != QNetworkReply::OperationCanceledError )
+		const QByteArray rest = reply->readAll();
+		if( ! rest.isEmpty() )
 		{
-			QMessageBox::warning( parent, QObject::tr( "Download" ),
-				QObject::tr( "Download failed:\n%1" ).arg( reply->errorString() ) );
+			const qint64 n = out.write( rest );
+			if( n != rest.size() )
+			{
+				write_ok = false;
+				write_err = out.errorString().isEmpty()
+					? QObject::tr( "Short write (disk full?)" )
+					: out.errorString();
+			}
 		}
-		reply->deleteLater();
+	}
+
+	const QNetworkReply::NetworkError net_err = reply->error();
+	const QString net_err_str = reply->errorString();
+	reply->deleteLater();
+
+	if( ! write_ok )
+	{
+		out.cancelWriting();
+		QMessageBox::warning( parent, QObject::tr( "Download" ),
+			QObject::tr( "Failed to write file:\n%1\n%2" ).arg( dest_path, write_err ) );
 		return QString();
 	}
 
-	QFile out( dest_path );
-	if( ! out.open( QIODevice::WriteOnly ) )
+	if( net_err != QNetworkReply::NoError )
 	{
-		QMessageBox::warning( parent, QObject::tr( "Download" ),
-			QObject::tr( "Cannot write:\n%1" ).arg( dest_path ) );
-		reply->deleteLater();
+		out.cancelWriting();
+		if( net_err != QNetworkReply::OperationCanceledError )
+		{
+			QMessageBox::warning( parent, QObject::tr( "Download" ),
+				QObject::tr( "Download failed:\n%1" ).arg( net_err_str ) );
+		}
 		return QString();
 	}
-	out.write( reply->readAll() );
-	out.close();
-	reply->deleteLater();
+
+	if( ! out.commit() )
+	{
+		QMessageBox::warning( parent, QObject::tr( "Download" ),
+			QObject::tr( "Failed to finalize file:\n%1\n%2" )
+				.arg( dest_path, out.errorString() ) );
+		return QString();
+	}
+
 	return QDir::toNativeSeparators( dest_path );
 }

--- a/src/VM_Session_Widget.cpp
+++ b/src/VM_Session_Widget.cpp
@@ -818,13 +818,51 @@ void VM_Session_Widget::Send_Monitor( const QString &cmd )
 	VM->Send_Emulator_Command( line );
 }
 
-QString VM_Session_Widget::USB_Device_Id( const QString &vid_pid ) const
+QString VM_Session_Widget::USB_Instance_Key( const VM_USB &u, int index ) const
 {
-	const QStringList vp = vid_pid.split( QLatin1Char( ':' ) );
-	if( vp.count() != 2 )
-		return QString();
-	return QStringLiteral( "aqusb_%1_%2" )
-		.arg( vp.at( 0 ).toLower(), vp.at( 1 ).toLower() );
+	if( ! u.Get_Bus().isEmpty() && ! u.Get_Addr().isEmpty() )
+		return QStringLiteral( "bus:%1.%2" ).arg( u.Get_Bus(), u.Get_Addr() );
+	if( ! u.Get_Serial_Number().isEmpty() )
+		return QStringLiteral( "ser:%1:%2:%3" )
+			.arg( u.Get_Vendor_ID().toLower(),
+			      u.Get_Product_ID().toLower(),
+			      u.Get_Serial_Number() );
+	if( ! u.Get_DevPath().isEmpty() )
+		return QStringLiteral( "path:%1" ).arg( u.Get_DevPath() );
+	return QStringLiteral( "vp:%1:%2#%3" )
+		.arg( u.Get_Vendor_ID().toLower(),
+		      u.Get_Product_ID().toLower(),
+		      QString::number( index ) );
+}
+
+QString VM_Session_Widget::USB_Qemu_Device_Id( const QString &instance_key ) const
+{
+	QString s = instance_key.toLower();
+	s.replace( QRegularExpression( QStringLiteral( "[^a-z0-9_]+" ) ), QStringLiteral( "_" ) );
+	while( s.contains( QStringLiteral( "__" ) ) )
+		s.replace( QStringLiteral( "__" ), QStringLiteral( "_" ) );
+	if( s.startsWith( QLatin1Char( '_' ) ) )
+		s.remove( 0, 1 );
+	if( s.isEmpty() )
+		s = QStringLiteral( "dev" );
+	return QStringLiteral( "aqusb_%1" ).arg( s.left( 48 ) );
+}
+
+QString VM_Session_Widget::USB_Device_Add_Command( const VM_USB &u, const QString &qemu_id ) const
+{
+	if( ! u.Get_Bus().isEmpty() && ! u.Get_Addr().isEmpty() )
+	{
+		bool ok_bus = false, ok_addr = false;
+		const int bus = u.Get_Bus().toInt( &ok_bus );
+		const int addr = u.Get_Addr().toInt( &ok_addr );
+		if( ok_bus && ok_addr )
+		{
+			return QStringLiteral( "device_add usb-host,hostbus=%1,hostaddr=%2,id=%3" )
+				.arg( bus ).arg( addr ).arg( qemu_id );
+		}
+	}
+	return QStringLiteral( "device_add usb-host,vendorid=0x%1,productid=0x%2,id=%3" )
+		.arg( u.Get_Vendor_ID().toLower(), u.Get_Product_ID().toLower(), qemu_id );
 }
 
 void VM_Session_Widget::Send_Hmp_Command( const QString &cmd )
@@ -853,15 +891,26 @@ void VM_Session_Widget::Start_USB_Host_Scan()
 {
 	if( USB_Enum_Busy || ! Menu_USB )
 		return;
+	if( USB_Scan_Thread && USB_Scan_Thread->isRunning() )
+		return;
+
 	USB_Enum_Busy = true;
 	Menu_USB->clear();
 	QAction *loading = Menu_USB->addAction( tr( "Scanning USB devices…" ) );
 	loading->setEnabled( false );
 
-	QThread *th = QThread::create( []() {
-		System_Info::Update_Host_USB();
+	// Scan into a heap list on a worker; publish to the cache only on the UI thread.
+	auto *holder = new QList<VM_USB>();
+	QThread *th = QThread::create( [holder]() {
+		System_Info::Scan_Host_USB_Snapshot( *holder );
 	} );
-	connect( th, &QThread::finished, this, [this, th]() {
+	th->setParent( this );
+	USB_Scan_Thread = th;
+	connect( th, &QThread::finished, this, [this, th, holder]() {
+		if( USB_Scan_Thread == th )
+			USB_Scan_Thread.clear();
+		System_Info::Set_Cached_Host_USB( *holder );
+		delete holder;
 		USB_Enum_Busy = false;
 		th->deleteLater();
 		Rebuild_USB_Menu();
@@ -886,7 +935,6 @@ void VM_Session_Widget::Rebuild_USB_Menu()
 	connect( refresh, &QAction::triggered, this, [this]() { Start_USB_Host_Scan(); } );
 	Menu_USB->addSeparator();
 
-	// Cache only on menu open — never block the UI thread (Qodo / PR #10)
 	const QList<VM_USB> host = System_Info::Get_Cached_Host_USB();
 	if( host.isEmpty() )
 	{
@@ -898,20 +946,32 @@ void VM_Session_Widget::Rebuild_USB_Menu()
 	for( int i = 0; i < host.count(); ++i )
 	{
 		const VM_USB &u = host[i];
-		const QString id = u.Get_ID_Line().toLower();
-		if( id.isEmpty() || ! id.contains( QLatin1Char( ':' ) ) )
+		const QString vidpid = u.Get_ID_Line().toLower();
+		if( vidpid.isEmpty() || ! vidpid.contains( QLatin1Char( ':' ) ) )
 			continue;
+		const QString key = USB_Instance_Key( u, i );
+		const QString qemu_id = USB_Qemu_Device_Id( key );
+
 		QString label = u.Get_Product_Name().trimmed();
 		if( label.isEmpty() )
-			label = id;
+			label = vidpid;
 		else
-			label = QStringLiteral( "%1  (%2)" ).arg( label, id );
+			label = QStringLiteral( "%1  (%2)" ).arg( label, vidpid );
+		if( ! u.Get_Bus().isEmpty() && ! u.Get_Addr().isEmpty() )
+			label += QStringLiteral( "  [%1.%2]" ).arg( u.Get_Bus(), u.Get_Addr() );
 
 		QAction *act = Menu_USB->addAction( label );
 		act->setCheckable( true );
-		act->setData( id );
+		QVariantMap data;
+		data.insert( QStringLiteral( "key" ), key );
+		data.insert( QStringLiteral( "qemu_id" ), qemu_id );
+		data.insert( QStringLiteral( "vid" ), u.Get_Vendor_ID().toLower() );
+		data.insert( QStringLiteral( "pid" ), u.Get_Product_ID().toLower() );
+		data.insert( QStringLiteral( "bus" ), u.Get_Bus() );
+		data.insert( QStringLiteral( "addr" ), u.Get_Addr() );
+		act->setData( data );
 		act->blockSignals( true );
-		act->setChecked( Connected_USB_Ids.contains( id ) );
+		act->setChecked( Connected_USB_Ids.contains( key ) );
 		act->blockSignals( false );
 		connect( act, SIGNAL(toggled(bool)), this, SLOT(On_USB_Device_Toggled(bool)) );
 	}
@@ -924,9 +984,8 @@ void VM_Session_Widget::Rebuild_USB_Menu()
 			const QStringList ids = Connected_USB_Ids.values();
 			for( int i = 0; i < ids.count(); ++i )
 			{
-				const QString devid = USB_Device_Id( ids[i] );
-				if( ! devid.isEmpty() )
-					Send_Hmp_Command( QStringLiteral( "device_del %1" ).arg( devid ) );
+				if( ! ids[i].isEmpty() )
+					Send_Hmp_Command( QStringLiteral( "device_del %1" ).arg( ids[i] ) );
 			}
 			Connected_USB_Ids.clear();
 		} );
@@ -938,26 +997,28 @@ void VM_Session_Widget::On_USB_Device_Toggled( bool checked )
 	QAction *act = qobject_cast<QAction *>( sender() );
 	if( ! act )
 		return;
-	const QString id = act->data().toString().toLower();
-	const QStringList vp = id.split( QLatin1Char( ':' ) );
-	if( vp.count() != 2 )
+	const QVariantMap data = act->data().toMap();
+	const QString key = data.value( QStringLiteral( "key" ) ).toString();
+	QString qemu_id = data.value( QStringLiteral( "qemu_id" ) ).toString();
+	if( key.isEmpty() )
 		return;
-	const QString vid = vp.at( 0 );
-	const QString pid = vp.at( 1 );
-	const QString devid = USB_Device_Id( id );
+	if( qemu_id.isEmpty() )
+		qemu_id = USB_Qemu_Device_Id( key );
 
 	if( checked )
 	{
-		const QString cmd = QStringLiteral(
-			"device_add usb-host,vendorid=0x%1,productid=0x%2,id=%3" )
-			.arg( vid, pid, devid );
-		Send_Hmp_Command( cmd );
-		Connected_USB_Ids.insert( id );
+		VM_USB tmp;
+		tmp.Set_Vendor_ID( data.value( QStringLiteral( "vid" ) ).toString() );
+		tmp.Set_Product_ID( data.value( QStringLiteral( "pid" ) ).toString() );
+		tmp.Set_Bus( data.value( QStringLiteral( "bus" ) ).toString() );
+		tmp.Set_Addr( data.value( QStringLiteral( "addr" ) ).toString() );
+		Send_Hmp_Command( USB_Device_Add_Command( tmp, qemu_id ) );
+		Connected_USB_Ids.insert( key, qemu_id );
 	}
 	else
 	{
-		Send_Hmp_Command( QStringLiteral( "device_del %1" ).arg( devid ) );
-		Connected_USB_Ids.remove( id );
+		Send_Hmp_Command( QStringLiteral( "device_del %1" ).arg( qemu_id ) );
+		Connected_USB_Ids.remove( key );
 	}
 }
 

--- a/src/VM_Session_Widget.h
+++ b/src/VM_Session_Widget.h
@@ -20,6 +20,10 @@
 #include <QSet>
 #include <QMenu>
 #include <QToolButton>
+#include <QThread>
+#include <QPointer>
+#include <QVariantMap>
+#include <QRegularExpression>
 
 #include "VM_Devices.h"
 #include "Serial_Console_Window.h"
@@ -121,7 +125,9 @@ class VM_Session_Widget : public QWidget
 		void Rebuild_USB_Menu();
 		void Start_USB_Host_Scan();
 		void Send_Hmp_Command( const QString &cmd );
-		QString USB_Device_Id( const QString &vid_pid ) const;
+		QString USB_Instance_Key( const VM_USB &u, int index ) const;
+		QString USB_Qemu_Device_Id( const QString &instance_key ) const;
+		QString USB_Device_Add_Command( const VM_USB &u, const QString &qemu_id ) const;
 
 		Virtual_Machine *VM;
 		QMP_Client *QMP;
@@ -148,8 +154,9 @@ class VM_Session_Widget : public QWidget
 		QAction *Act_Eject_FD1;
 		QToolButton *TB_USB;
 		QMenu *Menu_USB;
-		QSet<QString> Connected_USB_Ids; // "vid:pid"
+		QHash<QString, QString> Connected_USB_Ids; // instance key -> qemu device id
 		bool USB_Enum_Busy;
+		QPointer<QThread> USB_Scan_Thread;
 		Serial_Console_Window *Serial_Win;
 
 		QLabel *Light_FD0;

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -52,6 +52,7 @@
 #include <QUrl>
 
 #include "Utils.h"
+#include "AQ_UI_Style.h"
 #include "WSL_Launch.h"
 #include "VM_Wizard_Window.h"
 #include "System_Info.h"
@@ -65,6 +66,7 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	: QDialog(parent)
 {
 	ui.setupUi( this );
+	AQ_Cap_Content_Width( this, 900 );
 	
 	New_VM = new Virtual_Machine();
 	Win11_ARM_Page = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@
 #include <iostream>
 
 #include "Utils.h"
+#include "AQ_UI_Style.h"
 #include "Main_Window.h"
 #include "First_Start_Wizard.h"
 
@@ -188,6 +189,7 @@ int AQEMU_Main::main(int argc, char *argv[])
 
     // Create QApplication
     application = new QApplication( argc, argv );
+    AQ_Apply_App_Style( application );
     AQEMU_Startup_Log( "QApplication ok" );
 
     QString AQEMU_FILE;


### PR DESCRIPTION
## Summary
- Fix the four Qodo review bugs from PR #13:
  - **URL downloads**: stream to `QSaveFile` (no `readAll()` OOM), check write/commit, idle timeout
  - **USB scan race**: worker fills a local list via `Scan_Host_USB_Snapshot`; UI thread publishes with `Set_Cached_Host_USB`
  - **USB hotplug IDs**: unique instance keys (bus/addr, serial, Windows InstanceId) and unique QEMU `id=`
  - **SSH ports**: `QIntValidator` + integer parse/canonicalise before building `ssh` args
- Shared **AQ_UI_Style** app chrome + VM tab card/scroll polish across settings pages and major dialogs

## Test plan
- [ ] Wizard: download a small ISO/kernel URL; cancel mid-download; confirm no partial committed file
- [ ] Session toolbar USB menu: Refresh lists devices; connect two identical VID:PID devices if available
- [ ] File → Remote Hosts: invalid port (e.g. `abc`, `99999`) shows a clear error
- [ ] Open Info / VM / Media / Display / Network tabs — consistent card/tab look, no layout blow-up
- [ ] `cmake --build build_win --target aqemu`
