### PR TITLE
Polish main UI: DPI, West rail, white chrome, full-width sections

### DIFF
--- a/TODO
+++ b/TODO
@@ -19,3 +19,8 @@
   - Out of scope in-process: full Xen/LXC backends (use File → Remote Hosts)
 
 
+# Window chrome (done)
+
+* Main window resizes freely (Media chip strip no longer sets a ~1200px floor)
+* Maximize / restore geometry saved correctly; minimize-to-tray defaults on
+  (Advanced Settings → Minimize to tray)

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -8,6 +8,9 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <QStyle>
+#include <QStylePainter>
+#include <QStyleOptionTab>
+#include <QPainter>
 #include <QFontMetrics>
 #include <QWidget>
 #include <QLayout>
@@ -20,10 +23,12 @@
 #include <QSizePolicy>
 #include <QGroupBox>
 #include <QTabWidget>
+#include <QTabBar>
 #include <QListWidget>
 #include <QtGlobal>
 #include <QCoreApplication>
 #include <QWindow>
+#include <QPaintEvent>
 
 void AQ_Enable_High_Dpi()
 {
@@ -106,6 +111,81 @@ int AQ_Content_Max_Width( const QWidget *hint )
 	const QFontMetrics fm( font );
 	const int ch = qMax( 1, fm.averageCharWidth() );
 	return ch * 72; // ~readable column, scales with font (and High-DPI)
+}
+
+AQ_West_TabBar::AQ_West_TabBar( QWidget *parent )
+	: QTabBar( parent )
+{
+	setExpanding( false );
+	setUsesScrollButtons( true );
+	QFont f = QApplication::font();
+	f.setStyleHint( QFont::SansSerif, QFont::PreferAntialias );
+	f.setStyleStrategy( QFont::PreferAntialias );
+	f.setWeight( QFont::Medium );
+	setFont( f );
+	QStyle *st = style();
+	const int icon = st ? st->pixelMetric( QStyle::PM_SmallIconSize, nullptr, this ) : 16;
+	setIconSize( QSize( icon, icon ) );
+}
+
+QSize AQ_West_TabBar::tabSizeHint( int index ) const
+{
+	const QFontMetrics fm( font() );
+	const QSize ic = iconSize();
+	const int pad = qMax( 6, fm.height() / 3 );
+	const int text_len = fm.horizontalAdvance( tabText( index ) );
+	// West rail: width = thickness, height = length along the bar.
+	const int thick = qMax( ic.width(), fm.height() ) + pad;
+	const int along = qMax( text_len, ic.height() ) + pad * 2;
+	return QSize( thick, along );
+}
+
+void AQ_West_TabBar::paintEvent( QPaintEvent *event )
+{
+	Q_UNUSED( event );
+	QStylePainter painter( this );
+	painter.setRenderHint( QPainter::Antialiasing, true );
+	painter.setRenderHint( QPainter::TextAntialiasing, true );
+	painter.setRenderHint( QPainter::SmoothPixmapTransform, true );
+
+	for( int i = 0; i < count(); ++i )
+	{
+		QStyleOptionTab opt;
+		initStyleOption( &opt, i );
+		painter.drawControl( QStyle::CE_TabBarTabShape, opt );
+
+		painter.save();
+		QSize s = opt.rect.size();
+		s.transpose();
+		QRect r( QPoint(), s );
+		r.moveCenter( opt.rect.center() );
+		opt.shape = QTabBar::RoundedNorth;
+		opt.rect = r;
+
+		const QPoint c = tabRect( i ).center();
+		painter.translate( c );
+		painter.rotate( 90 );
+		painter.translate( -c );
+		painter.drawControl( QStyle::CE_TabBarTabLabel, opt );
+		painter.restore();
+	}
+}
+
+void AQ_Install_West_TabBar( QTabWidget *tabs )
+{
+	if( ! tabs )
+		return;
+	if( tabs->property( "aq_west_tabbar" ).toBool() )
+		return;
+
+	// setTabBar() is protected — access via a thin derived type.
+	struct Tab_Access : public QTabWidget {
+		using QTabWidget::setTabBar;
+	};
+	auto *bar = new AQ_West_TabBar( tabs );
+	static_cast<Tab_Access *>( tabs )->setTabBar( bar );
+	tabs->setTabPosition( QTabWidget::West );
+	tabs->setProperty( "aq_west_tabbar", true );
 }
 
 void AQ_Apply_App_Style( QApplication *app )

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -5,6 +5,10 @@
 #include "AQ_UI_Style.h"
 
 #include <QApplication>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QStyle>
+#include <QFontMetrics>
 #include <QWidget>
 #include <QLayout>
 #include <QLayoutItem>
@@ -17,6 +21,95 @@
 #include <QGroupBox>
 #include <QTabWidget>
 #include <QListWidget>
+#include <QtGlobal>
+#include <QCoreApplication>
+#include <QWindow>
+
+void AQ_Enable_High_Dpi()
+{
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+	QCoreApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
+	QCoreApplication::setAttribute( Qt::AA_UseHighDpiPixmaps );
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+		Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );
+#endif
+#endif
+}
+
+static QScreen *AQ_Hint_Screen( const QWidget *hint )
+{
+	if( hint )
+	{
+		if( QScreen *s = hint->screen() )
+			return s;
+		if( QWidget *top = hint->window() )
+		{
+			if( QWindow *wh = top->windowHandle() )
+			{
+				if( QScreen *s = wh->screen() )
+					return s;
+			}
+		}
+	}
+	return QGuiApplication::primaryScreen();
+}
+
+qreal AQ_Ui_Scale( const QWidget *hint )
+{
+	QScreen *screen = AQ_Hint_Screen( hint );
+	if( ! screen )
+		return 1.0;
+	// logicalDotsPerInch is already "CSS pixels" aware with HighDpiScaling;
+	// still normalize to the classic 96-DPI design baseline.
+	const qreal dpi = screen->logicalDotsPerInch();
+	if( dpi <= 0.0 )
+		return 1.0;
+	return qMax( qreal( 1.0 ), dpi / qreal( 96.0 ) );
+}
+
+int AQ_Px( int baseline_96dpi, const QWidget *hint )
+{
+	if( baseline_96dpi <= 0 )
+		return 0;
+	return qMax( 1, qRound( qreal( baseline_96dpi ) * AQ_Ui_Scale( hint ) ) );
+}
+
+static QSize AQ_Style_Icon( QStyle::PixelMetric metric, qreal bump, const QWidget *hint )
+{
+	QStyle *style = hint && hint->style()
+		? hint->style()
+		: QApplication::style();
+	int px = style ? style->pixelMetric( metric, nullptr, hint ) : 16;
+	px = qMax( 16, qRound( qreal( px ) * bump ) );
+	// Also respect DPI when the style metric lags behind (some Windows styles).
+	px = qMax( px, AQ_Px( metric == QStyle::PM_LargeIconSize ? 32 : 16, hint ) );
+	return QSize( px, px );
+}
+
+QSize AQ_Toolbar_Icon_Size( const QWidget *hint )
+{
+	return AQ_Style_Icon( QStyle::PM_ToolBarIconSize, 1.0, hint );
+}
+
+QSize AQ_Nav_Icon_Size( const QWidget *hint )
+{
+	// Slightly above small-icon metric — readable next to text on HiDPI.
+	return AQ_Style_Icon( QStyle::PM_ListViewIconSize, 1.15, hint );
+}
+
+QSize AQ_Vm_List_Icon_Size( const QWidget *hint )
+{
+	return AQ_Style_Icon( QStyle::PM_LargeIconSize, 1.25, hint );
+}
+
+int AQ_Content_Max_Width( const QWidget *hint )
+{
+	const QFont font = hint ? hint->font() : QApplication::font();
+	const QFontMetrics fm( font );
+	const int ch = qMax( 1, fm.averageCharWidth() );
+	return ch * 72; // ~readable column, scales with font/DPI
+}
 
 void AQ_Apply_App_Style( QApplication *app )
 {
@@ -183,6 +276,8 @@ void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px )
 {
 	if( ! layout )
 		return;
+	if( gap_px < 0 )
+		gap_px = AQ_Px( 6 );
 	for( int i = 0; i < layout->count(); ++i )
 	{
 		QLayoutItem *it = layout->itemAt( i );
@@ -192,9 +287,9 @@ void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px )
 		{
 			QSizePolicy::Policy vp = sp->sizePolicy().verticalPolicy();
 			if( vp == QSizePolicy::Expanding || vp == QSizePolicy::MinimumExpanding ||
-			    sp->sizeHint().height() > gap_px + 4 )
+			    sp->sizeHint().height() > gap_px + AQ_Px( 4 ) )
 			{
-				sp->changeSize( 20, gap_px, QSizePolicy::Minimum, QSizePolicy::Fixed );
+				sp->changeSize( AQ_Px( 20 ), gap_px, QSizePolicy::Minimum, QSizePolicy::Fixed );
 			}
 		}
 		else if( QLayout *sub = it->layout() )
