### PR TITLE
Merge release/1.0.0: UI polish, blank-tab fixes, wizard chrome

### DIFF
--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -45,12 +45,9 @@ QGroupBox::title {
 	color: palette(window-text);
 }
 
-/* Do NOT set QTabWidget::pane top/left offsets or heavy QTabBar::tab chrome
-   globally — they break West (vertical) tab widgets (blank content pane). */
-QTabWidget::pane {
-	border: 1px solid palette(mid);
-	background: palette(window);
-}
+/* Never style QTabWidget::pane / QTabBar globally — any pane rule breaks
+   QTabWidget::West on Qt 5 (content area paints blank). Style North tabs
+   on specific widgets only if needed. */
 
 QListWidget, QTreeWidget, QTableWidget {
 	border: 1px solid palette(mid);
@@ -161,16 +158,6 @@ QSplitter::handle {
 	height: 1px;
 }
 
-/* Section headers used on the VM page */
-Highlighted_Label {
-	font-size: 13px;
-	font-weight: 600;
-	color: palette(link);
-	padding: 8px 10px 4px 10px;
-	border-bottom: 1px solid palette(mid);
-	margin-top: 2px;
-	background: transparent;
-}
 )" ) );
 }
 
@@ -178,13 +165,13 @@ void AQ_Style_Card( QWidget *w, int max_width )
 {
 	if( ! w || w->objectName().isEmpty() )
 		return;
+	// Avoid CSS margin on QWidget — it breaks layout geometry on Qt 5.
 	w->setStyleSheet(
 		QStringLiteral(
 			"QWidget#%1 {"
 			"  background-color: palette(base);"
 			"  border: 1px solid palette(mid);"
 			"  border-radius: 6px;"
-			"  margin: 0px 4px 6px 4px;"
 			"  padding: 4px;"
 			"}"
 		).arg( w->objectName() ) );

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -45,29 +45,11 @@ QGroupBox::title {
 	color: palette(window-text);
 }
 
+/* Do NOT set QTabWidget::pane top/left offsets or heavy QTabBar::tab chrome
+   globally — they break West (vertical) tab widgets (blank content pane). */
 QTabWidget::pane {
 	border: 1px solid palette(mid);
-	border-radius: 4px;
-	top: -1px;
 	background: palette(window);
-	padding: 4px;
-}
-QTabBar::tab {
-	padding: 6px 14px;
-	margin-right: 2px;
-	border: 1px solid transparent;
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
-	background: transparent;
-}
-QTabBar::tab:selected {
-	background: palette(base);
-	border: 1px solid palette(mid);
-	border-bottom-color: palette(base);
-	font-weight: 600;
-}
-QTabBar::tab:hover:!selected {
-	background: palette(alternate-base);
 }
 
 QListWidget, QTreeWidget, QTableWidget {
@@ -296,13 +278,14 @@ void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name )
 	scroll->setObjectName( QStringLiteral( "AQ_Tab_Scroll" ) );
 	scroll->setWidgetResizable( true );
 	scroll->setFrameShape( QFrame::NoFrame );
-	scroll->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+	scroll->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+	scroll->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
 	scroll->setWidget( inner );
 
 	QVBoxLayout *outer = new QVBoxLayout( tab );
 	outer->setContentsMargins( 0, 0, 0, 0 );
 	outer->setSpacing( 0 );
-	outer->addWidget( scroll );
+	outer->addWidget( scroll, 1 );
 }
 
 void AQ_Cap_Content_Width( QWidget *root, int max_width )

--- a/src/HDD_Image_Info.cpp
+++ b/src/HDD_Image_Info.cpp
@@ -28,6 +28,8 @@
 #include "Utils.h"
 #include "HDD_Image_Info.h"
 
+QHash<QString, VM::Disk_Info> HDD_Image_Info::Info_Cache;
+
 HDD_Image_Info::HDD_Image_Info( QObject *parent )
 		: QObject( parent )
 {
@@ -47,34 +49,46 @@ VM::Disk_Info HDD_Image_Info::Get_Disk_Info() const
 void HDD_Image_Info::Update_Disk_Info( const QString &path )
 {
 	Info.Image_File_Name = path;
-	
+
 	if( Info.Image_File_Name.isEmpty() )
 	{
 		Clear_Info();
 		return;
 	}
-	
+
+	// Reuse cached qemu-img results when switching between VMs that share disks.
+	if( Info_Cache.contains( Info.Image_File_Name ) )
+	{
+		Info = Info_Cache.value( Info.Image_File_Name );
+		emit Completed( true );
+		return;
+	}
+
 	if( QFile::exists(Info.Image_File_Name) == false )
 	{
 		AQWarning( "void HDD_Image_Info::Update_Disk_Info( const QString &path )",
-                   "Image \"" + Info.Image_File_Name + "\" does not exist!" );
+				   "Image \"" + Info.Image_File_Name + "\" does not exist!" );
 		Clear_Info();
 		return;
 	}
-	else
+
+	if( QEMU_IMG_Proc->state() != QProcess::NotRunning )
 	{
-		QStringList args;
-		args << "info" << Info.Image_File_Name;
-		
-		QEMU_IMG_Proc = new QProcess( this );
-		QEMU_IMG_Proc->start( Get_QEMU_IMG_Path(), args );
-		
-		connect( QEMU_IMG_Proc, SIGNAL(finished(int, QProcess::ExitStatus)),
-				 this, SLOT(Parse_Info(int, QProcess::ExitStatus)), Qt::DirectConnection );
-		
-		connect( QEMU_IMG_Proc, SIGNAL(error(QProcess::ProcessError)),
-				 this, SLOT(Clear_Info()), Qt::DirectConnection );
+		QEMU_IMG_Proc->disconnect( this );
+		QEMU_IMG_Proc->kill();
+		QEMU_IMG_Proc->waitForFinished( 200 );
 	}
+
+	QStringList args;
+	args << "info" << Info.Image_File_Name;
+
+	connect( QEMU_IMG_Proc, SIGNAL(finished(int, QProcess::ExitStatus)),
+			 this, SLOT(Parse_Info(int, QProcess::ExitStatus)), Qt::UniqueConnection );
+
+	connect( QEMU_IMG_Proc, SIGNAL(error(QProcess::ProcessError)),
+			 this, SLOT(Clear_Info()), Qt::UniqueConnection );
+
+	QEMU_IMG_Proc->start( Get_QEMU_IMG_Path(), args );
 }
 
 void HDD_Image_Info::Clear_Info()
