### PR TITLE
feat: Interactive BIOS/ROM file pickers & non-x86 hardware bus guardrails

### DIFF
--- a/src/Advanced_Options.ui
+++ b/src/Advanced_Options.ui
@@ -248,14 +248,25 @@
        </widget>
       </item>
       <item row="15" column="1">
-       <widget class="QLineEdit" name="Edit_BIOS_File">
-        <property name="toolTip">
-         <string>Optional firmware image. Leave empty for SeaBIOS / machine default. UEFI still uses the OVMF paths below when enabled.</string>
-        </property>
-        <property name="placeholderText">
-         <string>optional path to BIOS / board firmware</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_BIOS_File">
+        <item>
+         <widget class="QLineEdit" name="Edit_BIOS_File">
+          <property name="toolTip">
+           <string>Optional firmware image. Leave empty for SeaBIOS / machine default. UEFI still uses the OVMF paths below when enabled.</string>
+          </property>
+          <property name="placeholderText">
+           <string>optional path to BIOS / board firmware (e.g. Rev_2.5_v66.bin)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="TB_BIOS_File_Browse">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="16" column="0">
        <widget class="QLabel" name="Label_Mem_Path">

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -214,6 +214,12 @@ Main_Window::Main_Window( QWidget *parent )
     connect(ui_ao.CH_Start_Date,SIGNAL(toggled(bool)),this,SLOT(adv_on_CH_Start_Date_toggled(bool)));
 	connect(ui_ao.TB_Refresh_Gamepads, SIGNAL(clicked()), this, SLOT(AO_Refresh_Gamepads_clicked()));
 	connect(ui_ao.TB_Edit_Blockdev_Graph, SIGNAL(clicked()), this, SLOT(AO_Edit_Blockdev_Graph_clicked()));
+	connect(ui_ao.TB_BIOS_File_Browse, &QToolButton::clicked, this, [this]() {
+		const QString file = QFileDialog::getOpenFileName( this, tr( "Select BIOS / Board Firmware File" ),
+			QString(), tr( "ROM / Firmware Files (*.bin *.rom *.fd *.elf);;All Files (*)" ) );
+		if( ! file.isEmpty() )
+			ui_ao.Edit_BIOS_File->setText( QDir::toNativeSeparators( file ) );
+	} );
 
 	ui_kvm.setupUi( Accelerator_Options );
 	ui_arch.setupUi( Architecture_Options );

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -6688,7 +6688,10 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		effective_machine.contains( QLatin1String( "mac99" ), Qt::CaseInsensitive ) ||
 		effective_machine.contains( QLatin1String( "g3beige" ), Qt::CaseInsensitive ) ||
 		Computer_Type.contains( QLatin1String( "s390" ), Qt::CaseInsensitive ) ||
-		Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive );
+		Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "m68k" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "sparc" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "mips" ), Qt::CaseInsensitive );
 	if( effective_machine.isEmpty() && is_virt_arch )
 		effective_machine = "virt";
 	// QEMU warns that old versioned virt-N.M aliases are deprecated; alias to current "virt".
@@ -6894,6 +6897,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		const bool no_mttcg =
 			legacy_force_tcg ||
 			Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive ) ||
+			Computer_Type.contains( QLatin1String( "m68k" ), Qt::CaseInsensitive ) ||
 			Computer_Type.contains( QLatin1String( "sparc" ), Qt::CaseInsensitive ) ||
 			Computer_Type.contains( QLatin1String( "mips" ), Qt::CaseInsensitive );
 		if( no_mttcg )

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -2203,6 +2203,12 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 	}
 
 	// Devices page / capability overrides (always win over class heuristics when set)