@@ -279,6 +374,8 @@ void AQ_Cap_Content_Width( QWidget *root, int max_width )
 {
 	if( ! root )
 		return;
+	if( max_width < 0 )
+		max_width = AQ_Content_Max_Width( root );
 	const auto boxes = root->findChildren<QGroupBox*>();
 	for( QGroupBox *gb : boxes )
 	{

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -25,6 +25,8 @@
 #include <QTabWidget>
 #include <QTabBar>
 #include <QListWidget>
+#include <QPalette>
+#include <QColor>
 #include <QtGlobal>
 #include <QCoreApplication>
 #include <QWindow>
@@ -193,22 +195,29 @@ void AQ_Apply_App_Style( QApplication *app )
 	if( ! app )
 		return;
 
+	// Light chrome: white page background (Windows palette(window) is grey).
+	QPalette pal = app->palette();
+	pal.setColor( QPalette::Window, QColor( 255, 255, 255 ) );
+	pal.setColor( QPalette::Base, QColor( 255, 255, 255 ) );
+	pal.setColor( QPalette::AlternateBase, QColor( 248, 248, 248 ) );
+	app->setPalette( pal );
+
 	// CRITICAL (Qt 5 + Windows HiDPI): never put padding / min-height / border-radius
 	// on QComboBox, QLineEdit, QSpinBox, QPushButton, QCheckBox, QRadioButton, or
 	// QToolButton in a global stylesheet. Those rules shrink the content rect and
 	// clip glyphs mid-letter. Keep chrome-only styling; leave form controls native.
 	app->setStyleSheet( QStringLiteral( R"(
 QMainWindow, QDialog {
-	background-color: palette(window);
+	background-color: #ffffff;
 }
 
 QGroupBox {
 	font-weight: 600;
-	border: 1px solid palette(mid);
+	border: 1px solid #e0e0e0;
 	border-radius: 6px;
 	margin-top: 12px;
 	padding-top: 8px;
-	background-color: palette(base);
+	background-color: #ffffff;
 }
 QGroupBox::title {
 	subcontrol-origin: margin;
@@ -221,9 +230,9 @@ QGroupBox::title {
 /* Never style QTabWidget::pane / QTabBar globally — blanks West panes on Qt 5. */
 
 QListWidget, QTreeWidget, QTableWidget {
-	border: 1px solid palette(mid);
+	border: 1px solid #e0e0e0;
 	border-radius: 4px;
-	background: palette(base);
+	background: #ffffff;
 	outline: 0;
 }
 QListWidget::item:selected, QTreeWidget::item:selected {
@@ -233,18 +242,19 @@ QListWidget::item:selected, QTreeWidget::item:selected {
 
 QScrollArea {
 	border: none;
-	background: transparent;
+	background: #ffffff;
 }
 QSplitter::handle {
-	background: palette(mid);
+	background: #e8e8e8;
 }
 
 QStatusBar {
-	border-top: 1px solid palette(mid);
+	border-top: 1px solid #e0e0e0;
+	background: #ffffff;
 }
 QMenuBar {
-	background: palette(window);
-	border-bottom: 1px solid palette(mid);
+	background: #ffffff;
+	border-bottom: 1px solid #e0e0e0;
 }
 QMenuBar::item:selected {
 	background: palette(highlight);
@@ -256,8 +266,8 @@ QMenu::item:selected {
 }
 
 QToolTip {
-	border: 1px solid palette(mid);
-	background: palette(base);
+	border: 1px solid #e0e0e0;
+	background: #ffffff;
 	color: palette(window-text);
 }
 )" ) );
@@ -293,9 +303,12 @@ void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px )
 			continue;
 		if( QSpacerItem *sp = it->spacerItem() )
 		{
-			QSizePolicy::Policy vp = sp->sizePolicy().verticalPolicy();
-			if( vp == QSizePolicy::Expanding || vp == QSizePolicy::MinimumExpanding ||
-			    sp->sizeHint().height() > gap_px + AQ_Px( 4 ) )
+			// Only collapse *vertical* expanding spacers. Touching horizontal ones
+			// (sizeHint height ~20) left Memory/Audio/Win11 bunched on the left.
+			const QSizePolicy::Policy vp = sp->sizePolicy().verticalPolicy();
+			const QSizePolicy::Policy hp = sp->sizePolicy().horizontalPolicy();
+			if( ( vp == QSizePolicy::Expanding || vp == QSizePolicy::MinimumExpanding ) &&
+			    hp != QSizePolicy::Expanding && hp != QSizePolicy::MinimumExpanding )
 			{
 				sp->changeSize( AQ_Px( 20 ), gap_px, QSizePolicy::Minimum, QSizePolicy::Fixed );
 			}

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -57,22 +57,20 @@ static QScreen *AQ_Hint_Screen( const QWidget *hint )
 
 qreal AQ_Ui_Scale( const QWidget *hint )
 {
-	QScreen *screen = AQ_Hint_Screen( hint );
-	if( ! screen )
-		return 1.0;
-	// logicalDotsPerInch is already "CSS pixels" aware with HighDpiScaling;
-	// still normalize to the classic 96-DPI design baseline.
-	const qreal dpi = screen->logicalDotsPerInch();
-	if( dpi <= 0.0 )
-		return 1.0;
-	return qMax( qreal( 1.0 ), dpi / qreal( 96.0 ) );
+	Q_UNUSED( hint );
+	// With AA_EnableHighDpiScaling, widget sizes are already device-independent
+	// pixels — multiplying by logicalDPI/96 double-scales (huge West tabs on 4K).
+	// Keep scale at 1; rely on QStyle / font metrics for proportional chrome.
+	return qreal( 1.0 );
 }
 
 int AQ_Px( int baseline_96dpi, const QWidget *hint )
 {
+	Q_UNUSED( hint );
 	if( baseline_96dpi <= 0 )
 		return 0;
-	return qMax( 1, qRound( qreal( baseline_96dpi ) * AQ_Ui_Scale( hint ) ) );
+	// Baselines are DIP design sizes; Qt High-DPI maps them to physical pixels.
+	return baseline_96dpi;
 }
 
 static QSize AQ_Style_Icon( QStyle::PixelMetric metric, qreal bump, const QWidget *hint )
@@ -81,9 +79,9 @@ static QSize AQ_Style_Icon( QStyle::PixelMetric metric, qreal bump, const QWidge
 		? hint->style()
 		: QApplication::style();
 	int px = style ? style->pixelMetric( metric, nullptr, hint ) : 16;
-	px = qMax( 16, qRound( qreal( px ) * bump ) );
-	// Also respect DPI when the style metric lags behind (some Windows styles).
-	px = qMax( px, AQ_Px( metric == QStyle::PM_LargeIconSize ? 32 : 16, hint ) );
+	if( px < 8 )
+		px = 16;
+	px = qMax( 8, qRound( qreal( px ) * bump ) );
 	return QSize( px, px );
 }
 
@@ -94,13 +92,12 @@ QSize AQ_Toolbar_Icon_Size( const QWidget *hint )
 
 QSize AQ_Nav_Icon_Size( const QWidget *hint )
 {
-	// Slightly above small-icon metric — readable next to text on HiDPI.
-	return AQ_Style_Icon( QStyle::PM_ListViewIconSize, 1.15, hint );
+	return AQ_Style_Icon( QStyle::PM_ListViewIconSize, 1.0, hint );
 }
 
 QSize AQ_Vm_List_Icon_Size( const QWidget *hint )
 {
-	return AQ_Style_Icon( QStyle::PM_LargeIconSize, 1.25, hint );
+	return AQ_Style_Icon( QStyle::PM_LargeIconSize, 1.0, hint );
 }
 
 int AQ_Content_Max_Width( const QWidget *hint )
@@ -108,7 +105,7 @@ int AQ_Content_Max_Width( const QWidget *hint )
 	const QFont font = hint ? hint->font() : QApplication::font();
 	const QFontMetrics fm( font );
 	const int ch = qMax( 1, fm.averageCharWidth() );
-	return ch * 72; // ~readable column, scales with font/DPI
+	return ch * 72; // ~readable column, scales with font (and High-DPI)
 }
 
 void AQ_Apply_App_Style( QApplication *app )

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -193,215 +193,72 @@ void AQ_Apply_App_Style( QApplication *app )
 	if( ! app )
 		return;
 
-	// Prefer font metrics over hard-coded min-heights — QSS min-height + padding
-	// clips QComboBox/QLineEdit text and top-aligns QPushButton labels on HiDPI.
-	const QFontMetrics fm( app->font() );
-	const int pad_v = qMax( 4, fm.height() / 5 );
-	const int pad_h = qMax( 8, fm.averageCharWidth() );
-	const int btn_pad_v = qMax( 5, fm.height() / 4 );
-	const int btn_pad_h = qMax( 12, fm.averageCharWidth() * 2 );
-	const int drop_w = qMax( 18, fm.height() );
-
-	app->setStyleSheet( QStringLiteral(
-"/* —— Global chrome —— */\n"
-"QMainWindow, QDialog {\n"
-"	background-color: palette(window);\n"
-"}\n"
-"\n"
-"QGroupBox {\n"
-"	font-weight: 600;\n"
-"	border: 1px solid palette(mid);\n"
-"	border-radius: 6px;\n"
-"	margin-top: 12px;\n"
-"	padding: 10px 8px 8px 8px;\n"
-"	background-color: palette(base);\n"
-"}\n"
-"QGroupBox::title {\n"
-"	subcontrol-origin: margin;\n"
-"	subcontrol-position: top left;\n"
-"	left: 10px;\n"
-"	padding: 0 6px;\n"
-"	color: palette(window-text);\n"
-"}\n"
-"\n"
-"/* Never style QTabWidget::pane / QTabBar globally — any pane rule breaks\n"
-"   QTabWidget::West on Qt 5 (content area paints blank). Style North tabs\n"
-"   on specific widgets only if needed. */\n"
-"\n"
-"QListWidget, QTreeWidget, QTableWidget {\n"
-"	border: 1px solid palette(mid);\n"
-"	border-radius: 4px;\n"
-"	background: palette(base);\n"
-"	padding: 2px;\n"
-"	outline: 0;\n"
-"}\n"
-"QListWidget::item, QTreeWidget::item {\n"
-"	padding: 4px 6px;\n"
-"	border-radius: 3px;\n"
-"}\n"
-"QListWidget::item:selected, QTreeWidget::item:selected {\n"
-"	background: palette(highlight);\n"
-"	color: palette(highlighted-text);\n"
-"}\n"
-"\n"
-"QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {\n"
-"	padding: %1px %2px;\n"
-"	border: 1px solid palette(mid);\n"
-"	border-radius: 4px;\n"
-"	background: palette(base);\n"
-"	selection-background-color: palette(highlight);\n"
-"}\n"
-"QComboBox {\n"
-"	padding: %1px %2px;\n"
-"	padding-right: %3px;\n"
-"	border: 1px solid palette(mid);\n"
-"	border-radius: 4px;\n"
-"	background: palette(base);\n"
-"	selection-background-color: palette(highlight);\n"
-"}\n"
-"QComboBox:editable {\n"
-"	padding: 0px;\n"
-"}\n"
-"QComboBox:editable QLineEdit {\n"
-"	padding: %1px %2px;\n"
-"	border: none;\n"
-"	background: transparent;\n"
-"}\n"
-"QComboBox::drop-down {\n"
-"	border: none;\n"
-"	width: %3px;\n"
-"}\n"
-"QComboBox QAbstractItemView {\n"
-"	border: 1px solid palette(mid);\n"
-"	selection-background-color: palette(highlight);\n"
-"	padding: 2px;\n"
-"}\n"
-"\n"
-"QPushButton {\n"
-"	padding: %4px %5px;\n"
-"	border: 1px solid palette(mid);\n"
-"	border-radius: 4px;\n"
-"	background: palette(button);\n"
-"}\n"
-"QPushButton:hover {\n"
-"	background: palette(light);\n"
-"}\n"
-"QPushButton:pressed {\n"
-"	background: palette(midlight);\n"
-"}\n"
-"QPushButton:default {\n"
-"	font-weight: 600;\n"
-"	border-color: palette(highlight);\n"
-"}\n"
-"QToolButton {\n"
-"	padding: %1px %2px;\n"
-"	border-radius: 4px;\n"
-"}\n"
-"\n"
-"QCheckBox, QRadioButton {\n"
-"	spacing: 6px;\n"
-"	padding: 2px 0;\n"
-"}\n"
-	).arg( pad_v ).arg( pad_h ).arg( drop_w ).arg( btn_pad_v ).arg( btn_pad_h )
-	+ QStringLiteral( R"(
-QScrollBar:vertical {
-	width: 12px;
-	margin: 0;
-}
-QScrollBar:horizontal {
-	height: 12px;
-	margin: 0;
+	// CRITICAL (Qt 5 + Windows HiDPI): never put padding / min-height / border-radius
+	// on QComboBox, QLineEdit, QSpinBox, QPushButton, QCheckBox, QRadioButton, or
+	// QToolButton in a global stylesheet. Those rules shrink the content rect and
+	// clip glyphs mid-letter. Keep chrome-only styling; leave form controls native.
+	app->setStyleSheet( QStringLiteral( R"(
+QMainWindow, QDialog {
+	background-color: palette(window);
 }
 
-QSlider::groove:horizontal {
-	height: 6px;
-	background: palette(mid);
-	border-radius: 3px;
-}
-QSlider::handle:horizontal {
-	width: 14px;
-	margin: -5px 0;
-	background: palette(highlight);
-	border-radius: 7px;
-}
-
-QStatusBar {
-	min-height: 24px;
-}
-
-QToolTip {
-	padding: 4px 8px;
+QGroupBox {
+	font-weight: 600;
 	border: 1px solid palette(mid);
-	background: palette(base);
+	border-radius: 6px;
+	margin-top: 12px;
+	padding-top: 8px;
+	background-color: palette(base);
+}
+QGroupBox::title {
+	subcontrol-origin: margin;
+	subcontrol-position: top left;
+	left: 10px;
+	padding: 0 6px;
 	color: palette(window-text);
 }
 
-QHeaderView::section {
-	padding: 4px 8px;
-	border: none;
-	border-right: 1px solid palette(mid);
-	border-bottom: 1px solid palette(mid);
-	background: palette(button);
-}
+/* Never style QTabWidget::pane / QTabBar globally — blanks West panes on Qt 5. */
 
-QProgressBar {
+QListWidget, QTreeWidget, QTableWidget {
 	border: 1px solid palette(mid);
 	border-radius: 4px;
-	text-align: center;
-	min-height: 16px;
-}
-QProgressBar::chunk {
-	background: palette(highlight);
-	border-radius: 3px;
-}
-
-QMenuBar {
-	padding: 2px;
-	background: palette(window);
-}
-QMenuBar::item {
-	padding: 4px 10px;
-	border-radius: 3px;
-}
-QMenuBar::item:selected {
-	background: palette(highlight);
-	color: palette(highlighted-text);
-}
-QMenu {
-	border: 1px solid palette(mid);
 	background: palette(base);
-	padding: 4px;
+	outline: 0;
 }
-QMenu::item {
-	padding: 5px 28px 5px 24px;
-	border-radius: 3px;
-}
-QMenu::item:selected {
+QListWidget::item:selected, QTreeWidget::item:selected {
 	background: palette(highlight);
 	color: palette(highlighted-text);
-}
-QMenu::separator {
-	height: 1px;
-	background: palette(mid);
-	margin: 4px 8px;
 }
 
 QScrollArea {
 	border: none;
 	background: transparent;
 }
-QScrollBar::handle:vertical {
-	background: palette(mid);
-	border-radius: 4px;
-	min-height: 24px;
-}
-QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-	height: 0;
-}
 QSplitter::handle {
 	background: palette(mid);
-	width: 1px;
-	height: 1px;
+}
+
+QStatusBar {
+	border-top: 1px solid palette(mid);
+}
+QMenuBar {
+	background: palette(window);
+	border-bottom: 1px solid palette(mid);
+}
+QMenuBar::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+}
+QMenu::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+}
+
+QToolTip {
+	border: 1px solid palette(mid);
+	background: palette(base);
+	color: palette(window-text);
 }
 )" ) );
 }
@@ -410,14 +267,13 @@ void AQ_Style_Card( QWidget *w, int max_width )
 {
 	if( ! w || w->objectName().isEmpty() )
 		return;
-	// Avoid CSS margin on QWidget — it breaks layout geometry on Qt 5.
+	// Avoid CSS margin/padding on QWidget — it breaks layout geometry on Qt 5.
 	w->setStyleSheet(
 		QStringLiteral(
 			"QWidget#%1 {"
 			"  background-color: palette(base);"
 			"  border: 1px solid palette(mid);"
 			"  border-radius: 6px;"
-			"  padding: 4px;"
 			"}"
 		).arg( w->objectName() ) );
 	if( max_width > 0 )

--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -193,112 +193,202 @@ void AQ_Apply_App_Style( QApplication *app )
 	if( ! app )
 		return;
 
-	app->setStyleSheet( QStringLiteral( R"(
-/* —— Global chrome —— */
-QMainWindow, QDialog {
-	background-color: palette(window);
-}
+	// Prefer font metrics over hard-coded min-heights — QSS min-height + padding
+	// clips QComboBox/QLineEdit text and top-aligns QPushButton labels on HiDPI.
+	const QFontMetrics fm( app->font() );
+	const int pad_v = qMax( 4, fm.height() / 5 );
+	const int pad_h = qMax( 8, fm.averageCharWidth() );
+	const int btn_pad_v = qMax( 5, fm.height() / 4 );
+	const int btn_pad_h = qMax( 12, fm.averageCharWidth() * 2 );
+	const int drop_w = qMax( 18, fm.height() );
 
-QGroupBox {
-	font-weight: 600;
-	border: 1px solid palette(mid);
-	border-radius: 6px;
-	margin-top: 12px;
-	padding: 10px 8px 8px 8px;
-	background-color: palette(base);
+	app->setStyleSheet( QStringLiteral(
+"/* —— Global chrome —— */\n"
+"QMainWindow, QDialog {\n"
+"	background-color: palette(window);\n"
+"}\n"
+"\n"
+"QGroupBox {\n"
+"	font-weight: 600;\n"
+"	border: 1px solid palette(mid);\n"
+"	border-radius: 6px;\n"
+"	margin-top: 12px;\n"
+"	padding: 10px 8px 8px 8px;\n"
+"	background-color: palette(base);\n"
+"}\n"
+"QGroupBox::title {\n"
+"	subcontrol-origin: margin;\n"
+"	subcontrol-position: top left;\n"
+"	left: 10px;\n"
+"	padding: 0 6px;\n"
+"	color: palette(window-text);\n"
+"}\n"
+"\n"
+"/* Never style QTabWidget::pane / QTabBar globally — any pane rule breaks\n"
+"   QTabWidget::West on Qt 5 (content area paints blank). Style North tabs\n"
+"   on specific widgets only if needed. */\n"
+"\n"
+"QListWidget, QTreeWidget, QTableWidget {\n"
+"	border: 1px solid palette(mid);\n"
+"	border-radius: 4px;\n"
+"	background: palette(base);\n"
+"	padding: 2px;\n"
+"	outline: 0;\n"
+"}\n"
+"QListWidget::item, QTreeWidget::item {\n"
+"	padding: 4px 6px;\n"
+"	border-radius: 3px;\n"
+"}\n"
+"QListWidget::item:selected, QTreeWidget::item:selected {\n"
+"	background: palette(highlight);\n"
+"	color: palette(highlighted-text);\n"
+"}\n"
+"\n"
+"QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {\n"
+"	padding: %1px %2px;\n"
+"	border: 1px solid palette(mid);\n"
+"	border-radius: 4px;\n"
+"	background: palette(base);\n"
+"	selection-background-color: palette(highlight);\n"
+"}\n"
+"QComboBox {\n"
+"	padding: %1px %2px;\n"
+"	padding-right: %3px;\n"
+"	border: 1px solid palette(mid);\n"
+"	border-radius: 4px;\n"
+"	background: palette(base);\n"
+"	selection-background-color: palette(highlight);\n"
+"}\n"
+"QComboBox:editable {\n"
+"	padding: 0px;\n"
+"}\n"
+"QComboBox:editable QLineEdit {\n"
+"	padding: %1px %2px;\n"
+"	border: none;\n"
+"	background: transparent;\n"
+"}\n"
+"QComboBox::drop-down {\n"
+"	border: none;\n"
+"	width: %3px;\n"
+"}\n"
+"QComboBox QAbstractItemView {\n"
+"	border: 1px solid palette(mid);\n"
+"	selection-background-color: palette(highlight);\n"
+"	padding: 2px;\n"
+"}\n"
+"\n"
+"QPushButton {\n"
+"	padding: %4px %5px;\n"
+"	border: 1px solid palette(mid);\n"
+"	border-radius: 4px;\n"
+"	background: palette(button);\n"
+"}\n"
+"QPushButton:hover {\n"
+"	background: palette(light);\n"
+"}\n"
+"QPushButton:pressed {\n"
+"	background: palette(midlight);\n"
+"}\n"
+"QPushButton:default {\n"
+"	font-weight: 600;\n"
+"	border-color: palette(highlight);\n"
+"}\n"
+"QToolButton {\n"
+"	padding: %1px %2px;\n"
+"	border-radius: 4px;\n"
+"}\n"
+"\n"
+"QCheckBox, QRadioButton {\n"
+"	spacing: 6px;\n"
+"	padding: 2px 0;\n"
+"}\n"
+	).arg( pad_v ).arg( pad_h ).arg( drop_w ).arg( btn_pad_v ).arg( btn_pad_h )
+	+ QStringLiteral( R"(
+QScrollBar:vertical {
+	width: 12px;
+	margin: 0;
 }
-QGroupBox::title {
-	subcontrol-origin: margin;
-	subcontrol-position: top left;
-	left: 10px;
-	padding: 0 6px;
-	color: palette(window-text);
-}
-
-/* Never style QTabWidget::pane / QTabBar globally — any pane rule breaks
-   QTabWidget::West on Qt 5 (content area paints blank). Style North tabs
-   on specific widgets only if needed. */
-
-QListWidget, QTreeWidget, QTableWidget {
-	border: 1px solid palette(mid);
-	border-radius: 4px;
-	background: palette(base);
-	padding: 2px;
-	outline: 0;
-}
-QListWidget::item, QTreeWidget::item {
-	padding: 4px 6px;
-	border-radius: 3px;
-}
-QListWidget::item:selected, QTreeWidget::item:selected {
-	background: palette(highlight);
-	color: palette(highlighted-text);
-}
-
-QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
-	padding: 3px 6px;
-	border: 1px solid palette(mid);
-	border-radius: 4px;
-	background: palette(base);
-	min-height: 22px;
-	selection-background-color: palette(highlight);
-}
-QComboBox::drop-down {
-	border: none;
-	width: 20px;
-}
-QComboBox QAbstractItemView {
-	border: 1px solid palette(mid);
-	selection-background-color: palette(highlight);
-}
-
-QPushButton {
-	padding: 5px 14px;
-	border: 1px solid palette(mid);
-	border-radius: 4px;
-	background: palette(button);
-	min-height: 22px;
-}
-QPushButton:hover {
-	background: palette(light);
-}
-QPushButton:pressed {
-	background: palette(midlight);
-}
-QPushButton:default {
-	font-weight: 600;
-	border-color: palette(highlight);
-}
-QToolButton {
-	padding: 3px 8px;
-	border-radius: 4px;
-}
-
-QCheckBox, QRadioButton {
-	spacing: 6px;
-	padding: 2px 0;
+QScrollBar:horizontal {
+	height: 12px;
+	margin: 0;
 }
 
 QSlider::groove:horizontal {
 	height: 6px;
-	border-radius: 3px;
 	background: palette(mid);
+	border-radius: 3px;
 }
 QSlider::handle:horizontal {
 	width: 14px;
 	margin: -5px 0;
-	border-radius: 7px;
 	background: palette(highlight);
+	border-radius: 7px;
+}
+
+QStatusBar {
+	min-height: 24px;
+}
+
+QToolTip {
+	padding: 4px 8px;
+	border: 1px solid palette(mid);
+	background: palette(base);
+	color: palette(window-text);
+}
+
+QHeaderView::section {
+	padding: 4px 8px;
+	border: none;
+	border-right: 1px solid palette(mid);
+	border-bottom: 1px solid palette(mid);
+	background: palette(button);
+}
+
+QProgressBar {
+	border: 1px solid palette(mid);
+	border-radius: 4px;
+	text-align: center;
+	min-height: 16px;
+}
+QProgressBar::chunk {
+	background: palette(highlight);
+	border-radius: 3px;
+}
+
+QMenuBar {
+	padding: 2px;
+	background: palette(window);
+}
+QMenuBar::item {
+	padding: 4px 10px;
+	border-radius: 3px;
+}
+QMenuBar::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+}
+QMenu {
+	border: 1px solid palette(mid);
+	background: palette(base);
+	padding: 4px;
+}
+QMenu::item {
+	padding: 5px 28px 5px 24px;
+	border-radius: 3px;
+}
+QMenu::item:selected {
+	background: palette(highlight);
+	color: palette(highlighted-text);
+}
+QMenu::separator {
+	height: 1px;
+	background: palette(mid);
+	margin: 4px 8px;
 }
 
 QScrollArea {
 	border: none;
 	background: transparent;
-}
-QScrollBar:vertical {
-	width: 10px;
-	background: transparent;
-	margin: 0;
 }
 QScrollBar::handle:vertical {
 	background: palette(mid);
@@ -308,26 +398,11 @@ QScrollBar::handle:vertical {
 QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
 	height: 0;
 }
-
-QStatusBar {
-	border-top: 1px solid palette(mid);
-}
-QMenuBar {
-	background: palette(window);
-	border-bottom: 1px solid palette(mid);
-	padding: 2px;
-}
-QMenuBar::item:selected {
-	background: palette(highlight);
-	color: palette(highlighted-text);
-	border-radius: 3px;
-}
 QSplitter::handle {
 	background: palette(mid);
 	width: 1px;
 	height: 1px;
 }
-
 )" ) );
 }
 

--- a/src/AQ_UI_Style.h
+++ b/src/AQ_UI_Style.h
@@ -6,19 +6,37 @@
 
 #include <QString>
 #include <QSize>
+#include <QTabBar>
 
 class QApplication;
 class QWidget;
 class QLayout;
+class QTabWidget;
 
 /** Must run before QApplication is constructed (Qt 5 High-DPI). */
 void AQ_Enable_High_Dpi();
 
 /**
- * Host UI scale vs a 96-DPI baseline (logicalDotsPerInch / 96, floored at 1).
- * Prefer this over hard-coded pixel sizes anywhere in the UI.
+ * Extra layout multiplier. With High-DPI enabled this stays 1.0 — Qt already
+ * maps DIPs; multiplying by logicalDPI/96 double-scales chrome on 4K.
  */
 qreal AQ_Ui_Scale( const QWidget *hint = nullptr );
+
+/**
+ * West (vertical) tab bar with a slim rail and antialiased rotated labels.
+ * Replaces the stock bar on a QTabWidget (avoids fat/pixelated West tabs).
+ */
+class AQ_West_TabBar : public QTabBar
+{
+public:
+	explicit AQ_West_TabBar( QWidget *parent = nullptr );
+	QSize tabSizeHint( int index ) const override;
+
+protected:
+	void paintEvent( QPaintEvent *event ) override;
+};
+
+void AQ_Install_West_TabBar( QTabWidget *tabs );
 
 /** Scale a size that was designed for 96 DPI into current logical pixels. */
 int AQ_Px( int baseline_96dpi, const QWidget *hint = nullptr );

--- a/src/AQ_UI_Style.h
+++ b/src/AQ_UI_Style.h
@@ -5,10 +5,31 @@
 #define AQ_UI_STYLE_H
 
 #include <QString>
+#include <QSize>
 
 class QApplication;
 class QWidget;
 class QLayout;
+
+/** Must run before QApplication is constructed (Qt 5 High-DPI). */
+void AQ_Enable_High_Dpi();
+
+/**
+ * Host UI scale vs a 96-DPI baseline (logicalDotsPerInch / 96, floored at 1).
+ * Prefer this over hard-coded pixel sizes anywhere in the UI.
+ */
+qreal AQ_Ui_Scale( const QWidget *hint = nullptr );
+
+/** Scale a size that was designed for 96 DPI into current logical pixels. */
+int AQ_Px( int baseline_96dpi, const QWidget *hint = nullptr );
+
+/** Toolbar / tab / list / VM-list icon sizes from QStyle + DPI (never hard-coded). */
+QSize AQ_Toolbar_Icon_Size( const QWidget *hint = nullptr );
+QSize AQ_Nav_Icon_Size( const QWidget *hint = nullptr );
+QSize AQ_Vm_List_Icon_Size( const QWidget *hint = nullptr );
+
+/** Readable content column width from font metrics (~72 average characters). */
+int AQ_Content_Max_Width( const QWidget *hint = nullptr );
 
 /** Install the global AQEMU chrome (group boxes, tabs, lists, inputs). */
 void AQ_Apply_App_Style( QApplication *app );
@@ -20,9 +41,9 @@ void AQ_Style_Card( QWidget *w, int max_width = 0 );
 void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name = QString() );
 
 /** Collapse large expanding vertical spacers to small fixed gaps. */
-void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px = 6 );
+void AQ_Tighten_Layout_Spacers( QLayout *layout, int gap_px = -1 );
 
 /** Cap readable content width on common panels under root. */
-void AQ_Cap_Content_Width( QWidget *root, int max_width = 960 );
+void AQ_Cap_Content_Width( QWidget *root, int max_width = -1 );
 
 #endif

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -451,7 +451,7 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	// Screenshot for OS Logo
 	ui.CH_Screenshot_for_OS_Logo->setChecked( Settings.value("Use_Screenshot_for_OS_Logo", "yes").toString() == "yes" );
 
-	ui.CH_Minimize_To_Tray->setChecked( Settings.value( "Minimize_To_Tray", "no" ).toString() == "yes" );
+	ui.CH_Minimize_To_Tray->setChecked( Settings.value( "Minimize_To_Tray", "yes" ).toString() == "yes" );
 	
 	Load_Templates();
 	

--- a/src/Highlighted_Label.cpp
+++ b/src/Highlighted_Label.cpp
@@ -31,12 +31,14 @@
 Highlighted_Label::Highlighted_Label( QWidget *parent )
 	: QLabel( parent )
 {
-	// Scale from the application font — no fixed pixel type size.
+	// Stay on the UI sans-serif — never fall into a serif display face.
 	QFont f = QApplication::font();
+	f.setStyleHint( QFont::SansSerif, QFont::PreferAntialias );
+	f.setStyleStrategy( QFont::PreferAntialias );
 	if( f.pointSizeF() > 0 )
-		f.setPointSizeF( f.pointSizeF() * 1.25 );
+		f.setPointSizeF( f.pointSizeF() * 1.15 );
 	else if( f.pixelSize() > 0 )
-		f.setPixelSize( qRound( f.pixelSize() * 1.25 ) );
+		f.setPixelSize( qRound( f.pixelSize() * 1.15 ) );
 	f.setWeight( QFont::DemiBold );
 	setFont( f );
 
@@ -48,18 +50,21 @@ Highlighted_Label::Highlighted_Label( QWidget *parent )
 	const int pad_t = AQ_Px( 8, this );
 	const int pad_b = AQ_Px( 5, this );
 	const int rule = qMax( 1, AQ_Px( 2, this ) );
+	const QString family = f.family().replace( QLatin1Char( '\'' ), QString() );
 
 	setStyleSheet( QStringLiteral(
 		"Highlighted_Label {"
+		"  font-family: '%1';"
 		"  font-weight: 600;"
-		"  color: %1;"
-		"  padding: %2px %3px %4px %3px;"
-		"  border-bottom: %5px solid palette(mid);"
-		"  margin-top: %6px;"
-		"  margin-bottom: %7px;"
+		"  color: %2;"
+		"  padding: %3px %4px %5px %4px;"
+		"  border-bottom: %6px solid palette(mid);"
+		"  margin-top: %7px;"
+		"  margin-bottom: %8px;"
 		"  background: transparent;"
 		"}"
-	).arg( use_link ? QStringLiteral( "palette(link)" ) : QStringLiteral( "palette(window-text)" ) )
+	).arg( family )
+	 .arg( use_link ? QStringLiteral( "palette(link)" ) : QStringLiteral( "palette(window-text)" ) )
 	 .arg( pad_t ).arg( AQ_Px( 2, this ) ).arg( pad_b )
 	 .arg( rule ).arg( AQ_Px( 4, this ) ).arg( AQ_Px( 2, this ) ) );
 }

--- a/src/Highlighted_Label.cpp
+++ b/src/Highlighted_Label.cpp
@@ -20,47 +20,41 @@
 **
 ****************************************************************************/
 
+#include <QFont>
 #include <QPalette>
-#include <Utils.h>
 
+#include "Utils.h"
 #include "Highlighted_Label.h"
 
-Highlighted_Label::Highlighted_Label(QWidget* parent) : QLabel(parent)
+Highlighted_Label::Highlighted_Label( QWidget *parent )
+	: QLabel( parent )
 {
-    QPalette pal = palette();
-    QColor background_color = pal.color(QPalette::Window);
-    QColor link_color = pal.color(QPalette::Link);
+	QFont f = font();
+	f.setPointSize( qMax( 12, f.pointSize() + 2 ) );
+	f.setWeight( QFont::DemiBold );
+	setFont( f );
 
-    if ( calculateContrast(background_color,link_color) > 3.0 )
-    {
-        setStyleSheet(R"(
-        Highlighted_Label
-            {
-                font-size: 13px;
-                font-weight: 600;
-                color: palette(link);
-                padding: 8px 10px 4px 10px;
-                border-bottom: 1px solid palette(mid);
-                margin-top: 2px;
-            }
-        )");
-    }
-    else
-    {
-        setStyleSheet(R"(
-        Highlighted_Label
-            {
-                font-size: 13px;
-                font-weight: 600;
-                padding: 8px 10px 4px 10px;
-                border-bottom: 1px solid palette(mid);
-                margin-top: 2px;
-            }
-        )");
-    }
+	QPalette pal = palette();
+	const QColor background_color = pal.color( QPalette::Window );
+	const QColor link_color = pal.color( QPalette::Link );
+	const bool use_link = calculateContrast( background_color, link_color ) > 3.0;
+
+	// Modern section header — larger type, clear rule, no tiny blue scrap.
+	setStyleSheet( QStringLiteral(
+		"Highlighted_Label {"
+		"  font-size: 15px;"
+		"  font-weight: 600;"
+		"  letter-spacing: 0.3px;"
+		"  color: %1;"
+		"  padding: 10px 4px 6px 2px;"
+		"  border-bottom: 2px solid palette(mid);"
+		"  margin-top: 4px;"
+		"  margin-bottom: 2px;"
+		"  background: transparent;"
+		"}"
+	).arg( use_link ? QStringLiteral( "palette(link)" ) : QStringLiteral( "palette(window-text)" ) ) );
 }
 
 Highlighted_Label::Highlighted_Label()
 {
 }
-

--- a/src/Highlighted_Label.cpp
+++ b/src/Highlighted_Label.cpp
@@ -20,17 +20,23 @@
 **
 ****************************************************************************/
 
+#include <QApplication>
 #include <QFont>
 #include <QPalette>
 
 #include "Utils.h"
+#include "AQ_UI_Style.h"
 #include "Highlighted_Label.h"
 
 Highlighted_Label::Highlighted_Label( QWidget *parent )
 	: QLabel( parent )
 {
-	QFont f = font();
-	f.setPointSize( qMax( 12, f.pointSize() + 2 ) );
+	// Scale from the application font — no fixed pixel type size.
+	QFont f = QApplication::font();
+	if( f.pointSizeF() > 0 )
+		f.setPointSizeF( f.pointSizeF() * 1.25 );
+	else if( f.pixelSize() > 0 )
+		f.setPixelSize( qRound( f.pixelSize() * 1.25 ) );
 	f.setWeight( QFont::DemiBold );
 	setFont( f );
 
@@ -39,20 +45,23 @@ Highlighted_Label::Highlighted_Label( QWidget *parent )
 	const QColor link_color = pal.color( QPalette::Link );
 	const bool use_link = calculateContrast( background_color, link_color ) > 3.0;
 
-	// Modern section header — larger type, clear rule, no tiny blue scrap.
+	const int pad_t = AQ_Px( 8, this );
+	const int pad_b = AQ_Px( 5, this );
+	const int rule = qMax( 1, AQ_Px( 2, this ) );
+
 	setStyleSheet( QStringLiteral(
 		"Highlighted_Label {"
-		"  font-size: 15px;"
 		"  font-weight: 600;"
-		"  letter-spacing: 0.3px;"
 		"  color: %1;"
-		"  padding: 10px 4px 6px 2px;"
-		"  border-bottom: 2px solid palette(mid);"
-		"  margin-top: 4px;"
-		"  margin-bottom: 2px;"
+		"  padding: %2px %3px %4px %3px;"
+		"  border-bottom: %5px solid palette(mid);"
+		"  margin-top: %6px;"
+		"  margin-bottom: %7px;"
 		"  background: transparent;"
 		"}"
-	).arg( use_link ? QStringLiteral( "palette(link)" ) : QStringLiteral( "palette(window-text)" ) ) );
+	).arg( use_link ? QStringLiteral( "palette(link)" ) : QStringLiteral( "palette(window-text)" ) )
+	 .arg( pad_t ).arg( AQ_Px( 2, this ) ).arg( pad_b )
+	 .arg( rule ).arg( AQ_Px( 4, this ) ).arg( AQ_Px( 2, this ) ) );
 }
 
 Highlighted_Label::Highlighted_Label()

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -45,6 +45,9 @@
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <QEvent>
+#include <QWindowStateChangeEvent>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QTextEdit>
@@ -118,6 +121,7 @@ Main_Window::Main_Window( QWidget *parent )
 	, Tray_Icon( nullptr )
 	, Act_Tray_Show( nullptr )
 	, Act_Tray_Quit( nullptr )
+	, Tray_Restore_Maximized( false )
 	, Auto_Save_Timer( nullptr )
 	, VM_Ui_Refresh_Timer( nullptr )
 {
@@ -425,7 +429,7 @@ void Main_Window::Update_System_Tray()
 	if( ! Tray_Icon )
 		return;
 
-	const bool enable = Settings.value( "Minimize_To_Tray", "no" ).toString() == "yes";
+	const bool enable = Settings.value( "Minimize_To_Tray", "yes" ).toString() == "yes";
 	if( ! enable )
 	{
 		Tray_Icon->hide();
@@ -443,7 +447,10 @@ void Main_Window::Update_System_Tray()
 
 void Main_Window::On_Tray_Show()
 {
-	showNormal();
+	if( Tray_Restore_Maximized )
+		showMaximized();
+	else
+		showNormal();
 	raise();
 	activateWindow();
 	if( Tray_Icon )
@@ -458,23 +465,22 @@ void Main_Window::On_Tray_Activated( QSystemTrayIcon::ActivationReason reason )
 
 void Main_Window::changeEvent( QEvent *event )
 {
-	QMainWindow::changeEvent( event );
-	if( event->type() != QEvent::WindowStateChange )
-		return;
-	if( Settings.value( "Minimize_To_Tray", "no" ).toString() != "yes" )
-		return;
-	if( ! Tray_Icon )
-		return;
-
-	if( isMinimized() )
+	if( event->type() == QEvent::WindowStateChange )
 	{
-		QTimer::singleShot( 0, this, SLOT(Hide_To_Tray()) );
+		auto *se = static_cast<QWindowStateChangeEvent *>( event );
+		if( Settings.value( "Minimize_To_Tray", "yes" ).toString() == "yes" &&
+		    Tray_Icon && isMinimized() )
+		{
+			Tray_Restore_Maximized = se->oldState().testFlag( Qt::WindowMaximized );
+			QTimer::singleShot( 0, this, SLOT(Hide_To_Tray()) );
+		}
 	}
+	QMainWindow::changeEvent( event );
 }
 
 void Main_Window::Hide_To_Tray()
 {
-	if( Settings.value( "Minimize_To_Tray", "no" ).toString() != "yes" )
+	if( Settings.value( "Minimize_To_Tray", "yes" ).toString() != "yes" )
 		return;
 	if( ! Tray_Icon )
 		return;
@@ -601,16 +607,10 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		if( gen_ix >= 0 )
 			ui.Tabs->setTabText( gen_ix, tr( "Machine" ) );
 
-		// Compact West rail — Qt High-DPI already scales DIPs; keep the strip slim.
+		AQ_Install_West_TabBar( ui.Tabs );
 		if( QTabBar *bar = ui.Tabs->tabBar() )
 		{
-			bar->setExpanding( false );
-			QFont tabFont = QApplication::font();
-			tabFont.setStyleHint( QFont::SansSerif, QFont::PreferAntialias );
-			tabFont.setStyleStrategy( QFont::PreferAntialias );
-			tabFont.setWeight( QFont::Medium );
-			bar->setFont( tabFont );
-			const QFontMetrics fm( tabFont );
+			const QFontMetrics fm( bar->font() );
 			const int pad_along = qMax( 4, fm.height() / 4 );
 			const int pad_thick = qMax( 2, fm.averageCharWidth() / 2 );
 			const int accent = qMax( 2, fm.averageCharWidth() / 3 );
@@ -633,12 +633,15 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 				"  background: palette(alternate-base);"
 				"}"
 			).arg( pad_along ).arg( pad_thick ).arg( accent ) );
-			// Small icons for the thin West rail (not list/nav size).
-			QStyle *st = style();
-			const int icon = st ? st->pixelMetric( QStyle::PM_SmallIconSize, nullptr, this ) : 16;
-			bar->setIconSize( QSize( icon, icon ) );
 		}
 	}
+
+	// Soft floor so the layout can shrink; Media chip strip no longer locks width.
+	setMinimumSize( 640, 480 );
+	if( ui.splitter )
+		ui.splitter->setChildrenCollapsible( true );
+	if( ui.Machines_List )
+		ui.Machines_List->setMinimumWidth( 140 );
 
 	// Keep the Machine / Memory / Audio… section headers; tighten the page.
 	if( ui.label )
@@ -1901,12 +1904,34 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 
 bool Main_Window::Load_Settings()
 {
-	// Main Window Size
-	resize( Settings.value("General_Window_Width", "885").toInt(),
-			Settings.value("General_Window_Height", "544").toInt() );
+	// Main Window Size — clamp to the available screen so a prior maximized
+	// save cannot leave the window stuck at "whole desktop" normal size.
+	int w = Settings.value( "General_Window_Width", 885 ).toInt();
+	int h = Settings.value( "General_Window_Height", 544 ).toInt();
+	QPoint pos = Settings.value( "General_Window_Position", QPoint( 300, 300 ) ).toPoint();
 
-	// Main Window Position
-	move( Settings.value("General_Window_Position", QPoint(300, 300)).toPoint() );
+	QScreen *screen = QGuiApplication::screenAt( pos );
+	if( ! screen )
+		screen = QGuiApplication::primaryScreen();
+	if( screen )
+	{
+		const QRect avail = screen->availableGeometry();
+		w = qBound( 640, w, avail.width() );
+		h = qBound( 480, h, avail.height() );
+		if( ! avail.contains( pos ) )
+		{
+			pos.setX( qBound( avail.left(), pos.x(), avail.right() - w ) );
+			pos.setY( qBound( avail.top(), pos.y(), avail.bottom() - h ) );
+		}
+	}
+	else
+	{
+		w = qMax( 640, w );
+		h = qMax( 480, h );
+	}
+
+	resize( w, h );
+	move( pos );
 
 	// Toolbar State
 	restoreState( Settings.value("General_Window_State").toByteArray());
@@ -1918,6 +1943,9 @@ bool Main_Window::Load_Settings()
 	// Splitter
 	ui.splitter->restoreState( Settings.value("General_Splitter",
 							   QByteArray("\0\0\0\xff\0\0\0\0\0\0\0\x2\0\0\0\xbc\0\0\x2$\0\0\0\0\x4\x1\0\0\0\x1")).toByteArray() );
+
+	if( Settings.value( "General_Window_Maximized", false ).toBool() )
+		showMaximized();
 
 	// VM Icons Size — user override if set, else host DPI / style metric.
 	{
@@ -1952,9 +1980,14 @@ bool Main_Window::Save_Settings()
 	// Current VM Index
 	Settings.setValue( "Current_VM_Index", ui.Machines_List->currentRow() );
 
-	// Save Windows Size
-	Settings.setValue( "General_Window_Width", QString::number(this->width()) );
-	Settings.setValue( "General_Window_Height", QString::number(this->height()) );
+	// Persist the restored (non-maximized) geometry so Maximize does not
+	// permanently inflate the next normal session size.
+	const QRect geo = normalGeometry();
+	Settings.setValue( "General_Window_Width", QString::number( geo.width() ) );
+	Settings.setValue( "General_Window_Height", QString::number( geo.height() ) );
+	Settings.setValue( "General_Window_Position", geo.topLeft() );
+	Settings.setValue( "General_Window_Maximized",
+		isMaximized() || ( ! isVisible() && Tray_Restore_Maximized ) );
 
 	// Save Toolbar State — never persist session-hidden left bars
 	const bool manage_vis = ui.Tool_Bar_VM_Manage->isVisible();
@@ -1964,9 +1997,6 @@ bool Main_Window::Save_Settings()
 	Settings.setValue( "General_Window_State", saveState() );
 	ui.Tool_Bar_VM_Manage->setVisible( manage_vis );
 	ui.Tool_Bar_VM_Control->setVisible( control_vis );
-
-	// Save Main Window Position
-	Settings.setValue( "General_Window_Position", pos() );
 
 	// Splitter
 	Settings.setValue( "General_Splitter", ui.splitter->saveState() );

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -707,12 +707,14 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	if( ui.Memory_Size )
 	{
 		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
-		ui.Memory_Size->setMaximumHeight( AQ_Px( 28, this ) );
-		ui.Memory_Size->setMinimumHeight( AQ_Px( 22, this ) );
+		// Don't clamp slider height — HiDPI + QSS already size it; hard caps clip neighbors.
 		ui.Memory_Size->setMaximumWidth( content_cap - AQ_Px( 80, this ) );
 	}
 	if( ui.CB_RAM_Size )
+	{
 		ui.CB_RAM_Size->setMinimumWidth( AQ_Px( 110, this ) );
+		ui.CB_RAM_Size->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
+	}
 
 	if( ui.widget && ui.widget->layout() )
 	{
@@ -732,8 +734,23 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	{
 		ui.TB_Show_Advanced_Options_Window->setSizePolicy(
 			QSizePolicy::Maximum, QSizePolicy::Fixed );
-		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( AQ_Px( 120, this ) );
+		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( 0 );
+		ui.TB_Show_Advanced_Options_Window->setMinimumHeight( 0 );
+		ui.TB_Show_Advanced_Options_Window->setMaximumHeight( QWIDGETSIZE_MAX );
 	}
+
+	// Win11 lifecycle buttons — Preferred width so long labels aren't truncated.
+	auto polish_btn = []( QPushButton *b ) {
+		if( ! b ) return;
+		b->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
+		b->setMinimumHeight( 0 );
+		b->setMaximumHeight( QWIDGETSIZE_MAX );
+	};
+	polish_btn( ui.Button_Win11_Install );
+	polish_btn( ui.Button_Win11_First_Boot );
+	polish_btn( ui.Button_Win11_Normal );
+	polish_btn( ui.Button_Win11_Repair );
+	polish_btn( ui.Button_VirtIO_Defaults );
 
 	if( ui.GB_Options )
 	{

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -59,6 +59,7 @@
 #include <QSizePolicy>
 #include <QSpacerItem>
 #include <QGroupBox>
+#include <QTabBar>
 #ifndef Q_OS_WIN32
 #include <QtDBus>
 #endif
@@ -261,7 +262,7 @@ Main_Window::Main_Window( QWidget *parent )
 	ui.TabWidget_Display->insertTab( 1, SPICE_Widget, QIcon(":/pepper.png"), tr("SPICE Remote") );
 
     Display_Settings_Widget = new Settings_Widget( ui.TabWidget_Display, QBoxLayout::LeftToRight, true );
-    Display_Settings_Widget->setIconSize(QSize(32,32));
+    Display_Settings_Widget->setIconSize(QSize(24,24));
     Display_Settings_Widget->addToGroup("Main");
 
 	// Update Emulators Information
@@ -313,7 +314,7 @@ Main_Window::Main_Window( QWidget *parent )
     ui.TabWidget_Media->setCurrentWidget(Dev_Manager);
 
     Media_Settings_Widget = new Settings_Widget( ui.TabWidget_Media, QBoxLayout::LeftToRight, true );
-    Media_Settings_Widget->setIconSize(QSize(32,32));
+    Media_Settings_Widget->setIconSize(QSize(24,24));
     Media_Settings_Widget->addToGroup("Main");
 	
 
@@ -323,7 +324,7 @@ Main_Window::Main_Window( QWidget *parent )
     ////
 
     Network_Settings_Widget = new Settings_Widget( ui.Network_Cards_Tabs, QBoxLayout::LeftToRight, true );
-    Network_Settings_Widget->setIconSize(QSize(32,32));
+    Network_Settings_Widget->setIconSize(QSize(24,24));
     Network_Settings_Widget->addToGroup("Main");
 
 	// This For Network Redirections Table
@@ -591,38 +592,65 @@ Virtual_Machine *Main_Window::Get_Current_VM()
 void Main_Window::Polish_Settings_Tabs_Layout()
 {
 	// Do NOT wrap West-tab pages in QScrollArea — that blanks the pane on Qt 5.
-	// Keep polish light: margins, list spacing, and clear any tab stylesheet.
 	if( ui.Tabs )
 	{
 		ui.Tabs->setDocumentMode( false );
-		ui.Tabs->setStyleSheet( QString() ); // never inherit pane rules
+		ui.Tabs->setStyleSheet( QString() );
+		// Rename VM → Machine so the West rail matches the section header language.
+		const int gen_ix = ui.Tabs->indexOf( ui.Tab_General );
+		if( gen_ix >= 0 )
+			ui.Tabs->setTabText( gen_ix, tr( "Machine" ) );
+
+		// Larger, clearer West tab labels (style the bar only — never the pane).
+		if( QTabBar *bar = ui.Tabs->tabBar() )
+		{
+			bar->setExpanding( false );
+			bar->setStyleSheet( QStringLiteral(
+				"QTabBar::tab {"
+				"  font-size: 12px;"
+				"  font-weight: 600;"
+				"  padding: 14px 8px;"
+				"  min-width: 52px;"
+				"  margin: 2px 0;"
+				"  border: none;"
+				"  border-right: 3px solid transparent;"
+				"  color: palette(window-text);"
+				"  background: transparent;"
+				"}"
+				"QTabBar::tab:selected {"
+				"  color: palette(highlight);"
+				"  border-right: 3px solid palette(highlight);"
+				"  background: palette(base);"
+				"}"
+				"QTabBar::tab:hover:!selected {"
+				"  background: palette(alternate-base);"
+				"}" ) );
+		}
 	}
 
-	// Redundant with the left VM list + Name field — drop the blue "Machine" header.
+	// Keep the Machine / Memory / Audio… section headers; tighten the page.
 	if( ui.label )
-		ui.label->hide();
-	if( ui.widget && ui.widget->layout() )
-		ui.widget->layout()->setContentsMargins( 12, 4, 6, 6 );
+		ui.label->show();
 
 	if( ui.Tab_General && ui.Tab_General->layout() )
 	{
-		ui.Tab_General->layout()->setContentsMargins( 8, 4, 10, 8 );
-		ui.Tab_General->layout()->setSpacing( 4 );
-		AQ_Tighten_Layout_Spacers( ui.Tab_General->layout(), 6 );
+		ui.Tab_General->layout()->setContentsMargins( 10, 6, 12, 10 );
+		ui.Tab_General->layout()->setSpacing( 2 );
+		AQ_Tighten_Layout_Spacers( ui.Tab_General->layout(), 4 );
 	}
 	if( ui.Tab_Display && ui.Tab_Display->layout() )
 	{
-		ui.Tab_Display->layout()->setContentsMargins( 8, 8, 10, 8 );
-		ui.Tab_Display->layout()->setSpacing( 8 );
+		ui.Tab_Display->layout()->setContentsMargins( 10, 8, 12, 8 );
+		ui.Tab_Display->layout()->setSpacing( 6 );
 	}
 	if( ui.Tab_Media && ui.Tab_Media->layout() )
 	{
-		ui.Tab_Media->layout()->setContentsMargins( 8, 8, 8, 8 );
+		ui.Tab_Media->layout()->setContentsMargins( 8, 6, 8, 8 );
 		ui.Tab_Media->layout()->setSpacing( 6 );
 	}
 	if( ui.Tab_Network && ui.Tab_Network->layout() )
 	{
-		ui.Tab_Network->layout()->setContentsMargins( 8, 8, 8, 8 );
+		ui.Tab_Network->layout()->setContentsMargins( 8, 6, 8, 8 );
 		ui.Tab_Network->layout()->setSpacing( 6 );
 	}
 	if( ui.Tab_Info && ui.Tab_Info->layout() )
@@ -642,14 +670,43 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		}
 	}
 
+	// Cap readable column width so ultrawide screens don't leave desert gaps.
+	const int content_cap = 760;
+	auto cap_w = [content_cap]( QWidget *w ) {
+		if( w ) w->setMaximumWidth( content_cap );
+	};
+	cap_w( ui.widget );
+	cap_w( ui.GB_Memory );
+	cap_w( ui.GB_Audio );
+	cap_w( ui.GB_Disk_Bus );
+	cap_w( ui.GB_Win11_Lifecycle );
+	cap_w( ui.GB_Intel_MacOS_Settings );
+	cap_w( ui.GB_Options );
+	cap_w( ui.Widget_Use_Network );
+	cap_w( ui.GB_Guest_Display_Mode );
 	if( ui.Memory_Size )
 	{
 		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
 		ui.Memory_Size->setMaximumHeight( 28 );
 		ui.Memory_Size->setMinimumHeight( 22 );
+		ui.Memory_Size->setMaximumWidth( content_cap - 80 );
 	}
 	if( ui.CB_RAM_Size )
 		ui.CB_RAM_Size->setMinimumWidth( 110 );
+
+	if( ui.widget && ui.widget->layout() )
+	{
+		ui.widget->layout()->setContentsMargins( 8, 4, 8, 4 );
+		ui.widget->layout()->setSpacing( 4 );
+		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.widget->layout() ) )
+		{
+			// Prefer left-packed columns; don't stretch the middle into a void.
+			gl->setColumnStretch( 0, 0 );
+			gl->setColumnStretch( 1, 1 );
+			gl->setColumnStretch( 2, 0 );
+			gl->setColumnStretch( 3, 0 );
+		}
+	}
 
 	if( ui.TB_Show_Advanced_Options_Window )
 	{
@@ -661,13 +718,13 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	if( ui.GB_Options )
 	{
 		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.GB_Options->layout() ) )
-			gl->setColumnStretch( 3, 1 );
+			gl->setColumnStretch( 3, 0 );
 	}
 
 	auto polish_nested_tabs = []( QTabWidget *tw ) {
 		if( ! tw ) return;
 		tw->setDocumentMode( false );
-		tw->setElideMode( Qt::ElideRight );
+		tw->setElideMode( Qt::ElideNone );
 	};
 	polish_nested_tabs( ui.TabWidget_Media );
 	polish_nested_tabs( ui.TabWidget_Display );

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -601,38 +601,42 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		if( gen_ix >= 0 )
 			ui.Tabs->setTabText( gen_ix, tr( "Machine" ) );
 
-		// Clearer West tab labels — sizes from host DPI / font, not fixed px.
+		// Compact West rail — Qt High-DPI already scales DIPs; keep the strip slim.
 		if( QTabBar *bar = ui.Tabs->tabBar() )
 		{
 			bar->setExpanding( false );
-			QFont tabFont = bar->font();
-			tabFont.setWeight( QFont::DemiBold );
+			QFont tabFont = QApplication::font();
+			tabFont.setStyleHint( QFont::SansSerif, QFont::PreferAntialias );
+			tabFont.setStyleStrategy( QFont::PreferAntialias );
+			tabFont.setWeight( QFont::Medium );
 			bar->setFont( tabFont );
-			const int pad_v = AQ_Px( 10, this );
-			const int pad_h = AQ_Px( 6, this );
-			const int min_w = AQ_Px( 44, this );
-			const int accent = AQ_Px( 3, this );
+			const QFontMetrics fm( tabFont );
+			const int pad_along = qMax( 4, fm.height() / 4 );
+			const int pad_thick = qMax( 2, fm.averageCharWidth() / 2 );
+			const int accent = qMax( 2, fm.averageCharWidth() / 3 );
 			bar->setStyleSheet( QStringLiteral(
 				"QTabBar::tab {"
-				"  font-weight: 600;"
+				"  font-weight: 500;"
 				"  padding: %1px %2px;"
-				"  min-width: %3px;"
-				"  margin: %4px 0;"
+				"  margin: 1px 0;"
 				"  border: none;"
-				"  border-right: %5px solid transparent;"
+				"  border-right: %3px solid transparent;"
 				"  color: palette(window-text);"
 				"  background: transparent;"
 				"}"
 				"QTabBar::tab:selected {"
 				"  color: palette(highlight);"
-				"  border-right: %5px solid palette(highlight);"
+				"  border-right: %3px solid palette(highlight);"
 				"  background: palette(base);"
 				"}"
 				"QTabBar::tab:hover:!selected {"
 				"  background: palette(alternate-base);"
 				"}"
-			).arg( pad_v ).arg( pad_h ).arg( min_w ).arg( AQ_Px( 2, this ) ).arg( accent ) );
-			bar->setIconSize( AQ_Nav_Icon_Size( this ) );
+			).arg( pad_along ).arg( pad_thick ).arg( accent ) );
+			// Small icons for the thin West rail (not list/nav size).
+			QStyle *st = style();
+			const int icon = st ? st->pixelMetric( QStyle::PM_SmallIconSize, nullptr, this ) : 16;
+			bar->setIconSize( QSize( icon, icon ) );
 		}
 	}
 

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -707,7 +707,8 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	if( ui.Memory_Size )
 	{
 		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
-		// Don't clamp slider height — HiDPI + QSS already size it; hard caps clip neighbors.
+		// .ui locked this to 28px — too short with tick labels on HiDPI.
+		ui.Memory_Size->setMaximumHeight( QWIDGETSIZE_MAX );
 		ui.Memory_Size->setMaximumWidth( content_cap - AQ_Px( 80, this ) );
 	}
 	if( ui.CB_RAM_Size )

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -262,7 +262,7 @@ Main_Window::Main_Window( QWidget *parent )
 	ui.TabWidget_Display->insertTab( 1, SPICE_Widget, QIcon(":/pepper.png"), tr("SPICE Remote") );
 
     Display_Settings_Widget = new Settings_Widget( ui.TabWidget_Display, QBoxLayout::LeftToRight, true );
-    Display_Settings_Widget->setIconSize(QSize(24,24));
+    Display_Settings_Widget->setIconSize( AQ_Nav_Icon_Size( this ) );
     Display_Settings_Widget->addToGroup("Main");
 
 	// Update Emulators Information
@@ -314,7 +314,7 @@ Main_Window::Main_Window( QWidget *parent )
     ui.TabWidget_Media->setCurrentWidget(Dev_Manager);
 
     Media_Settings_Widget = new Settings_Widget( ui.TabWidget_Media, QBoxLayout::LeftToRight, true );
-    Media_Settings_Widget->setIconSize(QSize(24,24));
+    Media_Settings_Widget->setIconSize( AQ_Nav_Icon_Size( this ) );
     Media_Settings_Widget->addToGroup("Main");
 	
 
@@ -324,7 +324,7 @@ Main_Window::Main_Window( QWidget *parent )
     ////
 
     Network_Settings_Widget = new Settings_Widget( ui.Network_Cards_Tabs, QBoxLayout::LeftToRight, true );
-    Network_Settings_Widget->setIconSize(QSize(24,24));
+    Network_Settings_Widget->setIconSize( AQ_Nav_Icon_Size( this ) );
     Network_Settings_Widget->addToGroup("Main");
 
 	// This For Network Redirections Table
@@ -601,30 +601,38 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		if( gen_ix >= 0 )
 			ui.Tabs->setTabText( gen_ix, tr( "Machine" ) );
 
-		// Larger, clearer West tab labels (style the bar only — never the pane).
+		// Clearer West tab labels — sizes from host DPI / font, not fixed px.
 		if( QTabBar *bar = ui.Tabs->tabBar() )
 		{
 			bar->setExpanding( false );
+			QFont tabFont = bar->font();
+			tabFont.setWeight( QFont::DemiBold );
+			bar->setFont( tabFont );
+			const int pad_v = AQ_Px( 10, this );
+			const int pad_h = AQ_Px( 6, this );
+			const int min_w = AQ_Px( 44, this );
+			const int accent = AQ_Px( 3, this );
 			bar->setStyleSheet( QStringLiteral(
 				"QTabBar::tab {"
-				"  font-size: 12px;"
 				"  font-weight: 600;"
-				"  padding: 14px 8px;"
-				"  min-width: 52px;"
-				"  margin: 2px 0;"
+				"  padding: %1px %2px;"
+				"  min-width: %3px;"
+				"  margin: %4px 0;"
 				"  border: none;"
-				"  border-right: 3px solid transparent;"
+				"  border-right: %5px solid transparent;"
 				"  color: palette(window-text);"
 				"  background: transparent;"
 				"}"
 				"QTabBar::tab:selected {"
 				"  color: palette(highlight);"
-				"  border-right: 3px solid palette(highlight);"
+				"  border-right: %5px solid palette(highlight);"
 				"  background: palette(base);"
 				"}"
 				"QTabBar::tab:hover:!selected {"
 				"  background: palette(alternate-base);"
-				"}" ) );
+				"}"
+			).arg( pad_v ).arg( pad_h ).arg( min_w ).arg( AQ_Px( 2, this ) ).arg( accent ) );
+			bar->setIconSize( AQ_Nav_Icon_Size( this ) );
 		}
 	}
 
@@ -634,28 +642,33 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 
 	if( ui.Tab_General && ui.Tab_General->layout() )
 	{
-		ui.Tab_General->layout()->setContentsMargins( 10, 6, 12, 10 );
-		ui.Tab_General->layout()->setSpacing( 2 );
-		AQ_Tighten_Layout_Spacers( ui.Tab_General->layout(), 4 );
+		const int m = AQ_Px( 8, this );
+		ui.Tab_General->layout()->setContentsMargins( m, AQ_Px( 6, this ), AQ_Px( 10, this ), m );
+		ui.Tab_General->layout()->setSpacing( AQ_Px( 2, this ) );
+		AQ_Tighten_Layout_Spacers( ui.Tab_General->layout() );
 	}
 	if( ui.Tab_Display && ui.Tab_Display->layout() )
 	{
-		ui.Tab_Display->layout()->setContentsMargins( 10, 8, 12, 8 );
-		ui.Tab_Display->layout()->setSpacing( 6 );
+		const int m = AQ_Px( 8, this );
+		ui.Tab_Display->layout()->setContentsMargins( m, m, AQ_Px( 10, this ), m );
+		ui.Tab_Display->layout()->setSpacing( AQ_Px( 6, this ) );
 	}
 	if( ui.Tab_Media && ui.Tab_Media->layout() )
 	{
-		ui.Tab_Media->layout()->setContentsMargins( 8, 6, 8, 8 );
-		ui.Tab_Media->layout()->setSpacing( 6 );
+		const int m = AQ_Px( 6, this );
+		ui.Tab_Media->layout()->setContentsMargins( m, m, m, AQ_Px( 8, this ) );
+		ui.Tab_Media->layout()->setSpacing( AQ_Px( 6, this ) );
 	}
 	if( ui.Tab_Network && ui.Tab_Network->layout() )
 	{
-		ui.Tab_Network->layout()->setContentsMargins( 8, 6, 8, 8 );
-		ui.Tab_Network->layout()->setSpacing( 6 );
+		const int m = AQ_Px( 6, this );
+		ui.Tab_Network->layout()->setContentsMargins( m, m, m, AQ_Px( 8, this ) );
+		ui.Tab_Network->layout()->setSpacing( AQ_Px( 6, this ) );
 	}
 	if( ui.Tab_Info && ui.Tab_Info->layout() )
 	{
-		ui.Tab_Info->layout()->setContentsMargins( 8, 8, 8, 8 );
+		const int m = AQ_Px( 8, this );
+		ui.Tab_Info->layout()->setContentsMargins( m, m, m, m );
 		if( ui.VM_Information_Text )
 		{
 			ui.VM_Information_Text->setFrameShape( QFrame::StyledPanel );
@@ -663,15 +676,15 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 				QStringLiteral(
 					"QTextEdit {"
 					"  border: 1px solid palette(mid);"
-					"  border-radius: 6px;"
+					"  border-radius: %1px;"
 					"  background: palette(base);"
-					"  padding: 8px;"
-					"}" ) );
+					"  padding: %2px;"
+					"}" ).arg( AQ_Px( 6, this ) ).arg( AQ_Px( 8, this ) ) );
 		}
 	}
 
-	// Cap readable column width so ultrawide screens don't leave desert gaps.
-	const int content_cap = 760;
+	// Cap readable column from font metrics so ultrawide doesn't leave desert gaps.
+	const int content_cap = AQ_Content_Max_Width( this );
 	auto cap_w = [content_cap]( QWidget *w ) {
 		if( w ) w->setMaximumWidth( content_cap );
 	};
@@ -687,20 +700,20 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	if( ui.Memory_Size )
 	{
 		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
-		ui.Memory_Size->setMaximumHeight( 28 );
-		ui.Memory_Size->setMinimumHeight( 22 );
-		ui.Memory_Size->setMaximumWidth( content_cap - 80 );
+		ui.Memory_Size->setMaximumHeight( AQ_Px( 28, this ) );
+		ui.Memory_Size->setMinimumHeight( AQ_Px( 22, this ) );
+		ui.Memory_Size->setMaximumWidth( content_cap - AQ_Px( 80, this ) );
 	}
 	if( ui.CB_RAM_Size )
-		ui.CB_RAM_Size->setMinimumWidth( 110 );
+		ui.CB_RAM_Size->setMinimumWidth( AQ_Px( 110, this ) );
 
 	if( ui.widget && ui.widget->layout() )
 	{
-		ui.widget->layout()->setContentsMargins( 8, 4, 8, 4 );
-		ui.widget->layout()->setSpacing( 4 );
+		ui.widget->layout()->setContentsMargins( AQ_Px( 8, this ), AQ_Px( 4, this ),
+			AQ_Px( 8, this ), AQ_Px( 4, this ) );
+		ui.widget->layout()->setSpacing( AQ_Px( 4, this ) );
 		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.widget->layout() ) )
 		{
-			// Prefer left-packed columns; don't stretch the middle into a void.
 			gl->setColumnStretch( 0, 0 );
 			gl->setColumnStretch( 1, 1 );
 			gl->setColumnStretch( 2, 0 );
@@ -712,7 +725,7 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	{
 		ui.TB_Show_Advanced_Options_Window->setSizePolicy(
 			QSizePolicy::Maximum, QSizePolicy::Fixed );
-		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( 120 );
+		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( AQ_Px( 120, this ) );
 	}
 
 	if( ui.GB_Options )
@@ -1902,9 +1915,14 @@ bool Main_Window::Load_Settings()
 	ui.splitter->restoreState( Settings.value("General_Splitter",
 							   QByteArray("\0\0\0\xff\0\0\0\0\0\0\0\x2\0\0\0\xbc\0\0\x2$\0\0\0\0\x4\x1\0\0\0\x1")).toByteArray() );
 
-	// VM Icons Size
-	ui.Machines_List->setIconSize( QSize( Settings.value("VM_Icons_Size", "48").toInt(),
-								   Settings.value("VM_Icons_Size", "48").toInt()) );
+	// VM Icons Size — user override if set, else host DPI / style metric.
+	{
+		const QSize dpi_icon = AQ_Vm_List_Icon_Size( this );
+		const int sz = Settings.contains( QStringLiteral( "VM_Icons_Size" ) )
+			? Settings.value( QStringLiteral( "VM_Icons_Size" ) ).toInt()
+			: dpi_icon.width();
+		ui.Machines_List->setIconSize( QSize( sz, sz ) );
+	}
 
 	// Load CD Exists Images List
 	VM_Folder = QDir::toNativeSeparators( Settings.value("VM_Directory", "~").toString() );

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -687,31 +687,36 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	}
 
 	// Cap readable column from font metrics so ultrawide doesn't leave desert gaps.
