### PR TITLE
Fix Win11 ARM boot, settings persistence, and Machine tab layout

### DIFF
--- a/src/AQ_UI_Style.cpp
+++ b/src/AQ_UI_Style.cpp
@@ -335,44 +335,43 @@ void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name )
 	QWidget *inner = new QWidget();
 	inner->setObjectName( inner_object_name.isEmpty()
 		? QStringLiteral( "AQ_Tab_Inner" ) : inner_object_name );
+	// Minimum vertical: grow with content so the scroll area scrolls instead of crushing.
+	inner->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Minimum );
+	inner->setAutoFillBackground( true );
 
 	QVBoxLayout *innerLay = new QVBoxLayout( inner );
 	innerLay->setContentsMargins( 10, 8, 14, 12 );
 	innerLay->setSpacing( 6 );
+	innerLay->setSizeConstraint( QLayout::SetMinimumSize );
 
-	if( QVBoxLayout *vold = qobject_cast<QVBoxLayout*>( old ) )
+	// Drain the old layout. Must use addWidget/addLayout — addItem() does NOT
+	// reparent widgets, which left them as invisible siblings of the scroll area
+	// (blank Machine tab on Qt 5 West tabs).
+	QList<QLayoutItem *> items;
+	while( old->count() > 0 )
+		items.append( old->takeAt( 0 ) );
+	delete old;
+
+	for( QLayoutItem *it : items )
 	{
-		while( vold->count() > 0 )
+		if( ! it )
+			continue;
+		if( QWidget *w = it->widget() )
 		{
-			QLayoutItem *it = vold->takeAt( 0 );
-			if( ! it )
-				continue;
+			innerLay->addWidget( w ); // reparents onto inner
+			delete it;
+		}
+		else if( QLayout *sub = it->layout() )
+		{
+			innerLay->addLayout( sub );
+			delete it;
+		}
+		else
+		{
 			if( QSpacerItem *sp = it->spacerItem() )
 				sp->changeSize( 20, 6, QSizePolicy::Minimum, QSizePolicy::Fixed );
 			innerLay->addItem( it );
 		}
-		delete vold;
-	}
-	else if( QGridLayout *gold = qobject_cast<QGridLayout*>( old ) )
-	{
-		// Lift the single primary child (usually a nested tab widget) into the scroll page.
-		QList<QLayoutItem*> items;
-		while( gold->count() > 0 )
-			items.append( gold->takeAt( 0 ) );
-		delete gold;
-		for( QLayoutItem *it : items )
-		{
-			if( ! it )
-				continue;
-			if( QSpacerItem *sp = it->spacerItem() )
-				sp->changeSize( 20, 6, QSizePolicy::Minimum, QSizePolicy::Fixed );
-			innerLay->addItem( it );
-		}
-	}
-	else
-	{
-		delete inner;
-		return;
 	}
 
 	innerLay->addStretch( 1 );
@@ -382,6 +381,7 @@ void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name )
 	scroll->setWidgetResizable( true );
 	scroll->setFrameShape( QFrame::NoFrame );
 	scroll->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+	scroll->setVerticalScrollBarPolicy( Qt::ScrollBarAsNeeded );
 	scroll->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
 	scroll->setWidget( inner );
 
@@ -389,6 +389,9 @@ void AQ_Make_Tab_Scrollable( QWidget *tab, const QString &inner_object_name )
 	outer->setContentsMargins( 0, 0, 0, 0 );
 	outer->setSpacing( 0 );
 	outer->addWidget( scroll, 1 );
+
+	inner->adjustSize();
+	inner->show();
 }
 
 void AQ_Cap_Content_Width( QWidget *root, int max_width )

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -56,6 +56,10 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QToolButton>
+#include <QAbstractButton>
+#include <QStyle>
+#include <QFontMetrics>
 #include <QLineEdit>
 #include <QClipboard>
 #include <QScrollArea>
@@ -133,7 +137,7 @@ Main_Window::Main_Window( QWidget *parent )
 
 	Auto_Save_Timer = new QTimer( this );
 	Auto_Save_Timer->setSingleShot( true );
-	Auto_Save_Timer->setInterval( 400 );
+	Auto_Save_Timer->setInterval( 150 );
 	connect( Auto_Save_Timer, SIGNAL(timeout()), this, SLOT(on_Button_Apply_clicked()) );
 
 	// Coalesce rapid VM-list clicks so we don't rebuild the whole form per click.
@@ -601,7 +605,6 @@ Virtual_Machine *Main_Window::Get_Current_VM()
 
 void Main_Window::Polish_Settings_Tabs_Layout()
 {
-	// Do NOT wrap West-tab pages in QScrollArea — that blanks the pane on Qt 5.
 	if( ui.Tabs )
 	{
 		ui.Tabs->setDocumentMode( false );
@@ -701,13 +704,13 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		ui.CB_RAM_Size->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
 	}
 
-	// Expand EVERY section under Machine across the page (all VMs, not just Win11).
+	// Expand horizontally; never shrink vertically below content (scroll instead).
 	auto expand_section = []( QWidget *w ) {
 		if( ! w ) return;
 		w->setMaximumWidth( QWIDGETSIZE_MAX );
-		w->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Preferred );
+		w->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
 		if( QLayout *lay = w->layout() )
-			lay->setSizeConstraint( QLayout::SetDefaultConstraint );
+			lay->setSizeConstraint( QLayout::SetMinimumSize );
 	};
 	expand_section( ui.widget );
 	expand_section( ui.GB_Memory );