+	const Guest_Capabilities caps = Current_Guest_Capabilities();
+	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
+	{
+		VM::Sound_Cards no_sound;
+		New_VM->Set_Audio_Cards( no_sound );
+	}
 	if( ! Guest_Video_Card.isEmpty() )
 		New_VM->Set_Video_Card( Guest_Video_Card );
 	else if( Current_Guest_Capabilities().guest_class == Guest_Capabilities::Classic_Mac )

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -1690,7 +1690,13 @@ void VM_Wizard_Window::Update_Guest_Compat_Tip()
 
 void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 {
-	if( Three_Path_Active )
+	const Guest_Capabilities caps = Current_Guest_Capabilities();
+	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
+	{
+		VM::Sound_Cards no_sound;
+		New_VM->Set_Audio_Cards( no_sound );
+	}
+	else if( Three_Path_Active )
 	{
 		if( ! Selected_Machine_Id.isEmpty() )
 			New_VM->Set_Machine_Type( Selected_Machine_Id );
@@ -2203,7 +2209,6 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 	}
 
 	// Devices page / capability overrides (always win over class heuristics when set)
-	const Guest_Capabilities caps = Current_Guest_Capabilities();
 	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
 	{
 		VM::Sound_Cards no_sound;
@@ -2211,7 +2216,7 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 	}
 	if( ! Guest_Video_Card.isEmpty() )
 		New_VM->Set_Video_Card( Guest_Video_Card );
-	else if( Current_Guest_Capabilities().guest_class == Guest_Capabilities::Classic_Mac )
+	else if( caps.guest_class == Guest_Capabilities::Classic_Mac )
 		New_VM->Set_Video_Card( QString() );
 
 	if( ! Guest_Disk_Bus.isEmpty() )
@@ -2351,6 +2356,24 @@ void VM_Wizard_Window::Build_Devices_Page()
 	add_row( tr( "Network card:" ), &CB_Dev_NIC );
 	add_row( tr( "Sound:" ), &CB_Dev_Sound );
 	add_row( tr( "Display:" ), &CB_Dev_Video );
+
+	QHBoxLayout *biosRow = new QHBoxLayout();
+	QLabel *lblBios = new QLabel( tr( "Machine BIOS / ROM:" ) );
+	lblBios->setMinimumWidth( 110 );
+	Edit_Dev_BIOS_File = new QLineEdit();
+	Edit_Dev_BIOS_File->setPlaceholderText( tr( "Optional custom firmware file (e.g. Rev_2.5_v66.bin for NeXT Cube)" ) );
+	QPushButton *btnBrowseBios = new QPushButton( tr( "Browse…" ) );
+	biosRow->addWidget( lblBios );
+	biosRow->addWidget( Edit_Dev_BIOS_File, 1 );
+	biosRow->addWidget( btnBrowseBios );
+	lay->addLayout( biosRow );
+
+	connect( btnBrowseBios, &QPushButton::clicked, this, [this]() {
+		const QString f = QFileDialog::getOpenFileName( this, tr( "Select BIOS / Firmware File" ),
+			QString(), tr( "ROM / Firmware Files (*.bin *.rom *.fd *.elf);;All Files (*)" ) );
+		if( ! f.isEmpty() && Edit_Dev_BIOS_File )
+			Edit_Dev_BIOS_File->setText( QDir::toNativeSeparators( f ) );
+	} );
 
 	CH_Dev_VirtIO_Extras = new QCheckBox( tr(
 		"VirtIO extras (RNG, balloon, keyboard) — only when the guest has VirtIO drivers" ) );
@@ -2583,6 +2606,8 @@ void VM_Wizard_Window::Apply_Devices_Page_To_State()
 	Guest_Video_Card = CB_Dev_Video ? CB_Dev_Video->currentData().toString() : Guest_Video_Card;
 	if( CB_Dev_Sound )
 		Apply_Sound_Preset( CB_Dev_Sound->currentData().toString() );
+	if( Edit_Dev_BIOS_File && ! Edit_Dev_BIOS_File->text().trimmed().isEmpty() )
+		New_VM->Set_BIOS_File( Edit_Dev_BIOS_File->text().trimmed() );
 	Guest_Use_VirtIO_Extras = CH_Dev_VirtIO_Extras && CH_Dev_VirtIO_Extras->isChecked();
 	Guest_Use_GPU_Passthrough = CH_Dev_GPU_Passthrough && CH_Dev_GPU_Passthrough->isChecked();
 	Guest_GPU_PCI = ( CB_Dev_GPU && Guest_Use_GPU_Passthrough )

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -282,6 +282,7 @@ class VM_Wizard_Window: public QDialog
 		QComboBox *CB_Dev_NIC;
 		QComboBox *CB_Dev_Sound;
 		QComboBox *CB_Dev_Video;
+		QLineEdit *Edit_Dev_BIOS_File;
 		QCheckBox *CH_Dev_VirtIO_Extras;
 		QCheckBox *CH_Dev_GPU_Passthrough;
 		QComboBox *CB_Dev_GPU;


### PR DESCRIPTION
## Summary

This PR adds interactive BIOS file pickers and non-x86 target hardware bus guardrails.

### 🌟 Key Enhancements:
- **Interactive BIOS File Pickers (... / Browse…)**: Added native file pickers for -bios firmware ROM selection (Rev_2.5_v66.bin, Quadra800.ROM, etc.) in both the New VM Wizard (Devices Page) and Main Window Advanced Options.
- **Non-PCI Sound Card Suppression**: Sanitizes audio cards against target capabilities to prevent attaching invalid devices like intel-hda on non-PCI machines (e.g. m68k, microblaze, vr, x, 	ricore).
- **Non-x86 Bus Guardrails**: Suppresses invalid x86 floppy/IDE controllers and enforces 	hread=single for single-threaded TCG targets (m68k).