-	// Do NOT cap ui.widget — the two-column Machine form needs room for full labels.
-	const int content_cap = AQ_Content_Max_Width( this );
-	auto cap_w = [content_cap]( QWidget *w ) {
-		if( w ) w->setMaximumWidth( content_cap );
-	};
-	cap_w( ui.GB_Memory );
-	cap_w( ui.GB_Audio );
-	cap_w( ui.GB_Disk_Bus );
-	cap_w( ui.GB_Win11_Lifecycle );
-	cap_w( ui.GB_Intel_MacOS_Settings );
-	cap_w( ui.GB_Options );
-	cap_w( ui.Widget_Use_Network );
-	cap_w( ui.GB_Guest_Display_Mode );
+	// Machine (ui.widget) and every section below must share the full content width.
 	if( ui.Memory_Size )
 	{
 		ui.Memory_Size->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
-		// .ui locked this to 28px — too short with tick labels on HiDPI.
 		ui.Memory_Size->setMaximumHeight( QWIDGETSIZE_MAX );
-		ui.Memory_Size->setMaximumWidth( content_cap - AQ_Px( 80, this ) );
+		ui.Memory_Size->setMaximumWidth( QWIDGETSIZE_MAX );
 	}
 	if( ui.CB_RAM_Size )
 	{
 		ui.CB_RAM_Size->setMinimumWidth( AQ_Px( 110, this ) );
 		ui.CB_RAM_Size->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
 	}