@@ -200,5 +214,6 @@ void HDD_Image_Info::Parse_Info( int exitCode, QProcess::ExitStatus exitStatus )
 	Info.Disk_Size = tmp_hdd.String_to_Device_Size( disk_size.isEmpty() ? virtual_size : disk_size );
 	Info.Cluster_Size = cluster_size.isEmpty() ? 0 : cluster_size.toInt();
 
+	Info_Cache.insert( Info.Image_File_Name, Info );
 	emit Completed( true );
 }

--- a/src/HDD_Image_Info.h
+++ b/src/HDD_Image_Info.h
@@ -24,6 +24,8 @@
 #define HDD_IMAGE_INFO_H
 
 #include <QProcess>
+#include <QHash>
+#include <QString>
 #include "VM_Devices.h"
 
 class HDD_Image_Info : public QObject
@@ -48,6 +50,7 @@ class HDD_Image_Info : public QObject
 	private:
 		VM::Disk_Info Info;
 		QProcess* QEMU_IMG_Proc;
+		static QHash<QString, VM::Disk_Info> Info_Cache;
 };
 
 #endif

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -118,6 +118,7 @@ Main_Window::Main_Window( QWidget *parent )
 	, Act_Tray_Show( nullptr )
 	, Act_Tray_Quit( nullptr )
 	, Auto_Save_Timer( nullptr )
+	, VM_Ui_Refresh_Timer( nullptr )
 {
     Advanced_Options = new QDialog(this);
     Accelerator_Options = new QDialog(this);
@@ -128,6 +129,12 @@ Main_Window::Main_Window( QWidget *parent )
 	Auto_Save_Timer->setSingleShot( true );
 	Auto_Save_Timer->setInterval( 400 );
 	connect( Auto_Save_Timer, SIGNAL(timeout()), this, SLOT(on_Button_Apply_clicked()) );
+
+	// Coalesce rapid VM-list clicks so we don't rebuild the whole form per click.
+	VM_Ui_Refresh_Timer = new QTimer( this );
+	VM_Ui_Refresh_Timer->setSingleShot( true );
+	VM_Ui_Refresh_Timer->setInterval( 60 );
+	connect( VM_Ui_Refresh_Timer, &QTimer::timeout, this, [this]() { Update_VM_Ui(); } );
 
     ui.setupUi( this );
 	ui_ao.setupUi( Advanced_Options );
@@ -583,62 +590,31 @@ Virtual_Machine *Main_Window::Get_Current_VM()
 
 void Main_Window::Polish_Settings_Tabs_Layout()
 {
-	// Scrollable pages with stacked sections; nested-tab pages get chrome only.
-	AQ_Make_Tab_Scrollable( ui.Tab_General, QStringLiteral( "VM_Tab_Inner" ) );
-	AQ_Make_Tab_Scrollable( ui.Tab_Display, QStringLiteral( "Display_Tab_Inner" ) );
-
-	AQ_Style_Card( ui.widget, 980 ); // Machine
-	AQ_Style_Card( ui.GB_Memory, 920 );
-	AQ_Style_Card( ui.GB_Audio, 920 );
-	AQ_Style_Card( ui.GB_Disk_Bus, 920 );
-	AQ_Style_Card( ui.GB_Win11_Lifecycle, 920 );
-	AQ_Style_Card( ui.GB_Intel_MacOS_Settings, 920 );
-	AQ_Style_Card( ui.GB_Options, 920 );
-	AQ_Style_Card( ui.Widget_Use_Network, 960 );
-
-	if( ui.Memory_Size )
+	// Do NOT wrap West-tab pages in QScrollArea — that blanks the pane on Qt 5.
+	// Keep polish light: margins, list spacing, and clear any tab stylesheet.
+	if( ui.Tabs )
 	{
-		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
-		ui.Memory_Size->setMaximumHeight( 28 );
-		ui.Memory_Size->setMinimumHeight( 22 );
-	}
-	if( ui.CB_RAM_Size )
-		ui.CB_RAM_Size->setMinimumWidth( 110 );
-
-	if( ui.TB_Show_Advanced_Options_Window )
-	{
-		ui.TB_Show_Advanced_Options_Window->setSizePolicy(
-			QSizePolicy::Maximum, QSizePolicy::Fixed );
-		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( 120 );
+		ui.Tabs->setDocumentMode( false );
+		ui.Tabs->setStyleSheet( QString() ); // never inherit pane rules
 	}
 
-	if( ui.GB_Options )
+	// Redundant with the left VM list + Name field — drop the blue "Machine" header.
+	if( ui.label )
+		ui.label->hide();
+	if( ui.widget && ui.widget->layout() )
+		ui.widget->layout()->setContentsMargins( 12, 4, 6, 6 );
+
+	if( ui.Tab_General && ui.Tab_General->layout() )
 	{
-		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.GB_Options->layout() ) )
-			gl->setColumnStretch( 3, 1 );
+		ui.Tab_General->layout()->setContentsMargins( 8, 4, 10, 8 );
+		ui.Tab_General->layout()->setSpacing( 4 );
+		AQ_Tighten_Layout_Spacers( ui.Tab_General->layout(), 6 );
 	}
-
-	if( ui.GB_Guest_Display_Mode )
-		ui.GB_Guest_Display_Mode->setMaximumWidth( 960 );
-
-	auto polish_nested_tabs = []( QTabWidget *tw ) {
-		if( ! tw ) return;
-		tw->setDocumentMode( true );
-		tw->setElideMode( Qt::ElideRight );
-		AQ_Cap_Content_Width( tw, 960 );
-		if( QWidget *parent = tw->parentWidget() )
-		{
-			if( QLayout *lay = parent->layout() )
-			{
-				lay->setContentsMargins( 8, 8, 8, 8 );
-				AQ_Tighten_Layout_Spacers( lay, 6 );
-			}
-		}
-	};
-	polish_nested_tabs( ui.TabWidget_Media );
-	polish_nested_tabs( ui.TabWidget_Display );
-	polish_nested_tabs( ui.Network_Cards_Tabs );
-
+	if( ui.Tab_Display && ui.Tab_Display->layout() )
+	{
+		ui.Tab_Display->layout()->setContentsMargins( 8, 8, 10, 8 );
+		ui.Tab_Display->layout()->setSpacing( 8 );
+	}
 	if( ui.Tab_Media && ui.Tab_Media->layout() )
 	{
 		ui.Tab_Media->layout()->setContentsMargins( 8, 8, 8, 8 );
@@ -666,21 +642,52 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		}
 	}
 
