### PR TITLE
Spread Machine section fields full width

### DIFF
--- a/packaging/README-WINDOWS.txt
+++ b/packaging/README-WINDOWS.txt
@@ -1,7 +1,7 @@
 AQEMU 1.0.0 — Windows portable (x64)
 ====================================
 
-Updated build: 2026-07-25 (wizard + virt-manager-inspired UX refresh).
+Updated build: 2026-07-25 (Machine section full-width + UI polish).
 
 Please file bugs:
   https://github.com/chronic8000/aqemu/issues
@@ -15,11 +15,11 @@ This zip includes:
   - OpenPartitionDxe.efi (Intel macOS OpenCore prep)
   - qemu_machine_catalog.json (New VM wizard machine list)
 
-What's new in this zip (vs the first 1.0.0 drop):
-  - New VM wizard: Platform / Architecture paths, guest-aware devices
-  - Import disk, ISO OS-guess, URL / kernel+initrd network install
-  - File → Storage Browser…, File → Remote Hosts…
-  - Serial console + live migrate URI dialog in the session toolbar
+What's new in this zip:
+  - Machine Name/Accelerator/… fields span full width (same as Memory/Audio/…)
+  - White main chrome; West Info/Machine/Media/Display/Network rail
+  - No clipped combo/button text on HiDPI
+  - Resize / maximize / minimize-to-tray geometry fixes
 
 Notes:
   - GitHub Release zips are NOT auto-updated. Grab a newer zip when we publish one.

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -56,6 +56,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QLineEdit>
 #include <QClipboard>
 #include <QScrollArea>
 #include <QFrame>
@@ -725,19 +726,51 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		ui.widget->layout()->setSpacing( AQ_Px( 6, this ) );
 		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.widget->layout() ) )
 		{
-			gl->setColumnStretch( 0, 0 );
-			gl->setColumnStretch( 1, 1 );
-			gl->setColumnStretch( 2, 0 );
-			gl->setColumnStretch( 3, 1 );
-			gl->setHorizontalSpacing( AQ_Px( 10, this ) );
+			// gridLayout_12: 0=left fields, 1=5px gap, 2=right fields, 3=trailing spacer.
+			// Stretch field columns — stretching col 1/3 left Machine bunched left.
+			gl->setColumnStretch( 0, 1 );
+			gl->setColumnStretch( 1, 0 );
+			gl->setColumnStretch( 2, 1 );
+			gl->setColumnStretch( 3, 0 );
+			gl->setHorizontalSpacing( AQ_Px( 16, this ) );
 		}
-		// Labels must keep their full text width (don't let combos crush them).
+		if( ui.Widget_for_General_Tab )
+		{
+			ui.Widget_for_General_Tab->setMaximumWidth( AQ_Px( 12, this ) );
+			ui.Widget_for_General_Tab->setMinimumWidth( AQ_Px( 8, this ) );
+			ui.Widget_for_General_Tab->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Preferred );
+		}
+		// Nested left/right grids: labels fixed, value columns expand.
+		const auto nested = ui.widget->findChildren<QGridLayout *>();
+		for( QGridLayout *sub : nested )
+		{
+			if( ! sub || sub == ui.widget->layout() ) continue;
+			sub->setColumnStretch( 0, 0 );
+			sub->setColumnStretch( 1, 1 );
+			if( sub->columnCount() > 2 )
+				sub->setColumnStretch( 2, 0 );
+			sub->setHorizontalSpacing( AQ_Px( 8, this ) );
+		}
 		const auto labels = ui.widget->findChildren<QLabel *>();
 		for( QLabel *lab : labels )
 		{
 			if( ! lab ) continue;
 			lab->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Preferred );
 			lab->setMinimumWidth( lab->sizeHint().width() );
+		}
+		const auto combos = ui.widget->findChildren<QComboBox *>();
+		for( QComboBox *cb : combos )
+		{
+			if( ! cb ) continue;
+			cb->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+			cb->setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
+			cb->setMinimumContentsLength( 6 );
+		}
+		const auto edits = ui.widget->findChildren<QLineEdit *>();
+		for( QLineEdit *le : edits )
+		{
+			if( ! le ) continue;
+			le->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Machine Name / Accelerator / Architecture / … rows now expand across the content pane like Memory, Audio, Disk, and Options
- Root cause: column stretch was applied to the 5px gap spacer instead of the two field columns

## Test plan
- [ ] Open any VM → Machine tab
- [ ] Left and right Machine columns fill the width (no large empty band on the right)
- [ ] Long combo texts (Machine type, Mouse device, USB controller) are readable
- [ ] Memory / Audio / Win11 / Options still full-width