+
+	// Expand EVERY section under Machine across the page (all VMs, not just Win11).
+	auto expand_section = []( QWidget *w ) {
+		if( ! w ) return;
+		w->setMaximumWidth( QWIDGETSIZE_MAX );
+		w->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Preferred );
+		if( QLayout *lay = w->layout() )
+			lay->setSizeConstraint( QLayout::SetDefaultConstraint );
+	};
+	expand_section( ui.widget );
+	expand_section( ui.GB_Memory );
+	expand_section( ui.GB_Audio );
+	expand_section( ui.GB_Disk_Bus );
+	expand_section( ui.GB_Win11_Lifecycle );
+	expand_section( ui.GB_Intel_MacOS_Settings );
+	expand_section( ui.GB_Options );
+	expand_section( ui.Widget_Use_Network );
+	expand_section( ui.GB_Guest_Display_Mode );
 
 	if( ui.widget && ui.widget->layout() )
 	{
@@ -723,7 +728,7 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 			gl->setColumnStretch( 0, 0 );
 			gl->setColumnStretch( 1, 1 );
 			gl->setColumnStretch( 2, 0 );
-			gl->setColumnStretch( 3, 0 );
+			gl->setColumnStretch( 3, 1 );
 			gl->setHorizontalSpacing( AQ_Px( 10, this ) );
 		}
 		// Labels must keep their full text width (don't let combos crush them).