+	if( ui.Memory_Size )
+	{
+		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+		ui.Memory_Size->setMaximumHeight( 28 );
+		ui.Memory_Size->setMinimumHeight( 22 );
+	}
+	if( ui.CB_RAM_Size )
+		ui.CB_RAM_Size->setMinimumWidth( 110 );
+
+	if( ui.TB_Show_Advanced_Options_Window )
+	{
+		ui.TB_Show_Advanced_Options_Window->setSizePolicy(
+			QSizePolicy::Maximum, QSizePolicy::Fixed );
+		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( 120 );
+	}
+
+	if( ui.GB_Options )
+	{
+		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.GB_Options->layout() ) )
+			gl->setColumnStretch( 3, 1 );
+	}
+
+	auto polish_nested_tabs = []( QTabWidget *tw ) {
+		if( ! tw ) return;
+		tw->setDocumentMode( false );
+		tw->setElideMode( Qt::ElideRight );
+	};
+	polish_nested_tabs( ui.TabWidget_Media );
+	polish_nested_tabs( ui.TabWidget_Display );
+	polish_nested_tabs( ui.Network_Cards_Tabs );
+
 	if( ui.Machines_List )
 	{
 		ui.Machines_List->setSpacing( 2 );
 		ui.Machines_List->setUniformItemSizes( true );
 	}
-
-	// Keep West tab bar in classic mode — documentMode blanks the content pane on Qt 5.
-	if( ui.Tabs )
-		ui.Tabs->setDocumentMode( false );
-
-	AQ_Cap_Content_Width( this, 980 );
 }
 
 void Main_Window::Connect_Signals()
 {
+	// Refresh Info HTML when that tab becomes visible (deferred while on other tabs).
+	connect( ui.Tabs, &QTabWidget::currentChanged, this, [this]( int ) {
+		if( ui.Tabs->currentWidget() == ui.Tab_Info )
+			Update_Info_Text();
+	} );
+
 	// General Tab
 	connect( ui.Edit_Machine_Name, SIGNAL(textChanged(const QString &)),
 			 this, SLOT(VM_Changed()) );
@@ -1990,9 +1997,21 @@ bool Main_Window::Save_Virtual_Machines()
 	return true;
 }
 
+void Main_Window::Schedule_Update_VM_Ui()
+{
+	if( VM_Ui_Refresh_Timer )
+		VM_Ui_Refresh_Timer->start();
+	else
+		Update_VM_Ui();
+}
+
 void Main_Window::Update_VM_Ui(bool update_info_tab)
 {
-    Block_VM_Changed_Signals bvmcs(this);
+	// Do not sync dirty-state on exit — that re-ran Create_VM_From_Ui and often
+	// falsely enabled Apply + auto-save after every list selection.
+	Block_VM_Changed_Signals bvmcs( this, false );
+
+	setUpdatesEnabled( false );
 
 	Update_VM_Port_Number();
 
@@ -2000,9 +2019,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	{
 		AQWarning( "void Main_Window::Update_VM_Ui()",
 				   "VM Index Out of Range" );
-		/*
-		AQGraphic_Error( "void Main_Window::Update_VM_Ui()", tr("Critical Error!"),
-						 tr("VM Index Out of Range! Close AQEMU?"), true );*/
+		setUpdatesEnabled( true );
 		return;
 	}
 
@@ -2012,6 +2029,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	{
 		AQError( "void Main_Window::Update_VM_Ui()",
 				 "Cannot Find VM!" );
+		setUpdatesEnabled( true );
 		return;
 	}
 
@@ -2025,6 +2043,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	{
 		AQError( "void Main_Window::Update_VM_Ui()",
 				 "VM in VM::VMS_In_Error state!" );
+		setUpdatesEnabled( true );
 		return;
 	}
 
@@ -2073,6 +2092,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	{
 		AQError( "void Main_Window::Update_VM_Ui()",
 				 "cur_comp not valid!" );
+		setUpdatesEnabled( true );
 		return;
 	}
 
@@ -2085,6 +2105,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	{
 		AQError( "void Main_Window::Update_VM_Ui()",
 				 "Cannot find computer type index!" );
+		setUpdatesEnabled( true );
 		return;
 	}
 
@@ -2243,19 +2264,11 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 		Enforce_Disk_Bus_Honesty();
 	}
 
-	// RAM
+	// RAM — clamp silently while switching VMs (no popup thrash).
 	if( tmp_vm->Get_Memory_Size() < 1 )
-	{
-		AQGraphic_Warning( tr("Error!"),
-						   tr("Memory size < 1! Using default value: 256 MB") );
 		ui.Memory_Size->setValue( 256 );
-	}
 	else if( tmp_vm->Get_Memory_Size() >= ui.Memory_Size->maximum() )
-	{
-		AQGraphic_Warning( tr("Error!"),
-						   tr("Memory size > all free memory on this system!") );
 		ui.Memory_Size->setValue( ui.Memory_Size->maximum() );
-	}
 	else ui.Memory_Size->setValue( tmp_vm->Get_Memory_Size() );
 
 	ui.CH_Remove_RAM_Size_Limitation->setChecked( tmp_vm->Get_Remove_RAM_Size_Limitation() );
@@ -2618,10 +2631,9 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	// x509 Folder
 	ui.Edit_x509verify_Folder->setText( tmp_vm->Get_VNC_x509verify_Folder_Path() );
 
-    if ( update_info_tab )
-    {
-    	Update_Info_Text();
-    }
+	// Skip heavy HTML Info rebuild unless that tab is visible.
+	if( update_info_tab && ui.Tabs && ui.Tabs->currentWidget() == ui.Tab_Info )
+		Update_Info_Text();
 	Update_Win11_Lifecycle_Ui();
 	Update_Intel_MacOS_Settings_Ui();
 	Update_Disabled_Controls(); // FIXME
@@ -2631,16 +2643,11 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	SMP_Settings->Set_Values( tmp_vm->Get_SMP(), curComp.PSO_SMP_Count, curComp.PSO_SMP_Cores,
 							  curComp.PSO_SMP_Threads, curComp.PSO_SMP_Sockets, curComp.PSO_SMP_MaxCPUs );
 