@@ -779,15 +782,19 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		ui.TB_Show_Advanced_Options_Window->setSizePolicy(
 			QSizePolicy::Maximum, QSizePolicy::Fixed );
 		ui.TB_Show_Advanced_Options_Window->setMinimumWidth( 0 );
-		ui.TB_Show_Advanced_Options_Window->setMinimumHeight( 0 );
+		const int btn_h = style()->pixelMetric( QStyle::PM_ButtonDefaultIndicator, nullptr, this );
+		Q_UNUSED( btn_h );
+		ui.TB_Show_Advanced_Options_Window->setMinimumHeight(
+			qMax( AQ_Px( 24, this ), fontMetrics().height() + AQ_Px( 8, this ) ) );
 		ui.TB_Show_Advanced_Options_Window->setMaximumHeight( QWIDGETSIZE_MAX );
 	}
 
 	// Disk / Win11 action rows — expand controls so they aren't glued left.
-	auto polish_btn = []( QPushButton *b ) {
+	const int ctrl_h = qMax( AQ_Px( 28, this ), fontMetrics().height() + AQ_Px( 10, this ) );
+	auto polish_btn = [ctrl_h]( QPushButton *b ) {
 		if( ! b ) return;
 		b->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
-		b->setMinimumHeight( 0 );
+		b->setMinimumHeight( ctrl_h );
 		b->setMaximumHeight( QWIDGETSIZE_MAX );
 	};
 	polish_btn( ui.Button_Win11_Install );
@@ -797,6 +804,20 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 	polish_btn( ui.Button_VirtIO_Defaults );
 	if( ui.CB_Disk_Interface )
 		ui.CB_Disk_Interface->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+
+	// Never allow checkboxes / radios on the Machine page to squash into unreadability.
+	if( ui.Tab_General )
+	{
+		const auto boxes = ui.Tab_General->findChildren<QAbstractButton *>();
+		for( QAbstractButton *b : boxes )
+		{
+			if( ! b ) continue;
+			if( qobject_cast<QPushButton *>( b ) && ! qobject_cast<QToolButton *>( b ) )
+				continue; // already polished above / size policy set
+			b->setSizePolicy( b->sizePolicy().horizontalPolicy(), QSizePolicy::Fixed );
+			b->setMinimumHeight( qMax( b->minimumHeight(), fontMetrics().height() + AQ_Px( 4, this ) ) );
+		}
+	}
 
 	// Trailing spacers in those rows should not steal all remaining width.
 	auto soft_trailing_spacer = []( QLayout *lay ) {
@@ -867,6 +888,10 @@ void Main_Window::Polish_Settings_Tabs_Layout()
 		ui.Machines_List->setSpacing( 2 );
 		ui.Machines_List->setUniformItemSizes( true );
 	}
+
+	// Scroll when the Machine page is taller than the window — never crush controls.
+	if( ui.Tab_General )
+		AQ_Make_Tab_Scrollable( ui.Tab_General, QStringLiteral( "AQ_Machine_Tab_Inner" ) );
 }
 
 void Main_Window::Connect_Signals()
@@ -899,9 +924,9 @@ void Main_Window::Connect_Signals()
 	connect( ui.CB_CPU_Type_Main, SIGNAL(currentIndexChanged(int)),
 			 this, SLOT(on_CB_CPU_Type_Main_currentIndexChanged(int)) );
 
-	connect( ui.CB_Boot_Priority, SIGNAL(currentIndexChanged(int)),
-			 this, SLOT(VM_Changed()) );
-
+	// Boot priority: only CB_Boot_Priority_currentIndexChanged — it updates
+	// Boot_Order_List then calls VM_Changed(). A prior VM_Changed() here ran
+	// with a stale list and could cancel a pending auto-save.
 	connect( ui.CB_Boot_Priority, SIGNAL(currentIndexChanged(int)),
 			 this, SLOT(CB_Boot_Priority_currentIndexChanged(int)) );
 
@@ -1516,6 +1541,7 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 		tmp_vm->Set_Keyboard_Layout( ui.CB_Keyboard_Layout->currentText() );
 
 	// Boot Priority
+	Boot_Order_List = VM::Expand_Boot_Order_List( Boot_Order_List );
 	tmp_vm->Set_Boot_Order_List( Boot_Order_List );
 	tmp_vm->Set_Show_Boot_Menu( Show_Boot_Menu );
 
@@ -2409,9 +2435,9 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	Apply_Mouse_Settings_To_Ui( tmp_vm );
 	Update_Mouse_Options_Enabled();
 
-	// Boot
-	Set_Boot_Order( tmp_vm->Get_Boot_Order_List() );
-	Boot_Order_List = tmp_vm->Get_Boot_Order_List();
+	// Boot — expand truncated lists so the combo can select any device type
+	Boot_Order_List = VM::Expand_Boot_Order_List( tmp_vm->Get_Boot_Order_List() );
+	Set_Boot_Order( Boot_Order_List );
 	Show_Boot_Menu = tmp_vm->Get_Show_Boot_Menu();
 
 	// Audio Cards