@@ -745,10 +750,10 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		ui.TB_Show_Advanced_Options_Window->setMaximumHeight( QWIDGETSIZE_MAX );
 	}
 
-	// Win11 lifecycle buttons — Preferred width so long labels aren't truncated.
+	// Disk / Win11 action rows — expand controls so they aren't glued left.
 	auto polish_btn = []( QPushButton *b ) {
 		if( ! b ) return;
-		b->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
+		b->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
 		b->setMinimumHeight( 0 );
 		b->setMaximumHeight( QWIDGETSIZE_MAX );
 	};
@@ -757,12 +762,63 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	polish_btn( ui.Button_Win11_Normal );
 	polish_btn( ui.Button_Win11_Repair );
 	polish_btn( ui.Button_VirtIO_Defaults );
+	if( ui.CB_Disk_Interface )
+		ui.CB_Disk_Interface->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+
+	// Trailing spacers in those rows should not steal all remaining width.
+	auto soft_trailing_spacer = []( QLayout *lay ) {
+		if( ! lay ) return;
+		for( int i = 0; i < lay->count(); ++i )
+		{
+			QLayoutItem *it = lay->itemAt( i );
+			if( ! it || ! it->spacerItem() ) continue;
+			if( i == lay->count() - 1 )
+				it->spacerItem()->changeSize( 8, 0, QSizePolicy::Minimum, QSizePolicy::Minimum );
+		}
+	};
+	if( ui.GB_Disk_Bus )
+		soft_trailing_spacer( ui.GB_Disk_Bus->layout() );
+	if( ui.GB_Win11_Lifecycle )
+	{
+		if( QVBoxLayout *vl = qobject_cast<QVBoxLayout *>( ui.GB_Win11_Lifecycle->layout() ) )
+		{
+			for( int i = 0; i < vl->count(); ++i )
+			{
+				if( QLayout *sub = vl->itemAt( i )->layout() )
+					soft_trailing_spacer( sub );
+			}
+		}
+	}
 
 	if( ui.GB_Options )
 	{
 		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.GB_Options->layout() ) )