-    /* TODO: POST 0.9.1
-    QString info_text = tr("Machine:") + " " + tmp_vm->Get_Machine_Name();
-    info_text += " " + tr("State:") + " " + tmp_vm->Get_State_Text();
-
-    ui.Label_Machine_Info->setText(info_text);
-    */
-
 	// For VM Changes Signals
 	ui.Button_Apply->setEnabled( false );
-    ui.Button_Cancel->setEnabled( false );
+	ui.Button_Cancel->setEnabled( false );
+
+	setUpdatesEnabled( true );
 }
 
 void Main_Window::Update_VM_Port_Number()
@@ -3752,7 +3759,6 @@ void Main_Window::on_Machines_List_currentItemChanged( QListWidgetItem *current,
 
 	if( ui.Machines_List->row(previous) < 0 ) return;
 
-    Virtual_Machine tmp_vm;
 	Virtual_Machine *old_vm = Get_VM_By_UID( previous->data(256).toString() );
 
 	if( old_vm == NULL )
@@ -3762,52 +3768,41 @@ void Main_Window::on_Machines_List_currentItemChanged( QListWidgetItem *current,
 		return;
 	}
 
-    if( Create_VM_From_Ui(&tmp_vm, old_vm) == false &&
-		old_vm->Get_State() != VM::VMS_In_Error )
+	// Skip expensive Create_VM_From_Ui when there are no pending edits.
+	if( ui.Button_Apply->isEnabled() && old_vm->Get_State() != VM::VMS_In_Error )
 	{
-		AQError( "void Main_Window::on_Machines_List_currentItemChanged( QListWidgetItem* current, QListWidgetItem* previous )",
-				 "Cannot Create VM! Discarding UI changes for previous VM." );
-
-		// Don't block switching — leave previous VM as-is on disk.
-		if( ui.Machines_List->row(current) >= 0 &&
-			ui.Machines_List->row(current) < ui.Machines_List->count() )
+		Virtual_Machine tmp_vm;
+		if( Create_VM_From_Ui( &tmp_vm, old_vm ) == false )
 		{
-			Update_VM_Ui();
+			AQError( "void Main_Window::on_Machines_List_currentItemChanged( QListWidgetItem* current, QListWidgetItem* previous )",
+					 "Cannot Create VM! Discarding UI changes for previous VM." );
 		}
-		return;
+		else if( *old_vm != tmp_vm )
+		{
+			if( Auto_Save_Timer )
+				Auto_Save_Timer->stop();
+
+			disconnect( old_vm, SIGNAL(State_Changed(Virtual_Machine*, VM::VM_State)),
+						this, SLOT(VM_State_Changed(Virtual_Machine*, VM::VM_State)) );
+
+			*old_vm = tmp_vm;
+
+			connect( old_vm, SIGNAL(State_Changed(Virtual_Machine*, VM::VM_State)),
+					 this, SLOT(VM_State_Changed(Virtual_Machine*, VM::VM_State)) );
+
+			old_vm->Save_VM();
+		}
 	}
 
-	// if previous machine settings were changed — auto-save, never ask
-    if( *old_vm != tmp_vm &&
-		old_vm->Get_State() != VM::VMS_In_Error && ui.Button_Apply->isEnabled() )
+	if( ui.Machines_List->row(current) >= 0 &&
+		ui.Machines_List->row(current) < ui.Machines_List->count() )
 	{
-		if( Auto_Save_Timer )
-			Auto_Save_Timer->stop();
-
-		disconnect( old_vm, SIGNAL(State_Changed(Virtual_Machine*, VM::VM_State)),
-					this, SLOT(VM_State_Changed(Virtual_Machine*, VM::VM_State)) );
-
-		*old_vm = tmp_vm;
-
-		connect( old_vm, SIGNAL(State_Changed(Virtual_Machine*, VM::VM_State)),
-				 this, SLOT(VM_State_Changed(Virtual_Machine*, VM::VM_State)) );
-
-		old_vm->Save_VM();
-		Update_VM_Ui();
-		return;
+		Schedule_Update_VM_Ui();
 	}
 	else
 	{
-		if( ui.Machines_List->row(current) >= 0 &&
-			ui.Machines_List->row(current) < ui.Machines_List->count() )
-		{
-			Update_VM_Ui();
-		}
-		else
-		{
-			AQError( "void Main_Window::on_Machines_List_currentItemChanged( QListWidgetItem* current, QListWidgetItem* previous )",
-					 "Index Invalid!" );
-		}
+		AQError( "void Main_Window::on_Machines_List_currentItemChanged( QListWidgetItem* current, QListWidgetItem* previous )",
+				 "Index Invalid!" );
 	}
 }
 

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -672,8 +672,9 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		ui.Machines_List->setUniformItemSizes( true );
 	}
 
+	// Keep West tab bar in classic mode — documentMode blanks the content pane on Qt 5.
 	if( ui.Tabs )
-		ui.Tabs->setDocumentMode( true );
+		ui.Tabs->setDocumentMode( false );
 
 	AQ_Cap_Content_Width( this, 980 );
 }

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -60,20 +60,25 @@ class Main_Window: public QMainWindow
     class Block_VM_Changed_Signals
     {
         public:
-            Block_VM_Changed_Signals(Main_Window* _mw)
+            // sync_on_exit=false: used by Update_VM_Ui — do not re-run dirty detection
+            // (that falsely marks Apply and triggers auto-save thrash when switching VMs).
+            Block_VM_Changed_Signals( Main_Window * _mw, bool sync_on_exit = true )
             {
                 mw = _mw;
+                call_VM_Changed = sync_on_exit;
                 mw->block_VM_changed_signals = true;
             }
 
             ~Block_VM_Changed_Signals()
             {
                 mw->block_VM_changed_signals = false;
-                mw->VM_Changed();
+                if( call_VM_Changed )
+                    mw->VM_Changed();
             }
 
         private:
-            Main_Window* mw;
+            Main_Window *mw;
+            bool call_VM_Changed;
     };
 
 	Q_OBJECT
@@ -262,6 +267,7 @@ class Main_Window: public QMainWindow
 		void setStateActionsEnabled(bool enabled);
         void Change_The_Icon(Virtual_Machine*,QString);
 		void Update_VM_Ui( bool update_info_tab = true );
+		void Schedule_Update_VM_Ui();
 		void Update_VM_Port_Number();
 		void Update_Info_Text( int info_mode = 0 );
 		void Update_Disabled_Controls();
@@ -362,6 +368,7 @@ class Main_Window: public QMainWindow
 
         bool block_VM_changed_signals;
 		QTimer *Auto_Save_Timer;