@@ -3872,7 +3898,13 @@ void Main_Window::VM_Changed()
     {
         auto tmp_vm = new Virtual_Machine();
 
-        Create_VM_From_Ui(tmp_vm,old_vm,false);
+        // Incomplete Create_VM_From_Ui must not mark dirty / schedule save —
+        // that would race Apply with a half-built VM and drop edits.
+        if( ! Create_VM_From_Ui( tmp_vm, old_vm, false ) )
+        {
+            delete tmp_vm;
+            return;
+        }
 
         bool test = ( *old_vm != *tmp_vm );
 
@@ -5899,6 +5931,7 @@ void Main_Window::Enforce_Disk_Bus_Honesty()
 	auto *model = qobject_cast<QStandardItemModel *>( ui.CB_Disk_Interface->model() );
 	ui.CB_Disk_Interface->blockSignals( true );
 
+	const int prev_index = ui.CB_Disk_Interface->currentIndex();
 	int first_enabled = -1;
 	for( int i = 0; i < ui.CB_Disk_Interface->count(); ++i )
 	{
@@ -5943,7 +5976,13 @@ void Main_Window::Enforce_Disk_Bus_Honesty()
 			.arg( computer, machine.isEmpty() ? tr( "(default)" ) : machine ) );
 	}
 
+	const int new_index = ui.CB_Disk_Interface->currentIndex();
 	ui.CB_Disk_Interface->blockSignals( false );
+
+	// Persist AHCI→VirtIO (etc.) clamps — previously the combo was fixed in the UI
+	// only, so Start kept emitting ich9-ahci on aarch64.
+	if( new_index != prev_index && ! block_VM_changed_signals )
+		VM_Changed();
 }
 
 void Main_Window::Update_Accelerator_Options()
@@ -6036,12 +6075,24 @@ void Main_Window::Apply_Emulator( int mode )
 
 void Main_Window::CB_Boot_Priority_currentIndexChanged( int index )
 {
-	// Clear old string
-	if( ui.CB_Boot_Priority->count() >= 5 ) ui.CB_Boot_Priority->removeItem( 5 );
+	// Custom multi-boot row (index 5+) already matches Boot_Order_List — do not
+	// strip it or map through the single-device enable logic (that wiped the list
+	// to all-disabled → UI "None" and UEFI shell).
+	if( index >= 5 )
+	{
+		VM_Changed();
+		return;
+	}
+
+	// Drop the dynamic multi-boot label only (base items are indices 0–4).
+	while( ui.CB_Boot_Priority->count() > 5 )
+		ui.CB_Boot_Priority->removeItem( 5 );
 
 	VM::Boot_Device bootDev;
 
-	switch( ui.CB_Boot_Priority->currentIndex() )
+	// Use the signal's index — not currentIndex() after removeItem, which can
+	// jump to "None" when the removed row was selected.
+	switch( index )
 	{
 		case 0:
 			bootDev = VM::Boot_From_FDA;
@@ -6064,19 +6115,16 @@ void Main_Window::CB_Boot_Priority_currentIndexChanged( int index )
 			break;
 
 		default:
-			AQWarning( "void Main_Window::on_CB_Boot_Priority_currentIndexChanged( int index )",
+			AQWarning( "void Main_Window::CB_Boot_Priority_currentIndexChanged( int index )",
 					   "Use Default Boot Device: CD-ROM" );
 			bootDev = VM::Boot_From_CDROM;
 			break;
 	}
 
-	for( int bx = 0; bx < Boot_Order_List.count(); bx++ )
-	{
-		if( Boot_Order_List[bx].Type == bootDev ) Boot_Order_List[ bx ].Enabled = true;
-		else Boot_Order_List[ bx ].Enabled = false;
-	}
+	// Expand truncated lists (Win11 lifecycle / wizard) so the chosen type exists.
+	VM::Set_Boot_Order_Single( Boot_Order_List, bootDev );
 
-    VM_Changed();
+	VM_Changed();
 }
 
 void Main_Window::Set_Boot_Order( const QList<VM::Boot_Order> &list )
@@ -6084,10 +6132,12 @@ void Main_Window::Set_Boot_Order( const QList<VM::Boot_Order> &list )
 	disconnect( ui.CB_Boot_Priority, SIGNAL(currentIndexChanged(int)),
 				this, SLOT(CB_Boot_Priority_currentIndexChanged(int)) );
 
-    QStringList bootStr = VM::Boot_Order_To_String_List(list);
+	const QList<VM::Boot_Order> expanded = VM::Expand_Boot_Order_List( list );
+	QStringList bootStr = VM::Boot_Order_To_String_List( expanded );
 
-	// Clear old string
-	if( ui.CB_Boot_Priority->count() >= 5 ) ui.CB_Boot_Priority->removeItem( 5 );
+	// Clear dynamic multi-boot label (indices 0–4 are fixed)
+	while( ui.CB_Boot_Priority->count() > 5 )
+		ui.CB_Boot_Priority->removeItem( 5 );
 
 	// Select boot device
 	if( bootStr.count() < 1 ) // None
@@ -6133,11 +6183,13 @@ void Main_Window::on_TB_Show_Boot_Settings_Window_clicked()
 
 	if( boot_win.exec() == QDialog::Accepted )
 	{
-		Boot_Order_List = boot_win.data();
+		Boot_Order_List = VM::Expand_Boot_Order_List( boot_win.data() );
 		Show_Boot_Menu = boot_win.useBootMenu();
 
-		// Apply data to UI
+		// Apply data to UI and persist (Set_Boot_Order alone may not emit
+		// currentIndexChanged when the combo index stays the same).
 		Set_Boot_Order( Boot_Order_List );
+		VM_Changed();
 	}
 }
 