-			gl->setColumnStretch( 3, 0 );
+		{
+			gl->setColumnStretch( 0, 1 );
+			gl->setColumnStretch( 1, 1 );
+			gl->setColumnStretch( 2, 1 );
+			gl->setColumnStretch( 3, 1 );
+		}
 	}
+
+	// White page behind Machine / Memory / … (avoid grey Window chrome bleed).
+	auto paint_white = []( QWidget *w ) {
+		if( ! w ) return;
+		w->setAutoFillBackground( true );
+		QPalette p = w->palette();
+		p.setColor( QPalette::Window, Qt::white );
+		p.setColor( QPalette::Base, Qt::white );
+		w->setPalette( p );
+	};
+	paint_white( ui.centralwidget );
+	paint_white( ui.Widget_for_Tabs );
+	paint_white( ui.Tabs );
+	paint_white( ui.Tab_General );
+	paint_white( ui.Tab_Info );
+	paint_white( ui.Tab_Media );
+	paint_white( ui.Tab_Display );
+	paint_white( ui.Tab_Network );
+	paint_white( ui.Machines_List );
 
 	auto polish_nested_tabs = []( QTabWidget *tw ) {
 		if( ! tw ) return;

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -207,15 +207,18 @@ Main_Window::Main_Window( QWidget *parent )
 	ui_kvm.setupUi( Accelerator_Options );
 	ui_arch.setupUi( Architecture_Options );
 
-	// Combos were truncating long QEMU machine/video names
+	// Combos: keep the closed field compact; show full names in the popup.
+	// AdjustToContents + MinimumContentsLength(28) stole width from labels
+	// ("Mouse device:" → "Mouse devic").
 	auto fixComboElide = []( QComboBox *cb ) {
 		if( ! cb ) return;
-		cb->setSizeAdjustPolicy( QComboBox::AdjustToContents );
-		cb->setMinimumContentsLength( 28 );
+		cb->setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
+		cb->setMinimumContentsLength( 8 );
+		cb->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
 		if( cb->view() )
 		{
 			cb->view()->setTextElideMode( Qt::ElideNone );
-			cb->view()->setMinimumWidth( 360 );
+			cb->view()->setMinimumWidth( 280 );
 		}
 	};
 	fixComboElide( ui.CB_Computer_Type );
@@ -602,46 +605,39 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	{
 		ui.Tabs->setDocumentMode( false );
 		ui.Tabs->setStyleSheet( QString() );
+		ui.Tabs->setTabPosition( QTabWidget::West );
 		// Rename VM → Machine so the West rail matches the section header language.
 		const int gen_ix = ui.Tabs->indexOf( ui.Tab_General );
 		if( gen_ix >= 0 )
 			ui.Tabs->setTabText( gen_ix, tr( "Machine" ) );
 
-		AQ_Install_West_TabBar( ui.Tabs );
+		// Stock West tab bar — custom AQ_West_TabBar + QSS collapsed the rail to
+		// zero width (stylesheet overrides tabSizeHint). Keep it native + visible.
 		if( QTabBar *bar = ui.Tabs->tabBar() )
 		{
-			const QFontMetrics fm( bar->font() );
-			const int pad_along = qMax( 4, fm.height() / 4 );
-			const int pad_thick = qMax( 2, fm.averageCharWidth() / 2 );
-			const int accent = qMax( 2, fm.averageCharWidth() / 3 );
-			bar->setStyleSheet( QStringLiteral(
-				"QTabBar::tab {"
-				"  font-weight: 500;"
-				"  padding: %1px %2px;"
-				"  margin: 1px 0;"
-				"  border: none;"
-				"  border-right: %3px solid transparent;"
-				"  color: palette(window-text);"
-				"  background: transparent;"
-				"}"
-				"QTabBar::tab:selected {"
-				"  color: palette(highlight);"
-				"  border-right: %3px solid palette(highlight);"
-				"  background: palette(base);"
-				"}"
-				"QTabBar::tab:hover:!selected {"
-				"  background: palette(alternate-base);"
-				"}"
-			).arg( pad_along ).arg( pad_thick ).arg( accent ) );
+			bar->setExpanding( false );
+			bar->setDrawBase( true );
+			bar->setStyleSheet( QString() );
+			QStyle *st = style();
+			const int icon = st ? st->pixelMetric( QStyle::PM_SmallIconSize, nullptr, this ) : 16;
+			bar->setIconSize( QSize( icon, icon ) );
+			// Ensure the rail has a readable thickness without QSS padding tricks.
+			const int thick = qMax( icon + 16, QFontMetrics( bar->font() ).height() + 14 );
+			bar->setMinimumWidth( thick );
+			bar->show();
 		}
+		ui.Tabs->show();
 	}
 
 	// Soft floor so the layout can shrink; Media chip strip no longer locks width.
 	setMinimumSize( 640, 480 );
 	if( ui.splitter )
-		ui.splitter->setChildrenCollapsible( true );
+	{
+		ui.splitter->setChildrenCollapsible( false );
+		ui.splitter->setHandleWidth( qMax( 4, AQ_Px( 4, this ) ) );
+	}
 	if( ui.Machines_List )
-		ui.Machines_List->setMinimumWidth( 140 );
+		ui.Machines_List->setMinimumWidth( 160 );
 
 	// Keep the Machine / Memory / Audio… section headers; tighten the page.
 	if( ui.label )
@@ -691,11 +687,11 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	}
 
 	// Cap readable column from font metrics so ultrawide doesn't leave desert gaps.