+		QTimer *VM_Ui_Refresh_Timer;
 };
 
 #endif

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -21,17 +21,18 @@
 **
 ****************************************************************************/
 
-#include <QDir>
-#include <QRegExp>
-#include <QFileDialog>
-#include <QLabel>
-#include <QRadioButton>
-#include <QCheckBox>
-#include <QLineEdit>
-#include <QToolButton>
-#include <QGroupBox>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
+#include <QFrame>
+#include <QScrollArea>
+#include <QSizePolicy>
+#include <QAbstractButton>
+#include <QButtonGroup>
+#include <QSpacerItem>
+#include <QFont>
+#include <QGridLayout>
+#include <QStyle>
+#include <QMouseEvent>
+#include <QEvent>
+#include <QAbstractItemView>
 #include <QFile>
 #include <QFileInfo>
 #include <QTreeWidget>
@@ -66,7 +67,6 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	: QDialog(parent)
 {
 	ui.setupUi( this );
-	AQ_Cap_Content_Width( this, 900 );
 	
 	New_VM = new Virtual_Machine();
 	Win11_ARM_Page = nullptr;
@@ -138,6 +138,7 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	Guest_Video_Card = QStringLiteral( "std" );
 	Guest_Use_VirtIO_Extras = false;
 	Guest_Use_GPU_Passthrough = false;
+	List_Wizard_Steps = nullptr;
 	
 	// Hide release date widgets
 	ui.Label_Relese_Date->hide();
@@ -182,9 +183,7 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	Label_Wizard_Machine->hide();
 	CB_Wizard_Machine->hide();
 
-	// Fixed wizard size — do not grow/shrink when changing pages
-	setMinimumSize( 640, 620 );
-	resize( 640, 620 );
+	Polish_Wizard_Chrome();
 
 	// Loading All Templates
 	if( Load_OS_Templates() )
@@ -205,57 +204,348 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	ui.Wizard_Pages->setCurrentWidget( Creation_Method_Page );
 	ui.Label_Page->setText( tr("Creation Method") );
 	ui.Button_Back->setEnabled( false );
+	Sync_Wizard_Side_Steps();
 
     connect(ui.RB_Emulator_KVM, SIGNAL(toggled(bool)),this, SLOT(KVM_toggled(bool)));
+}
+
+void VM_Wizard_Window::Polish_Wizard_Chrome()
+{
+	// Virt-manager-style wide dialog — room for cards + side steps.
+	setMinimumSize( 860, 640 );
+	resize( 920, 700 );
+	setSizeGripEnabled( true );
+
+	setStyleSheet( QStringLiteral( R"(
+QDialog#VM_Wizard_Window {
+	background: palette(window);
+}
+QFrame#WizardSideRail {
+	background: palette(base);
+	border: none;
+	border-right: 1px solid palette(mid);
+}
+QLabel#WizardSideTitle {
+	font-size: 15px;
+	font-weight: 700;
+	color: palette(window-text);
+	padding: 4px 2px 10px 2px;
+}
+QLabel#WizardSideHint {
+	color: palette(mid);
+	font-size: 11px;
+	padding: 0 2px 8px 2px;
+}
+QListWidget#WizardStepList {
+	background: transparent;
+	border: none;
+	outline: 0;
+	font-size: 12px;
+}
+QListWidget#WizardStepList::item {
+	padding: 8px 10px;
+	margin: 2px 0;
+	border-radius: 6px;
+	color: palette(window-text);
+}
+QListWidget#WizardStepList::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+	font-weight: 600;
+}
+QLabel#Label_Page {
+	font-size: 18px;
+	font-weight: 700;
+	padding: 4px 2px 2px 2px;
+	background: transparent;
+	border: none;
+	min-height: 36px;
+}
+QFrame#WizardMethodCard {
+	background: palette(base);
+	border: 1px solid palette(mid);
+	border-radius: 8px;
+}
+QFrame#WizardMethodCard[selected="true"] {
+	border: 2px solid palette(highlight);
+	background: palette(alternate-base);
+}
+QPushButton#Button_Back, QPushButton#Button_Next, QPushButton#Button_Cancel {
+	min-width: 96px;
+	min-height: 28px;
+	padding: 6px 18px;
+}
+QPushButton#Button_Next {
+	font-weight: 600;
+}
+)" ) );
+
+	QGridLayout *root = qobject_cast<QGridLayout*>( layout() );
+	if( ! root )
+		return;
+
+	// Pull known pieces out of the designer grid (order in .ui is not row order).
+	root->removeWidget( ui.Label_Page );
+	root->removeWidget( ui.Wizard_Pages );
+	root->removeWidget( ui.line_2 );
+
+	QHBoxLayout *buttonRow = nullptr;
+	for( int i = root->count() - 1; i >= 0; --i )
+	{
+		QLayoutItem *it = root->itemAt( i );
+		if( it && it->layout() )
+		{
+			buttonRow = qobject_cast<QHBoxLayout*>( it->layout() );
+			root->takeAt( i );
+			break;
+		}
+	}
+
+	// Clear any leftover placeholders
+	while( root->count() > 0 )
+	{
+		QLayoutItem *it = root->takeAt( 0 );
+		if( it && it->widget() )
+			it->widget()->setParent( nullptr );
+		delete it;
+	}
+
+	root->setContentsMargins( 0, 0, 0, 0 );
+	root->setHorizontalSpacing( 0 );
+	root->setVerticalSpacing( 0 );
+
+	QFrame *rail = new QFrame( this );
+	rail->setObjectName( QStringLiteral( "WizardSideRail" ) );
+	rail->setFixedWidth( 210 );
+	QVBoxLayout *railLay = new QVBoxLayout( rail );
+	railLay->setContentsMargins( 16, 18, 12, 16 );
+	railLay->setSpacing( 4 );
+
+	QLabel *sideTitle = new QLabel( tr( "New Virtual Machine" ), rail );
+	sideTitle->setObjectName( QStringLiteral( "WizardSideTitle" ) );
+	sideTitle->setWordWrap( true );
+	railLay->addWidget( sideTitle );
+
+	QLabel *sideHint = new QLabel(
+		tr( "Pick a path, then fine-tune hardware. You can change architecture and machine later." ),
+		rail );
+	sideHint->setObjectName( QStringLiteral( "WizardSideHint" ) );
+	sideHint->setWordWrap( true );
+	railLay->addWidget( sideHint );
+
+	List_Wizard_Steps = new QListWidget( rail );
+	List_Wizard_Steps->setObjectName( QStringLiteral( "WizardStepList" ) );
+	List_Wizard_Steps->setFocusPolicy( Qt::NoFocus );
+	List_Wizard_Steps->setSelectionMode( QAbstractItemView::SingleSelection );
+	List_Wizard_Steps->setEditTriggers( QAbstractItemView::NoEditTriggers );
+	List_Wizard_Steps->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+	List_Wizard_Steps->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+	const QStringList steps = {
+		tr( "1. Creation method" ),
+		tr( "2. Guest / platform" ),
+		tr( "3. Hardware" ),
+		tr( "4. Storage & memory" ),
+		tr( "5. Network" ),
+		tr( "6. Finish" )
+	};
+	for( const QString &s : steps )
+		List_Wizard_Steps->addItem( s );
+	List_Wizard_Steps->setCurrentRow( 0 );
+	List_Wizard_Steps->setEnabled( false ); // navigation stays Back/Next
+	railLay->addWidget( List_Wizard_Steps, 1 );
+
+	QWidget *content = new QWidget( this );
+	content->setObjectName( QStringLiteral( "WizardContent" ) );
+	QVBoxLayout *contentLay = new QVBoxLayout( content );
+	contentLay->setContentsMargins( 22, 16, 22, 14 );
+	contentLay->setSpacing( 10 );
+
+	ui.Label_Page->setObjectName( QStringLiteral( "Label_Page" ) );
+	ui.Label_Page->setAutoFillBackground( false );
+	ui.Label_Page->setMinimumHeight( 36 );
+	ui.Wizard_Pages->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+
+	contentLay->addWidget( ui.Label_Page );
+	contentLay->addWidget( ui.Wizard_Pages, 1 );
+	contentLay->addWidget( ui.line_2 );
+
+	if( buttonRow )
+	{
+		QWidget *footer = new QWidget( content );
+		QHBoxLayout *fl = new QHBoxLayout( footer );
+		fl->setContentsMargins( 0, 8, 0, 0 );
+		fl->setSpacing( 10 );
+		while( buttonRow->count() > 0 )
+		{
+			QLayoutItem *bi = buttonRow->takeAt( 0 );
+			if( bi )
+				fl->addItem( bi );
+		}
+		delete buttonRow;
+		contentLay->addWidget( footer );
+	}
+
+	root->addWidget( rail, 0, 0 );
+	root->addWidget( content, 0, 1 );
+	root->setColumnStretch( 1, 1 );
+
+	ui.Button_Back->setMinimumWidth( 96 );
+	ui.Button_Next->setMinimumWidth( 104 );
+	ui.Button_Cancel->setMinimumWidth( 96 );
+	ui.Button_Next->setAutoDefault( true );
+	ui.Button_Next->setDefault( true );
+
+	connect( ui.Wizard_Pages, &QStackedWidget::currentChanged, this, [this]( int ) {
+		Sync_Wizard_Side_Steps();
+	} );
+}
+
+void VM_Wizard_Window::Sync_Wizard_Side_Steps()
+{
+	if( ! List_Wizard_Steps )
+		return;
+
+	QWidget *w = ui.Wizard_Pages ? ui.Wizard_Pages->currentWidget() : nullptr;
+	int step = 0;
+	if( w == Creation_Method_Page )
+		step = 0;
+	else if( w == OS_Tree_Page || w == Platform_Tree_Page || w == Arch_List_Page ||
+	         w == Arch_Machines_Page || w == ui.Wizard_Mode_Page )
+		step = 1;
+	else if( w == ui.Template_Page || w == ui.Accelerator_Page || w == ui.General_Settings_Page ||
+	         w == Devices_Page || w == Intel_MacOS_Page )
+		step = 2;
+	else if( w == ui.Typical_HDD_Page || w == ui.Custom_HDD_Page || w == ui.Memory_Page ||
+	         w == Win11_ARM_Page )
+		step = 3;
+	else if( w == ui.Network_Page )
+		step = 4;
+	else if( w == ui.Finish_Page )
+		step = 5;
+
+	List_Wizard_Steps->blockSignals( true );
+	List_Wizard_Steps->setCurrentRow( step );
+	List_Wizard_Steps->blockSignals( false );
+}
+
+bool VM_Wizard_Window::eventFilter( QObject *watched, QEvent *event )
+{
+	if( event->type() == QEvent::MouseButtonPress )
+	{
+		if( QFrame *card = qobject_cast<QFrame*>( watched ) )
+		{
+			if( card->objectName() == QLatin1String( "WizardMethodCard" ) )
+			{
+				if( QRadioButton *rb = card->findChild<QRadioButton*>() )
+					rb->setChecked( true );
+				return true;
+			}
+		}
+	}
+	return QDialog::eventFilter( watched, event );
+}
+
+QFrame *VM_Wizard_Window::Add_Method_Card( QVBoxLayout *parent_lay, QRadioButton *rb, const QString &hint )
+{
+	QFrame *card = new QFrame();
+	card->setObjectName( QStringLiteral( "WizardMethodCard" ) );
+	card->setProperty( "selected", rb->isChecked() );
+	card->setCursor( Qt::PointingHandCursor );
+	card->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
+
+	QVBoxLayout *cardLay = new QVBoxLayout( card );
+	cardLay->setContentsMargins( 14, 10, 14, 10 );
+	cardLay->setSpacing( 4 );
+
+	rb->setStyleSheet( QStringLiteral( "QRadioButton { font-weight: 600; font-size: 13px; spacing: 8px; }" ) );
+	cardLay->addWidget( rb );
+
+	QLabel *h = new QLabel( hint );
+	h->setWordWrap( true );
+	h->setStyleSheet( QStringLiteral(
+		"QLabel { color: palette(mid); margin-left: 24px; font-size: 12px; }" ) );
+	cardLay->addWidget( h );
+
+	auto refresh = [card, rb]() {
+		card->setProperty( "selected", rb->isChecked() );
+		card->style()->unpolish( card );
+		card->style()->polish( card );
+		card->update();
+	};
+	connect( rb, &QRadioButton::toggled, card, [refresh]( bool ) { refresh(); } );
+
+	// Clicking empty card area selects the option.
+	card->installEventFilter( this );
+
+	parent_lay->addWidget( card );
+	return card;
 }
 
 void VM_Wizard_Window::Build_Three_Path_Pages()
 {
 	Load_Wizard_Trees();
 
-	// --- Creation method ---
+	// --- Creation method (card list) ---
 	Creation_Method_Page = new QWidget();
-	QVBoxLayout *methodLay = new QVBoxLayout( Creation_Method_Page );
-	methodLay->addWidget( new QLabel( tr(
-		"<b>How do you want to create this virtual machine?</b><br/>"
-		"<span style=\"color:gray;\">Any path can reach any QEMU architecture — "
-		"you can always override Computer Type and machine later.</span>") ) );
+	QVBoxLayout *methodOuter = new QVBoxLayout( Creation_Method_Page );
+	methodOuter->setContentsMargins( 0, 0, 0, 0 );
+	methodOuter->setSpacing( 0 );
 
-	RB_Method_Guest_OS = new QRadioButton( tr("Guest Operating System") );
-	RB_Method_Platform = new QRadioButton( tr("System / Machine Platform") );
-	RB_Method_Architecture = new QRadioButton( tr("CPU Architecture") );
-	RB_Method_Custom = new QRadioButton( tr("Custom / Advanced") );
+	QScrollArea *scroll = new QScrollArea( Creation_Method_Page );
+	scroll->setWidgetResizable( true );
+	scroll->setFrameShape( QFrame::NoFrame );
+	scroll->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+
+	QWidget *inner = new QWidget();
+	QVBoxLayout *methodLay = new QVBoxLayout( inner );
+	methodLay->setContentsMargins( 4, 4, 12, 8 );
+	methodLay->setSpacing( 10 );
+
+	QLabel *intro = new QLabel( tr(
+		"<span style='font-size:13px;'>How do you want to create this virtual machine?</span><br/>"
+		"<span style='color:gray; font-size:12px;'>"
+		"Any path can reach any QEMU architecture — you can always override Computer Type "
+		"and machine later.</span>" ) );
+	intro->setWordWrap( true );
+	intro->setTextFormat( Qt::RichText );
+	methodLay->addWidget( intro );
+
+	RB_Method_Guest_OS = new QRadioButton( tr( "Guest Operating System" ) );
+	RB_Method_Platform = new QRadioButton( tr( "System / Machine Platform" ) );
+	RB_Method_Architecture = new QRadioButton( tr( "CPU Architecture" ) );
+	RB_Method_Custom = new QRadioButton( tr( "Custom / Advanced" ) );
+	RB_Method_Import = new QRadioButton( tr( "Import Existing Disk" ) );
 	RB_Method_Guest_OS->setChecked( true );
 
-	auto add_method = [methodLay]( QRadioButton *rb, const QString &hint ) {
-		methodLay->addWidget( rb );
-		QLabel *h = new QLabel( hint );
-		h->setWordWrap( true );
-		h->setStyleSheet( QStringLiteral( "color: gray; margin-left: 22px; margin-bottom: 8px;" ) );
-		methodLay->addWidget( h );
-	};
-	add_method( RB_Method_Guest_OS,
+	Add_Method_Card( methodLay, RB_Method_Guest_OS,
 		tr( "Best for Windows, Linux, macOS, DOS, BSD… — AQEMU picks a matching QEMU binary and machine, then you confirm." ) );
-	add_method( RB_Method_Platform,
+	Add_Method_Card( methodLay, RB_Method_Platform,
 		tr( "Best for Raspberry Pi, SGI Indy, PowerMac, SPARCstation, PC (Q35)… — choose the board/platform first." ) );
-	add_method( RB_Method_Architecture,
+	Add_Method_Card( methodLay, RB_Method_Architecture,
 		tr( "Best when you know the CPU family (x86-64, ARM64, MIPS, RISC-V…) — then pick any machine QEMU offers for it." ) );
-	add_method( RB_Method_Custom,
+	Add_Method_Card( methodLay, RB_Method_Custom,
 		tr( "Full manual control: Typical or Custom disk/RAM flow, any qemu-system-* binary, templates or generate." ) );
-	RB_Method_Import = new QRadioButton( tr( "Import Existing Disk" ) );
-	add_method( RB_Method_Import,
+	Add_Method_Card( methodLay, RB_Method_Import,
 		tr( "Attach an existing qcow2/raw/vmdk (and optional ISO). Fastest path when you already have an image." ) );
 
 	methodLay->addStretch( 1 );
+	scroll->setWidget( inner );
+	methodOuter->addWidget( scroll );
+
 	ui.Wizard_Pages->insertWidget( 0, Creation_Method_Page );
 
 	// --- Guest OS / Select OS tree ---
 	OS_Tree_Page = new QWidget();
 	QVBoxLayout *osLay = new QVBoxLayout( OS_Tree_Page );
-	osLay->addWidget( new QLabel( tr("Select a guest operating system:") ) );
+	osLay->setContentsMargins( 4, 4, 8, 4 );
+	osLay->setSpacing( 10 );
+	QLabel *osIntro = new QLabel( tr( "Select a guest operating system:" ) );
+	osIntro->setStyleSheet( QStringLiteral( "font-weight: 600;" ) );
+	osLay->addWidget( osIntro );
 	Tree_OS = new QTreeWidget();
 	Tree_OS->setHeaderHidden( true );
 	Tree_OS->setRootIsDecorated( true );
+	Tree_OS->setAlternatingRowColors( true );
 	osLay->addWidget( Tree_OS );
 	Populate_OS_Tree();
 	connect( Tree_OS, &QTreeWidget::itemDoubleClicked, this, [this]( QTreeWidgetItem *item, int ) {
@@ -267,11 +557,16 @@ void VM_Wizard_Window::Build_Three_Path_Pages()
 	// --- Platform tree ---
 	Platform_Tree_Page = new QWidget();
 	QVBoxLayout *platLay = new QVBoxLayout( Platform_Tree_Page );
-	platLay->addWidget( new QLabel( tr(
+	platLay->setContentsMargins( 4, 4, 8, 4 );
+	platLay->setSpacing( 10 );
+	QLabel *platIntro = new QLabel( tr(
 		"Select a system / machine platform:\n"
-		"(This sets the QEMU binary and -machine; you can change both on the next page.)" ) ) );
+		"(This sets the QEMU binary and -machine; you can change both on the next page.)" ) );
+	platIntro->setWordWrap( true );
+	platLay->addWidget( platIntro );
 	Tree_Platform = new QTreeWidget();
 	Tree_Platform->setHeaderHidden( true );
+	Tree_Platform->setAlternatingRowColors( true );
 	platLay->addWidget( Tree_Platform );
 	Populate_Platform_Tree();
 	connect( Tree_Platform, &QTreeWidget::itemDoubleClicked, this, [this]( QTreeWidgetItem *item, int ) {
@@ -283,8 +578,12 @@ void VM_Wizard_Window::Build_Three_Path_Pages()
 	// --- Architecture list ---
 	Arch_List_Page = new QWidget();
 	QVBoxLayout *archLay = new QVBoxLayout( Arch_List_Page );
-	archLay->addWidget( new QLabel( tr("Select a CPU architecture (qemu-system-* target):") ) );
+	archLay->setContentsMargins( 4, 4, 8, 4 );
+	archLay->setSpacing( 10 );
+	archLay->addWidget( new QLabel( tr( "Select a CPU architecture (qemu-system-* target):" ) ) );
 	List_Arch = new QListWidget();
+	List_Arch->setAlternatingRowColors( true );
+	List_Arch->setSpacing( 2 );
 	archLay->addWidget( List_Arch );
 	Populate_Arch_List();
 	connect( List_Arch, &QListWidget::itemDoubleClicked, this, [this]( QListWidgetItem * ) {
@@ -295,11 +594,16 @@ void VM_Wizard_Window::Build_Three_Path_Pages()
 	// --- Machines filtered by arch ---
 	Arch_Machines_Page = new QWidget();
 	QVBoxLayout *machLay = new QVBoxLayout( Arch_Machines_Page );
-	machLay->addWidget( new QLabel( tr(
+	machLay->setContentsMargins( 4, 4, 8, 4 );
+	machLay->setSpacing( 10 );
+	QLabel *machIntro = new QLabel( tr(
 		"Select a machine for this architecture:\n"
-		"(Recommended boards first; expand “All available machines…” for the full QEMU list when catalog is present.)" ) ) );
+		"(Recommended boards first; expand “All available machines…” for the full QEMU list when catalog is present.)" ) );
+	machIntro->setWordWrap( true );
+	machLay->addWidget( machIntro );
 	Tree_Arch_Machines = new QTreeWidget();
 	Tree_Arch_Machines->setHeaderHidden( true );
+	Tree_Arch_Machines->setAlternatingRowColors( true );
 	machLay->addWidget( Tree_Arch_Machines );
 	connect( Tree_Arch_Machines, &QTreeWidget::itemDoubleClicked, this, [this]( QTreeWidgetItem *item, int ) {
 		if( item && item->childCount() == 0 )

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -63,6 +63,9 @@ class VM_Wizard_Window: public QDialog
 		
 		void on_Button_Back_clicked();
 		void on_Button_Next_clicked();
+
+	protected:
+		bool eventFilter( QObject *watched, QEvent *event ) override;
 		
 		void on_RB_VM_Template_toggled( bool on );
 		void on_RB_Generate_VM_toggled( bool on );
@@ -122,6 +125,10 @@ class VM_Wizard_Window: public QDialog
 		void Probe_WSL_For_Intel_Mac_Page();
 		void Update_Finish_Page_Guidance();
 		void Enhance_Typical_HDD_Page();
+
+		void Polish_Wizard_Chrome();
+		void Sync_Wizard_Side_Steps();
+		QFrame *Add_Method_Card( QVBoxLayout *parent_lay, QRadioButton *rb, const QString &hint );
 
 		void Build_Devices_Page();
 		void Refresh_Devices_Page();
@@ -292,6 +299,7 @@ class VM_Wizard_Window: public QDialog
 		QComboBox *CB_Wizard_Machine;
 		QJsonObject Machine_Catalog;
 		bool Machine_Catalog_Loaded;
+		QListWidget *List_Wizard_Steps;
 };
 
 #endif


### PR DESCRIPTION
## Summary

Brings `release/1.0.0` up to date on `master` after the post–PR #15 UI polish wave. Includes PRs **#16**, **#17**, and **#18**, plus the refreshed GitHub portable zip for **v1.0.0**.

## Changelog

### New Virtual Machine wizard (#18)
- Wider dialog (~920×700) with virt-manager-style left step rail
- Creation-method options as selectable cards (full labels, no truncated **Next**)
- Better margins, page title chrome, and scrollable method page
- Clickable cards select the radio option

### Blank VM / Display tabs (#16, #17)
- Removed global `QTabWidget::pane` stylesheet rules that blank West (vertical) tab content on Qt 5
- Stopped wrapping VM/Display pages in `QScrollArea` (also blanked the pane)
- Cleared inherited tab stylesheets; keep West tabs out of `documentMode`
- Dropped aggressive card CSS margins / content-width caps that hurt layout

### VM list switching (#17 follow-on)
- Skip dirty-check / auto-save thrash after `Update_VM_Ui`
- Debounce list selection (~60 ms) so rapid clicks do not rebuild the form every time
- Skip expensive `Create_VM_From_Ui` when Apply is idle
- Cache `qemu-img info` results by disk path
- Freeze painting during UI reload; silent RAM clamp (no popup spam)
- Lazy Info HTML rebuild (only when the Info tab is visible)
- Hide redundant blue **Machine** section header on the VM page

### Release packaging
- Replaced GitHub **v1.0.0** portable zip (`aqemu-1.0.0-win64.zip`) with this build
- Release notes: https://github.com/chronic8000/aqemu/releases/tag/v1.0.0

### Already on master (context — from earlier PRs #13–#15)
- Three-path wizard (Guest OS / Platform / Architecture / Custom / Import)
- Guest capability matrix, devices step, ISO OS-guess, URL/network install
- Storage browser, serial console, remote hosts, migrate URI dialog
- Qodo review fixes (URL fetch streaming, USB scan race, hotplug IDs, SSH ports)
- Shared UI chrome module (`AQ_UI_Style`)

## Commits in this PR
- #18 — Polish New VM wizard: wider layout, side steps, method cards
- #17 — Hard fix: blank VM/Display West tabs (+ switch jank / Machine header)
- #16 — Fix blank VM/Display panes caused by West-tab stylesheet

## Test plan
- [ ] Merge this PR; `master` matches `release/1.0.0` tip
- [ ] Open New VM wizard — wide layout, cards, full **Next** label
- [ ] Select VMs and open **VM** / **Display** — content visible, no blank pane
- [ ] Click through several VMs quickly — UI stays responsive
- [ ] Optional: unzip latest [v1.0.0 portable](https://github.com/chronic8000/aqemu/releases/tag/v1.0.0) and smoke-test First Start