@@ -6154,24 +6206,29 @@ void Main_Window::on_TB_Show_Architecture_Options_Window_clicked()
 void Main_Window::Discard_Changes(QDialog* dialog)
 {
     auto old_vm = Get_Current_VM();
-    Virtual_Machine old_vm_copy(*old_vm);
-    Virtual_Machine tmp_vm;
-    bool ok = Create_VM_From_Ui(&tmp_vm, old_vm, false);
-    bool a = ui.Button_Apply->isEnabled();
-    bool c = ui.Button_Cancel->isEnabled();
-
-    if ( dialog->exec() == QDialog::Accepted )
+    if( ! old_vm )
         return;
 
-    if ( ok )
+    Virtual_Machine old_vm_copy( *old_vm );
+    Virtual_Machine tmp_vm;
+    bool ok = Create_VM_From_Ui( &tmp_vm, old_vm, false );
+
+    if( dialog->exec() == QDialog::Accepted )
+    {
+        // Dialog widgets may already have fired VM_Changed; force a flush so
+        // Accept never leaves unsaved edits (index-unchanged combos, etc.).
+        VM_Changed();
+        if( ui.Button_Apply->isEnabled() )
+            on_Button_Apply_clicked();
+        return;
+    }
+
+    // Cancel: restore UI to the pre-dialog snapshot
+    if( ok )
     {
         *old_vm = tmp_vm;
-        Update_VM_Ui(false);
-
+        Update_VM_Ui( false );
         *old_vm = old_vm_copy;
-
-	    ui.Button_Apply->setEnabled( a );
-	    ui.Button_Cancel->setEnabled( c );
     }
 }
 
@@ -6678,9 +6735,6 @@ void Main_Window::Apply_Win11_Lifecycle_Mode( VM::Win11_Lifecycle_Mode mode )
 			ui.CB_Mouse_Type->setCurrentIndex( by_text );
 	}
 
-	QList<VM::Boot_Order> boot;
-	VM::Boot_Order b;
-
 	if( mode == VM::Win11_Install )
 	{
 		const int vix = ui.CB_Video_Card->findData( "ramfb" );
@@ -6694,13 +6748,8 @@ void Main_Window::Apply_Win11_Lifecycle_Mode( VM::Win11_Lifecycle_Mode mode )
 		if( ! Dev_Manager->CD_ROM.Get_File_Name().isEmpty() )
 			Dev_Manager->CD_ROM.Set_Enabled( true );
 
-		b.Type = VM::Boot_From_CDROM;
-		b.Enabled = true;
-		boot << b;
-		b.Type = VM::Boot_From_HDD;
-		b.Enabled = true;
-		boot << b;
-		Boot_Order_List = boot;
+		// Full boot list (CD then HDD) — truncated lists break the boot combo
+		VM::Set_Boot_Order_Enabled( Boot_Order_List, VM::Boot_From_CDROM, VM::Boot_From_HDD );
 		Set_Boot_Order( Boot_Order_List );
 	}
 	else if( mode == VM::Win11_First_Boot )
@@ -6716,10 +6765,7 @@ void Main_Window::Apply_Win11_Lifecycle_Mode( VM::Win11_Lifecycle_Mode mode )
 		// Keep path but detach ISO for this phase
 		Dev_Manager->CD_ROM.Set_Enabled( false );
 
-		b.Type = VM::Boot_From_HDD;
-		b.Enabled = true;
-		boot << b;
-		Boot_Order_List = boot;
+		VM::Set_Boot_Order_Enabled( Boot_Order_List, VM::Boot_From_HDD );
 		Set_Boot_Order( Boot_Order_List );
 	}
 	else // Normal
@@ -6730,10 +6776,7 @@ void Main_Window::Apply_Win11_Lifecycle_Mode( VM::Win11_Lifecycle_Mode mode )
 
 		Dev_Manager->CD_ROM.Set_Enabled( false );
 
-		b.Type = VM::Boot_From_HDD;
-		b.Enabled = true;
-		boot << b;
-		Boot_Order_List = boot;
+		VM::Set_Boot_Order_Enabled( Boot_Order_List, VM::Boot_From_HDD );
 		Set_Boot_Order( Boot_Order_List );
 	}
 

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -1544,7 +1544,19 @@ bool System_Info::Is_Disk_Bus_Allowed( const QString &computer_type, const QStri
 			return false;
 
 		case VM::DI_SD:
-			return is_virt_machine || fam == VAF_MIPS || fam == VAF_OTHER;
+			// if=sd needs a board with an SD controller (raspi, etc.).
+			// Generic aarch64/arm "virt" / "virt-*" has no SD bus — QEMU errors with
+			// "machine type does not support if=sd".
+			if( m.startsWith( QLatin1String( "virt" ) ) )
+				return false;
+			if( m.contains( QLatin1String( "raspi" ) ) ||
+			    m.contains( QLatin1String( "sabrelite" ) ) ||
+			    m.contains( QLatin1String( "cubie" ) ) ||
+			    m.contains( QLatin1String( "orangepi" ) ) ||
+			    m.contains( QLatin1String( "npcm" ) ) ||
+			    m.contains( QLatin1String( "bpim" ) ) )
+				return true;
+			return fam == VAF_MIPS || fam == VAF_OTHER;
 
 		case VM::DI_Floppy:
 			return is_pc_x86 && ! is_virt_machine;

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -4426,6 +4426,10 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 				}
 			}
 			