+	// Do NOT cap ui.widget — the two-column Machine form needs room for full labels.
 	const int content_cap = AQ_Content_Max_Width( this );
 	auto cap_w = [content_cap]( QWidget *w ) {
 		if( w ) w->setMaximumWidth( content_cap );
 	};
-	cap_w( ui.widget );
 	cap_w( ui.GB_Memory );
 	cap_w( ui.GB_Audio );
 	cap_w( ui.GB_Disk_Bus );
@@ -721,13 +717,22 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	{
 		ui.widget->layout()->setContentsMargins( AQ_Px( 8, this ), AQ_Px( 4, this ),
 			AQ_Px( 8, this ), AQ_Px( 4, this ) );
-		ui.widget->layout()->setSpacing( AQ_Px( 4, this ) );
+		ui.widget->layout()->setSpacing( AQ_Px( 6, this ) );
 		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.widget->layout() ) )
 		{
 			gl->setColumnStretch( 0, 0 );
 			gl->setColumnStretch( 1, 1 );
 			gl->setColumnStretch( 2, 0 );
 			gl->setColumnStretch( 3, 0 );
+			gl->setHorizontalSpacing( AQ_Px( 10, this ) );
+		}
+		// Labels must keep their full text width (don't let combos crush them).
+		const auto labels = ui.widget->findChildren<QLabel *>();
+		for( QLabel *lab : labels )
+		{
+			if( ! lab ) continue;
+			lab->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Preferred );
+			lab->setMinimumWidth( lab->sizeHint().width() );
 		}
 	}
 

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -365,6 +365,7 @@ class Main_Window: public QMainWindow
 		QSystemTrayIcon *Tray_Icon;
 		QAction *Act_Tray_Show;
 		QAction *Act_Tray_Quit;
+		bool Tray_Restore_Maximized;
 
         bool block_VM_changed_signals;
 		QTimer *Auto_Save_Timer;

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -1231,7 +1231,7 @@
                    <property name="maximumSize">
                     <size>
                      <width>16777215</width>
-                     <height>28</height>
+                     <height>16777215</height>
                     </size>
                    </property>
                    <property name="minimum">

--- a/src/Settings_Widget.cpp
+++ b/src/Settings_Widget.cpp
@@ -29,6 +29,7 @@
 #include <QSplitter>
 #include <QFontMetrics>
 #include <QAbstractItemView>
+#include <QSizePolicy>
 
 #include "Settings_Widget.h"
 #include "AQ_UI_Style.h"
@@ -39,6 +40,27 @@
 My_List_Widget::My_List_Widget(QWidget* parent) : QListWidget(parent)
 {
   
+}
+
+QSize My_List_Widget::minimumSizeHint() const
+{
+	// Horizontal Media/Display/Network chip strips must not dictate the
+	// main window's minimum width (sum of all chips was ~1200px on HiDPI).
+	if( flow() == QListView::LeftToRight )
+	{
+		const QFontMetrics fm( font() );
+		const int h = qMax( iconSize().height(), fm.height() ) + 16;
+		const int w = qMax( 160, iconSize().width() + fm.horizontalAdvance( QStringLiteral( "MMMMMMMM" ) ) + 24 );
+		return QSize( w, h );
+	}
+	return QListWidget::minimumSizeHint();
+}
+
+QSize My_List_Widget::sizeHint() const
+{
+	if( flow() == QListView::LeftToRight )
+		return minimumSizeHint();
+	return QListWidget::sizeHint();
 }
 
 void My_List_Widget::wheelEvent(QWheelEvent* e)
@@ -236,7 +258,10 @@ void Settings_Widget::syncGroupIconSizes(QString g)
 
         sw->list->setMinimumHeight( row_h + AQ_Px( 10, sw ) );
         sw->list->setMaximumHeight( row_h + AQ_Px( 14, sw ) );
-        sw->list->setMinimumWidth( qMin( min_total_list_width, AQ_Px( 1200, sw ) ) );
+		// Prefer scroll over locking the main window to the full chip strip width.
+		Q_UNUSED( min_total_list_width );
+		sw->list->setMinimumWidth( 0 );
+		sw->list->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
     }
 }
 

--- a/src/Settings_Widget.cpp
+++ b/src/Settings_Widget.cpp
@@ -27,6 +27,8 @@
 #include <QBoxLayout>
 #include <QApplication>
 #include <QSplitter>
+#include <QFontMetrics>
+#include <QAbstractItemView>
 
 #include "Settings_Widget.h"
 #include "AQ_UI_Style.h"
@@ -73,31 +75,21 @@ Settings_Widget::Settings_Widget(QTabWidget* tab_widget, QBoxLayout::Direction d
 
         list->setFlow( QListView::TopToBottom );
         list->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Preferred );
+        list->setViewMode( QListView::ListMode );
+        list->setMovement( QListView::Static );
+        list->setWrapping( false );
     }
     else
     {
         l = new QBoxLayout(QBoxLayout::TopToBottom);
 
-        //list->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Maximum );
-        //list->setMaximumHeight(60); //FIXME: dynamic would be preferred 
-
-        /*auto app = dynamic_cast<QApplication*>(QApplication::instance());
-        if ( app != nullptr )
-        {
-            QPalette pal = list->palette();
-            pal.setColor(QPalette::Base, app->palette("QWidget").color(QPalette::Midlight));
-            list->setPalette(pal);
-        }*/
-
-        //stack->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Expanding );
-
-
-        list->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Preferred );
-
+        // Icon beside text (like the VM list) — not tiny truncated IconMode captions.
+        list->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
         list->setFlow( QListView::LeftToRight );
-        list->setViewMode( QListView::IconMode );
+        list->setViewMode( QListView::ListMode );
         list->setMovement( QListView::Static );
         list->setWrapping( false );
+        list->setHorizontalScrollMode( QAbstractItemView::ScrollPerPixel );
 
         stack->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Expanding );
     }
@@ -141,11 +133,32 @@ Settings_Widget::Settings_Widget(QTabWidget* tab_widget, QBoxLayout::Direction d
 
     if ( dir != QBoxLayout::TopToBottom )
     {
-        list->setVerticalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
-        list->setHorizontalScrollBarPolicy (Qt::ScrollBarAlwaysOff);
-        list->setSpacing(5);
-        list->setMinimumHeight(list->sizeHintForRow(0)+15);
-        list->setMaximumHeight(list->sizeHintForRow(0)+15);
+        list->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+        list->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+        list->setSpacing( 4 );
+        list->setStyleSheet( QStringLiteral(
+			"QListWidget {"
+			"  background: transparent;"
+			"  border: none;"
+			"  border-bottom: 1px solid palette(mid);"
+			"  padding: 4px 2px;"
+			"  outline: 0;"
+			"}"
+			"QListWidget::item {"
+			"  padding: 6px 12px;"
+			"  margin-right: 4px;"
+			"  border-radius: 6px;"
+			"}"
+			"QListWidget::item:selected {"
+			"  background: palette(highlight);"
+			"  color: palette(highlighted-text);"
+			"}"
+			"QListWidget::item:hover:!selected {"
+			"  background: palette(alternate-base);"
+			"}" ) );
+        // Height fits icon + single line of text side-by-side.
+        list->setMinimumHeight( 44 );
+        list->setMaximumHeight( 52 );
     }
     else
     {
@@ -180,86 +193,44 @@ void Settings_Widget::syncGroupIconSizes(QString g)
     QList<Settings_Widget*> list = groups[g];
 
     QList<int> max_width;
+    const int row_h = 40;
 
-    int max_list_height = 0;
-
-    //first find max_width for each index
+    // Measure full text + icon so captions are never truncated.
     for( int i = 0; i < list.count(); i++ )
     {
         auto sw = list.at(i);
 
         for ( int j = 0; j < sw->list->count(); j++ )
         {
-            int w = sw->list->item(j)->sizeHint().width();
+            QListWidgetItem *it = sw->list->item(j);
+            const int icon_w = sw->list->iconSize().width() > 0
+                ? sw->list->iconSize().width() + 10 : 28;
+            QFontMetrics fm( sw->list->font() );
+            const int text_w = fm.horizontalAdvance( it->text() ) + 24;
+            const int w = icon_w + text_w;
 
-            int list_h = sw->list->minimumSizeHint().height();
-
-            if ( list_h > 0 )
-            {
-                if ( max_list_height == 0 )
-                    max_list_height = list_h;
-                else if ( max_list_height > list_h )
-                    max_list_height = list_h;
-            }
-
-            if ( w == -1 ) // which will always be the case :-(
-            {
-                QString t = sw->list->item(j)->text();
-                QLabel l(t);
-
-                w = l.sizeHint().width() + 20;
-            }
-
-            
             if ( max_width.count() < j + 1 )
-            {
-                //index number not in list
-                max_width.append( w);
-            }
-            else
-            {
-                //index number is in list
-                if ( w > max_width.at(j) )
-                    max_width.replace(j, w);
-            }
-            
+                max_width.append( w );
+            else if ( w > max_width.at(j) )
+                max_width.replace( j, w );
         }
     }
 
-    //minimum total list width
-    int min_total_list_width = 15;
+    int min_total_list_width = 20;
     for ( int j = 0; j < max_width.count(); j++ )
-    {
-        //int h = sw->list->item(j)->sizeHint().height();
-        min_total_list_width += max_width.at(j) +5;
-    }
+        min_total_list_width += max_width.at(j) + 8;
 
-    if ( max_list_height > 0  && max_list_height <= 58 )
-    {
-        max_list_height = 68;
-    }
-
-    //then apply max_width to all
     for( int i = 0; i < list.count(); i++ )
     {
         auto sw = list.at(i);
 
         for ( int j = 0; j < sw->list->count(); j++ )
-        {
-            //int h = sw->list->item(j)->sizeHint().height();
-            sw->list->item(j)->setSizeHint(QSize(max_width.at(j),58));
-        }
+            sw->list->item(j)->setSizeHint( QSize( max_width.at(j), row_h ) );
 
-        if ( max_list_height > 0 )
-        {
-            sw->list->setMinimumHeight(max_list_height);
-            sw->list->setMaximumHeight(max_list_height);
-        }
-        sw->list->setMinimumWidth(min_total_list_width);
-        sw->stack->setMinimumWidth(min_total_list_width);
+        sw->list->setMinimumHeight( row_h + 12 );
+        sw->list->setMaximumHeight( row_h + 16 );
+        sw->list->setMinimumWidth( qMin( min_total_list_width, 1200 ) );
     }
-
-    
 }
 
 void Settings_Widget::setIconSize(QSize s)

--- a/src/Settings_Widget.cpp
+++ b/src/Settings_Widget.cpp
@@ -135,19 +135,21 @@ Settings_Widget::Settings_Widget(QTabWidget* tab_widget, QBoxLayout::Direction d
     {
         list->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
         list->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
-        list->setSpacing( 4 );
+        list->setSpacing( AQ_Px( 4, this ) );
+        const int pad = AQ_Px( 6, this );
+        const int rad = AQ_Px( 6, this );
         list->setStyleSheet( QStringLiteral(
 			"QListWidget {"
 			"  background: transparent;"
 			"  border: none;"
 			"  border-bottom: 1px solid palette(mid);"
-			"  padding: 4px 2px;"
+			"  padding: %1px %2px;"
 			"  outline: 0;"
 			"}"
 			"QListWidget::item {"
-			"  padding: 6px 12px;"
-			"  margin-right: 4px;"
-			"  border-radius: 6px;"
+			"  padding: %1px %3px;"
+			"  margin-right: %2px;"
+			"  border-radius: %4px;"
 			"}"
 			"QListWidget::item:selected {"
 			"  background: palette(highlight);"
@@ -155,10 +157,11 @@ Settings_Widget::Settings_Widget(QTabWidget* tab_widget, QBoxLayout::Direction d
 			"}"
 			"QListWidget::item:hover:!selected {"
 			"  background: palette(alternate-base);"
-			"}" ) );
-        // Height fits icon + single line of text side-by-side.
-        list->setMinimumHeight( 44 );
-        list->setMaximumHeight( 52 );
+			"}" ).arg( pad ).arg( AQ_Px( 2, this ) ).arg( AQ_Px( 10, this ) ).arg( rad ) );
+        const int row = qMax( AQ_Nav_Icon_Size( this ).height(), QFontMetrics( list->font() ).height() )
+			+ AQ_Px( 12, this );
+        list->setMinimumHeight( row );
+        list->setMaximumHeight( row + AQ_Px( 8, this ) );
     }
     else
     {
@@ -168,7 +171,7 @@ Settings_Widget::Settings_Widget(QTabWidget* tab_widget, QBoxLayout::Direction d
         list->setUniformItemSizes( true );
     }
 
-    AQ_Cap_Content_Width( this, 980 );
+    AQ_Cap_Content_Width( this );
 }
 
 void Settings_Widget::setCurrentIndex(int i)
@@ -193,43 +196,47 @@ void Settings_Widget::syncGroupIconSizes(QString g)
     QList<Settings_Widget*> list = groups[g];
 
     QList<int> max_width;
-    const int row_h = 40;
 
-    // Measure full text + icon so captions are never truncated.
     for( int i = 0; i < list.count(); i++ )
     {
         auto sw = list.at(i);
+        const int row_h = qMax( sw->list->iconSize().height(),
+			QFontMetrics( sw->list->font() ).height() ) + AQ_Px( 12, sw );
 
         for ( int j = 0; j < sw->list->count(); j++ )
         {
             QListWidgetItem *it = sw->list->item(j);
             const int icon_w = sw->list->iconSize().width() > 0
-                ? sw->list->iconSize().width() + 10 : 28;
+                ? sw->list->iconSize().width() + AQ_Px( 10, sw ) : AQ_Px( 28, sw );
             QFontMetrics fm( sw->list->font() );
-            const int text_w = fm.horizontalAdvance( it->text() ) + 24;
+            const int text_w = fm.horizontalAdvance( it->text() ) + AQ_Px( 24, sw );
             const int w = icon_w + text_w;
 
             if ( max_width.count() < j + 1 )
                 max_width.append( w );
             else if ( w > max_width.at(j) )
                 max_width.replace( j, w );
+
+            Q_UNUSED( row_h );
         }
     }
 
-    int min_total_list_width = 20;
+    int min_total_list_width = AQ_Px( 20 );
     for ( int j = 0; j < max_width.count(); j++ )
-        min_total_list_width += max_width.at(j) + 8;
+        min_total_list_width += max_width.at(j) + AQ_Px( 8 );
 
     for( int i = 0; i < list.count(); i++ )
     {
         auto sw = list.at(i);
+        const int row_h = qMax( sw->list->iconSize().height(),
+			QFontMetrics( sw->list->font() ).height() ) + AQ_Px( 12, sw );
 
         for ( int j = 0; j < sw->list->count(); j++ )
             sw->list->item(j)->setSizeHint( QSize( max_width.at(j), row_h ) );
 
-        sw->list->setMinimumHeight( row_h + 12 );
-        sw->list->setMaximumHeight( row_h + 16 );
-        sw->list->setMinimumWidth( qMin( min_total_list_width, 1200 ) );
+        sw->list->setMinimumHeight( row_h + AQ_Px( 10, sw ) );
+        sw->list->setMaximumHeight( row_h + AQ_Px( 14, sw ) );
+        sw->list->setMinimumWidth( qMin( min_total_list_width, AQ_Px( 1200, sw ) ) );
     }
 }
 

--- a/src/Settings_Widget.h
+++ b/src/Settings_Widget.h
@@ -41,6 +41,8 @@ class My_List_Widget : public QListWidget
     
     public:
         My_List_Widget(QWidget* parent);
+		QSize minimumSizeHint() const override;
+		QSize sizeHint() const override;
 
     protected:
         virtual void wheelEvent(QWheelEvent* e);

--- a/src/VM_Session_Widget.cpp
+++ b/src/VM_Session_Widget.cpp
@@ -23,6 +23,8 @@
 #include <QMenu>
 #include <QToolButton>
 #include <QThread>
+#include <QFontMetrics>
+#include <QLabel>
 
 #include "VM.h"
 #include "QMP_Client.h"
@@ -32,31 +34,45 @@
 #include "Utils.h"
 #include "System_Info.h"
 #include "Serial_Console_Window.h"
+#include "AQ_UI_Style.h"
 
 #ifdef VNC_DISPLAY
 #include "Embedded_Display/Machine_View.h"
 #endif
 
-static const int kHotZoneHeight = 48;
 static const int kHotZoneDwellMs = 1000; // hold top-center ~1s to reveal (Chrome-like)
 static const int kToolbarHideMs = 700;   // hide soon after leaving the toolbar
 static const int kDrivePollMs = 200;
 
-static const char *kToolbarStyle =
-	"QToolBar { background: #2d2d30; border: none; border-bottom: 1px solid #1a1a1a; spacing: 4px; padding: 4px; }"
-	"QToolButton { color: #eee; padding: 4px 6px; border-radius: 3px; }"
-	"QToolButton:hover { background: rgba(255,255,255,30); }"
-	"QToolButton:pressed { background: rgba(255,255,255,50); }";
+static int AQ_Hot_Zone_Height( const QWidget *w )
+{
+	return qMax( AQ_Px( 40, w ), AQ_Toolbar_Icon_Size( w ).height() + AQ_Px( 20, w ) );
+}
 
-static const char *kLightOff =
-	"QLabel { min-width: 12px; max-width: 12px; min-height: 12px; max-height: 12px;"
-	" border-radius: 6px; background: #3a3a3a; border: 1px solid #222; margin: 0 3px; }";
-static const char *kLightLoaded =
-	"QLabel { min-width: 12px; max-width: 12px; min-height: 12px; max-height: 12px;"
-	" border-radius: 6px; background: #1a6b2a; border: 1px solid #0d3d18; margin: 0 3px; }";
-static const char *kLightActive =
-	"QLabel { min-width: 12px; max-width: 12px; min-height: 12px; max-height: 12px;"
-	" border-radius: 6px; background: #5dff6a; border: 1px solid #2a8a35; margin: 0 3px; }";
+static QString AQ_Toolbar_Style( const QWidget *w )
+{
+	const int pad = AQ_Px( 4, w );
+	const int btn_pad_h = AQ_Px( 6, w );
+	const int rad = AQ_Px( 3, w );
+	return QStringLiteral(
+		"QToolBar { background: #2d2d30; border: none; border-bottom: 1px solid #1a1a1a;"
+		" spacing: %1px; padding: %1px; }"
+		"QToolButton { color: #eee; padding: %1px %2px; border-radius: %3px; }"
+		"QToolButton:hover { background: rgba(255,255,255,30); }"
+		"QToolButton:pressed { background: rgba(255,255,255,50); }"
+	).arg( pad ).arg( btn_pad_h ).arg( rad );
+}
+
+static QString AQ_Drive_Light_Style( const QWidget *w, const QString &bg, const QString &border )
+{
+	const int d = qMax( AQ_Px( 14, w ), QFontMetrics( w ? w->font() : QApplication::font() ).height() / 2 );
+	const int rad = d / 2;
+	const int margin = AQ_Px( 3, w );
+	return QStringLiteral(
+		"QLabel { min-width: %1px; max-width: %1px; min-height: %1px; max-height: %1px;"
+		" border-radius: %2px; background: %3; border: 1px solid %4; margin: 0 %5px; }"
+	).arg( d ).arg( rad ).arg( bg ).arg( border ).arg( margin );
+}
 
 VM_Session_Widget::VM_Session_Widget( QWidget *parent )
 	: QWidget( parent )
@@ -158,9 +174,9 @@ void VM_Session_Widget::Build_Toolbar()
 	Toolbar = new QToolBar( this );
 	Toolbar->setMovable( false );
 	Toolbar->setFloatable( false );
-	Toolbar->setIconSize( QSize( 22, 22 ) );
+	Toolbar->setIconSize( AQ_Toolbar_Icon_Size( this ) );
 	Toolbar->setToolButtonStyle( Qt::ToolButtonIconOnly );
-	Toolbar->setStyleSheet( kToolbarStyle );
+	Toolbar->setStyleSheet( AQ_Toolbar_Style( this ) );
 
 	// Runtime power controls (replaces left Tool_Bar_VM_Control in session mode)
 	Act_Pause = Add_Toolbar_Action( QIcon( ":/pause.png" ), tr( "Pause / Resume" ), SLOT(On_Pause()) );
@@ -216,7 +232,8 @@ void VM_Session_Widget::Build_Toolbar()
 	Toolbar->addWidget( spacer );
 
 	QLabel *lights_label = new QLabel( tr( "Drives" ), Toolbar );
-	lights_label->setStyleSheet( "QLabel { color: #888; font-size: 10px; margin-right: 2px; }" );
+	lights_label->setStyleSheet( QStringLiteral(
+		"QLabel { color: #888; margin-right: %1px; }" ).arg( AQ_Px( 2, this ) ) );
 	Toolbar->addWidget( lights_label );
 
 	Light_FD0 = Make_Drive_Light( "A" );
@@ -232,7 +249,7 @@ void VM_Session_Widget::Build_Toolbar()
 QLabel *VM_Session_Widget::Make_Drive_Light( const QString &letter )
 {
 	QLabel *l = new QLabel( Toolbar );
-	l->setStyleSheet( kLightOff );
+	l->setStyleSheet( AQ_Drive_Light_Style( this, QStringLiteral( "#3a3a3a" ), QStringLiteral( "#222" ) ) );
 	l->setToolTip( letter );
 	l->setAlignment( Qt::AlignCenter );
 	return l;
@@ -282,7 +299,8 @@ void VM_Session_Widget::Show_Fullscreen_Toolbar()
 	Toolbar_Show_Timer->stop();
 	Toolbar_Hide_Timer->stop();
 
-	const int th = qMax( Toolbar->sizeHint().height(), 36 );
+	const int th = qMax( Toolbar->sizeHint().height(),
+		AQ_Toolbar_Icon_Size( this ).height() + AQ_Px( 16, this ) );
 	QRect start( 0, -th, width(), th );
 	QRect end( 0, 0, width(), th );
 
@@ -323,7 +341,7 @@ void VM_Session_Widget::Hide_Fullscreen_Toolbar()
 bool VM_Session_Widget::Hot_Zone_Contains_Global( const QPoint &global_pos ) const
 {
 	const QPoint local = mapFromGlobal( global_pos );
-	if( local.y() < 0 || local.y() > kHotZoneHeight )
+	if( local.y() < 0 || local.y() > AQ_Hot_Zone_Height( this ) )
 		return false;
 	// Top-center band (middle third), like Chrome's F11 exit chip.
 	const int cx = width() / 2;
@@ -1086,11 +1104,11 @@ void VM_Session_Widget::Set_Drive_Light( QLabel *light, bool loaded, bool active
 		return;
 	light->setToolTip( tip );
 	if( active && loaded )
-		light->setStyleSheet( kLightActive );
+		light->setStyleSheet( AQ_Drive_Light_Style( this, QStringLiteral( "#5dff6a" ), QStringLiteral( "#2a8a35" ) ) );
 	else if( loaded )
-		light->setStyleSheet( kLightLoaded );
+		light->setStyleSheet( AQ_Drive_Light_Style( this, QStringLiteral( "#1a6b2a" ), QStringLiteral( "#0d3d18" ) ) );
 	else
-		light->setStyleSheet( kLightOff );
+		light->setStyleSheet( AQ_Drive_Light_Style( this, QStringLiteral( "#3a3a3a" ), QStringLiteral( "#222" ) ) );
 }
 
 void VM_Session_Widget::Update_Media_Actions()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -650,5 +650,6 @@ void AQEMU_Main::vm_dir_exists_or_create()
 
 int main( int argc, char *argv[] )
 {
-    return AQEMU_Main().main(argc,argv);
+	AQ_Enable_High_Dpi();
+	return AQEMU_Main().main(argc,argv);
 }


### PR DESCRIPTION
## Summary
- High-DPI without double-scaling; form controls stay native (no clipped combo/button text)
- West Info/Machine/Media/Display/Network rail restored and visible
- Memory / Audio / Disk / Options / Win11 rows expand full width like Machine (all VMs)
- White main chrome instead of grey Window palette
- Window resize / maximize / minimize-to-tray geometry fixes

## Test plan
- [ ] Machine page: sections below Machine span the content width (not left-bunched)
- [ ] West tab rail visible; switch Info/Machine/Media/Display/Network
- [ ] Combo/button text fully visible (not mid-glyph clipped)
- [ ] Background is white; resize and maximize work
- [ ] Minimize-to-tray (Advanced Settings) restores correctly