+			// Expand truncated boot lists (older Win11 saves) so the UI can
+			// select any device without wiping the order to "None".
+			Boot_Order_List = VM::Expand_Boot_Order_List( Boot_Order_List );
+
 			// Show Boot Menu
 			Show_Boot_Menu = (Child_Element.firstChildElement("Show_Boot_Menu").text() == "true");
 			
@@ -6086,16 +6090,33 @@ static bool Is_Network_Boot( VM::Boot_Device type )
 	       type == VM::Boot_From_Network3 || type == VM::Boot_From_Network4;
 }
 
+static QString Storage_Boot_Path( const VM_Storage_Device &dev )
+{
+	if( ! dev.Get_File_Name().isEmpty() )
+		return dev.Get_File_Name();
+	if( dev.Get_Native_Mode() && dev.Get_Native_Device().Use_File_Path() )
+		return dev.Get_Native_Device().Get_File_Path();
+	return QString();
+}
+
 static bool Media_Is_Bootable_Now( const Virtual_Machine &vm, VM::Boot_Device type )
 {
 	switch( type )
 	{
 		case VM::Boot_From_FDA:
-			return vm.Get_FD0().Get_Enabled() && QFile::exists( vm.Get_FD0().Get_File_Name() );
+		{
+			const QString p = Storage_Boot_Path( vm.Get_FD0() );
+			return vm.Get_FD0().Get_Enabled() && ! p.isEmpty() && QFile::exists( p );
+		}
 		case VM::Boot_From_FDB:
-			return vm.Get_FD1().Get_Enabled() && QFile::exists( vm.Get_FD1().Get_File_Name() );
+		{
+			const QString p = Storage_Boot_Path( vm.Get_FD1() );
+			return vm.Get_FD1().Get_Enabled() && ! p.isEmpty() && QFile::exists( p );
+		}
 		case VM::Boot_From_CDROM:
-			if( vm.Get_CD_ROM().Get_Enabled() && QFile::exists( vm.Get_CD_ROM().Get_File_Name() ) )
+		{
+			const QString p = Storage_Boot_Path( vm.Get_CD_ROM() );
+			if( vm.Get_CD_ROM().Get_Enabled() && ! p.isEmpty() && QFile::exists( p ) )
 				return true;
 			// Intel macOS: OpenCore / Recovery ISOs are the CD-class boot media
 			if( vm.Use_Intel_MacOS_Profile() )
@@ -6108,11 +6129,30 @@ static bool Media_Is_Bootable_Now( const Virtual_Machine &vm, VM::Boot_Device ty
 					return true;
 			}
 			return false;
+		}
 		case VM::Boot_From_HDD:
-			return ( vm.Get_HDA().Get_Enabled() && QFile::exists( vm.Get_HDA().Get_File_Name() ) ) ||
-			       ( vm.Get_HDB().Get_Enabled() && QFile::exists( vm.Get_HDB().Get_File_Name() ) ) ||
-			       ( vm.Get_HDC().Get_Enabled() && QFile::exists( vm.Get_HDC().Get_File_Name() ) ) ||
-			       ( vm.Get_HDD().Get_Enabled() && QFile::exists( vm.Get_HDD().Get_File_Name() ) );
+		{
+			const VM_HDD disks[] = { vm.Get_HDA(), vm.Get_HDB(), vm.Get_HDC(), vm.Get_HDD() };
+			for( const VM_HDD &d : disks )
+			{
+				const QString p = Storage_Boot_Path( d );
+				if( d.Get_Enabled() && ! p.isEmpty() && QFile::exists( p ) )
+					return true;
+			}
+			// Native / Device Manager extra storage (virtio, NVMe, …)
+			const QList<VM_Native_Storage_Device> &extra = vm.Get_Storage_Devices_List();
+			for( int i = 0; i < extra.count(); ++i )
+			{
+				if( ! extra[i].Use_File_Path() )
+					continue;
+				if( extra[i].Use_Media() && extra[i].Get_Media() == VM::DM_CD_ROM )
+					continue;
+				const QString p = extra[i].Get_File_Path();
+				if( ! p.isEmpty() && QFile::exists( p ) )
+					return true;
+			}
+			return false;
+		}
 		case VM::Boot_From_Network1:
 		case VM::Boot_From_Network2:
 		case VM::Boot_From_Network3:
@@ -6607,6 +6647,13 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive );
 	if( effective_machine.isEmpty() && is_virt_arch )
 		effective_machine = "virt";
+	// QEMU warns that old versioned virt-N.M aliases are deprecated; alias to current "virt".
+	if( is_virt_arch )
+	{
+		static const QRegExp virt_ver( QStringLiteral( "^virt-\\d+\\.\\d+$" ), Qt::CaseInsensitive );
+		if( virt_ver.exactMatch( effective_machine.trimmed() ) )
+			effective_machine = QStringLiteral( "virt" );
+	}
 	
 	// Keyboard Layout (language)
 	if( Keyboard_Layout != "Default" )
@@ -7012,12 +7059,17 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 
 	if( is_virt_arch )
 	{
-		// BVM firstboot attaches installer ISO; first_boot/normal omit it.
+		// BVM install attaches the ISO; first_boot omits it.
 		if( Win11_Lifecycle_Mode == VM::Win11_First_Boot )
 			attach_cdrom = false;
 		else if( Win11_Lifecycle_Mode == VM::Win11_Install &&
 				 QFile::exists( CD_ROM.Get_File_Name() ) )
 			attach_cdrom = true;
+		// HDD-only boot: do not present the installer as usb-storage.
+		// EDK2 names it "QEMU USB HARDDRIVE" and often prefers it over virtio-blk.
+		else if( Bootindex_For( *this, VM::Boot_From_CDROM ) <= 0 &&
+			 Bootindex_For( *this, VM::Boot_From_HDD ) > 0 )
+			attach_cdrom = false;
 	}
 
 	// Intel macOS Recovery/installer ISO is attached separately — do not also take IDE index 2.
@@ -7290,13 +7342,73 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
         else if( HDA.Get_Native_Mode() )
         {
-            // Testing for the interface type 'virtio-scsi'
-            VM::Device_Interface iftype = HDA.Get_Native_Device().Get_Interface();
+            VM_Native_Storage_Device native_hda = HDA.Get_Native_Device();
+			// aarch64/arm/riscv virt: never emit AHCI/IDE — UEFI cannot boot the
+			// guest disk and falls through to the USB installer ("USB HARDDRIVE").
+			if( is_virt_arch )
+			{
+				const VM::Device_Interface want = System_Info::Sanitize_Disk_Bus(
+					Computer_Type,
+					effective_machine.isEmpty() ? Machine_Type : effective_machine,
+					native_hda.Get_Interface(),
+					false );
+				if( want != native_hda.Get_Interface() )
+				{
+					native_hda.Set_Interface( want );
+					native_hda.Use_Interface( true );
+					if( ! native_hda.Use_File_Path() )
+					{
+						native_hda.Use_File_Path( true );
+						native_hda.Set_File_Path( HDA.Get_File_Name() );
+					}
+				}
+			}
+            VM::Device_Interface iftype = native_hda.Get_Interface();
             if (iftype == VM::DI_Virtio_SCSI)
             {
 				has_virt_scsi = true;
 			}
-            StorageArgs << Build_Native_Device_Args( HDA.Get_Native_Device(), Build_QEMU_Args_for_Tab_Info );
+			// Prefer the shared virtio-blk builder (bootindex) over raw if=virtio
+			if( is_virt_arch && iftype == VM::DI_Virtio &&
+			    ( ! native_hda.Use_Media() || native_hda.Get_Media() == VM::DM_Disk ) &&
+			    ( QFile::exists( HDA.Get_File_Name() ) || Build_QEMU_Args_for_Tab_Info ) )
+			{
+				const int hdd_boot = Bootindex_For( *this, VM::Boot_From_HDD );
+				const bool win11_disk_bvm =
+					Win11_Lifecycle_Mode != VM::Win11_Install;
+				// Windows: cache=none (O_DIRECT) lies with "Image is not in qcow2 format"
+				#ifdef Q_OS_WIN32
+				const QString cache = QStringLiteral( "writeback" );
+				#else
+				const QString cache = QStringLiteral( "none" );
+				#endif
+				QString drive;
+				if( win11_disk_bvm )
+				{
+					drive = QString(
+						"file=%1,if=none,id=aqhd0,cache=%2,aio=threads,discard=unmap" )
+						.arg( HDA.Get_File_Name(), cache );
+				}
+				else
+				{
+					drive = QString( "file=%1,if=none,id=aqhd0,cache=%2,aio=threads" )
+						.arg( HDA.Get_File_Name(), cache );
+				}
+				const QString virtio_dev = With_Bootindex(
+					QStringLiteral( "virtio-blk-pci,drive=aqhd0" ), hdd_boot );
+				if( Build_QEMU_Args_for_Script_Mode )
+				{
+					StorageArgs << "-device" << virtio_dev;
+					StorageArgs << "-drive" << "\"" + drive + "\"";
+				}
+				else
+				{
+					StorageArgs << "-device" << virtio_dev;
+					StorageArgs << "-drive" << drive;
+				}
+			}
+			else
+				StorageArgs << Build_Native_Device_Args( native_hda, Build_QEMU_Args_for_Tab_Info );
 		}
 		else
 		{
@@ -7309,22 +7421,24 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 					const bool win11_disk_bvm =
 						is_virt_arch &&
 						Win11_Lifecycle_Mode != VM::Win11_Install;
+					// Windows: cache=none (O_DIRECT) lies with "Image is not in qcow2 format"
+					#ifdef Q_OS_WIN32
+					const QString cache = QStringLiteral( "writeback" );
+					#else
+					const QString cache = QStringLiteral( "none" );
+					#endif
 					QString drive;
 					if( win11_disk_bvm )
 					{
 						drive = QString(
-							"file=%1,if=none,id=aqhd0,cache=none,aio=threads,discard=unmap" )
-							.arg( HDA.Get_File_Name() );
+							"file=%1,if=none,id=aqhd0,cache=%2,aio=threads,discard=unmap" )
+							.arg( HDA.Get_File_Name(), cache );
 					}
-					#ifdef Q_OS_WIN32
 					else
-						drive = QString( "file=%1,if=none,id=aqhd0,cache=writeback,aio=threads" )
-							.arg( HDA.Get_File_Name() );
-					#else
-					else
-						drive = QString( "file=%1,if=none,id=aqhd0,cache=none,aio=threads" )
-							.arg( HDA.Get_File_Name() );
-					#endif
+					{
+						drive = QString( "file=%1,if=none,id=aqhd0,cache=%2,aio=threads" )
+							.arg( HDA.Get_File_Name(), cache );
+					}
 					const QString virtio_dev = With_Bootindex(
 						QStringLiteral( "virtio-blk-pci,drive=aqhd0" ), hdd_boot );
 					if( Build_QEMU_Args_for_Script_Mode )
@@ -9334,6 +9448,14 @@ QStringList Virtual_Machine::Build_QEMU_Args_For_Script()
 QStringList Virtual_Machine::Build_Native_Device_Args( VM_Native_Storage_Device device, bool Build_QEMU_Args_for_Script_Mode )
 {
 	QStringList opt;
+
+	// Clamp illegal buses for this arch/machine (e.g. if=sd on generic virt).
+	if( device.Use_Interface() )
+	{
+		const bool optical = device.Use_Media() && device.Get_Media() == VM::DM_CD_ROM;
+		device.Set_Interface( System_Info::Sanitize_Disk_Bus(
+			Computer_Type, Machine_Type, device.Get_Interface(), optical ) );
+	}
 
 	QString vsname = (device.Get_Media() == VM::DM_CD_ROM ? "aqcd" : "aqhd")
                + QString::number (native_device_count++);

--- a/src/VM_Devices.cpp
+++ b/src/VM_Devices.cpp
@@ -2094,6 +2094,9 @@ const VM_Native_Storage_Device &VM_Storage_Device::Get_Native_Device() const
 void VM_Storage_Device::Set_Native_Device( const VM_Native_Storage_Device &device )
 {
     Native_Device = device;
+    // Keep File_Name in sync so boot-order / UI path checks see the image
+    if( device.Use_File_Path() && ! device.Get_File_Path().isEmpty() )
+        File_Name = device.Get_File_Path();
 }
 
 //===========================================================================

--- a/src/VM_Devices.h
+++ b/src/VM_Devices.h
@@ -265,6 +265,99 @@ class VM
             return bootStr;
         }
 
+		// Full FDA..Network4 list (matches Virtual_Machine defaults). Truncated lists
+		// (e.g. Win11 lifecycle) break the boot-priority combo — selecting a type that
+		// is missing disables every entry and the UI falls back to "None".
+		static QList<Boot_Order> Make_Full_Boot_Order_List()
+		{
+			QList<Boot_Order> list;
+			const Boot_Device types[] = {
+				Boot_From_FDA, Boot_From_FDB, Boot_From_CDROM, Boot_From_HDD,
+				Boot_From_Network1, Boot_From_Network2, Boot_From_Network3, Boot_From_Network4
+			};
+			for( Boot_Device t : types )
+			{
+				Boot_Order b;
+				b.Type = t;
+				b.Enabled = false;
+				list << b;
+			}
+			return list;
+		}
+
+		static QList<Boot_Order> Expand_Boot_Order_List( const QList<Boot_Order> &src )
+		{
+			QList<Boot_Order> list = Make_Full_Boot_Order_List();
+			for( int i = 0; i < src.count(); ++i )
+			{
+				for( int j = 0; j < list.count(); ++j )
+				{
+					if( list[j].Type == src[i].Type )
+					{
+						list[j].Enabled = src[i].Enabled;
+						break;
+					}
+				}
+			}
+			// Preserve relative order of enabled devices from src for multi-boot
+			QList<Boot_Order> ordered;
+			QList<Boot_Device> seen;
+			for( int i = 0; i < src.count(); ++i )
+			{
+				if( ! src[i].Enabled )
+					continue;
+				for( int j = 0; j < list.count(); ++j )
+				{
+					if( list[j].Type == src[i].Type )
+					{
+						ordered << list[j];
+						seen << list[j].Type;
+						break;
+					}
+				}
+			}
+			for( int j = 0; j < list.count(); ++j )
+			{
+				if( seen.contains( list[j].Type ) )
+					continue;
+				ordered << list[j];
+			}
+			return ordered.isEmpty() ? list : ordered;
+		}
+
+		static void Set_Boot_Order_Single( QList<Boot_Order> &list, Boot_Device only )
+		{
+			list = Expand_Boot_Order_List( list );
+			for( int i = 0; i < list.count(); ++i )
+				list[i].Enabled = ( only != Boot_None && list[i].Type == only );
+		}
+
+		static void Set_Boot_Order_Enabled( QList<Boot_Order> &list,
+						   Boot_Device first,
+						   Boot_Device second = Boot_None )
+		{
+			list = Make_Full_Boot_Order_List();
+			// Put enabled devices first so multi-boot order is stable
+			QList<Boot_Order> ordered;
+			if( first != Boot_None )
+			{
+				Boot_Order b; b.Type = first; b.Enabled = true;
+				ordered << b;
+			}
+			if( second != Boot_None && second != first )
+			{
+				Boot_Order b; b.Type = second; b.Enabled = true;
+				ordered << b;
+			}
+			for( int i = 0; i < list.count(); ++i )
+			{
+				if( list[i].Type == first || list[i].Type == second )
+					continue;
+				ordered << list[i];
+			}
+			list = ordered;
+		}
+
 		// Kilobyte, Megabyte, Gigabyte
 		enum Size_Suffix { Size_Suf_Kb, Size_Suf_Mb, Size_Suf_Gb };
 		

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -4348,17 +4348,14 @@ bool VM_Wizard_Window::Create_New_VM(bool simulate)
 		New_VM->Set_Initrd_Path( Guest_Initrd_Path );
 		New_VM->Set_Kernel_ComLine( Guest_Kernel_Append );
 		QList<VM::Boot_Order> boot;
-		VM::Boot_Order bhd; bhd.Enabled = true; bhd.Type = VM::Boot_From_HDD;
-		boot << bhd;
+		VM::Set_Boot_Order_Enabled( boot, VM::Boot_From_HDD );
 		New_VM->Set_Boot_Order_List( boot );
 	}
 	else if( ! Guest_Install_ISO.isEmpty() && QFile::exists( Guest_Install_ISO ) )
 	{
 		New_VM->Set_CD_ROM( VM_Storage_Device( true, Guest_Install_ISO ) );
 		QList<VM::Boot_Order> boot;
-		VM::Boot_Order bcd; bcd.Enabled = true; bcd.Type = VM::Boot_From_CDROM;
-		VM::Boot_Order bhd; bhd.Enabled = true; bhd.Type = VM::Boot_From_HDD;
-		boot << bcd << bhd;
+		VM::Set_Boot_Order_Enabled( boot, VM::Boot_From_CDROM, VM::Boot_From_HDD );
 		New_VM->Set_Boot_Order_List( boot );
 	}
 	
@@ -4588,10 +4585,7 @@ void VM_Wizard_Window::Apply_Windows11_ARM_Profile( bool simulate )
 	{
 		New_VM->Set_CD_ROM( VM_Storage_Device( false, "" ) );
 		QList<VM::Boot_Order> boot;
-		VM::Boot_Order b;
-		b.Type = VM::Boot_From_HDD;
-		b.Enabled = true;
-		boot << b;
+		VM::Set_Boot_Order_Enabled( boot, VM::Boot_From_HDD );
 		New_VM->Set_Boot_Order_List( boot );
 		New_VM->Set_Win11_Lifecycle_Mode( VM::Win11_Normal );
 		New_VM->Set_Video_Card( "virtio-gpu-pci" );
@@ -4602,14 +4596,7 @@ void VM_Wizard_Window::Apply_Windows11_ARM_Profile( bool simulate )
 		New_VM->Set_CD_ROM( cd );
 		
 		QList<VM::Boot_Order> boot;
-		VM::Boot_Order bcd;
-		bcd.Type = VM::Boot_From_CDROM;
-		bcd.Enabled = true;
-		boot << bcd;
-		VM::Boot_Order bhdd;
-		bhdd.Type = VM::Boot_From_HDD;
-		bhdd.Enabled = true;
-		boot << bhdd;
+		VM::Set_Boot_Order_Enabled( boot, VM::Boot_From_CDROM, VM::Boot_From_HDD );
 		New_VM->Set_Boot_Order_List( boot );
 		New_VM->Set_Win11_Lifecycle_Mode( VM::Win11_Install );
 		// BVM firstboot: ramfb only during install
@@ -4710,16 +4697,9 @@ void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )
 	QList<VM::Boot_Order> boot;
 	const QString oc_path = Edit_Intel_Mac_OpenCore->text().trimmed().toLower();
 	if( oc_path.endsWith( QLatin1String( ".iso" ) ) )
-	{
-		VM::Boot_Order bcd;
-		bcd.Type = VM::Boot_From_CDROM;
-		bcd.Enabled = true;
-		boot << bcd;
-	}
-	VM::Boot_Order bhdd;
-	bhdd.Type = VM::Boot_From_HDD;
-	bhdd.Enabled = true;
-	boot << bhdd;
+		VM::Set_Boot_Order_Enabled( boot, VM::Boot_From_CDROM, VM::Boot_From_HDD );
+	else
+		VM::Set_Boot_Order_Enabled( boot, VM::Boot_From_HDD );
 	New_VM->Set_Boot_Order_List( boot );
 }
 


### PR DESCRIPTION
## Summary
- Persist VM settings and boot order immediately (no more resets to None / UEFI shell from empty bootindex)
- Coerce invalid aarch64 disk buses (AHCI/SD) to VirtIO, use Windows-safe `cache=writeback`, alias deprecated `virt-N.M` to `virt`, and detach ISO when HDD-only boot
- Machine tab scrolls instead of crushing or blanking controls when the window is resized

## Test plan
- [x] Windows 11 ARM boots from HDD after fixes
- [ ] Change boot order / machine settings, restart AQEMU — values stick
- [ ] Resize main window on Machine tab — controls stay readable with scrollbar
- [ ] Confirm disk bus shows VirtIO (not SD/AHCI) for aarch64 virt
- [ ] Start Win11 ARM — no `if=sd` / qcow2 cache=none errors
