### PR TITLE
Release AQEMU 1.1.0 — full QEMU probe catalogs & wizard CPU defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ SET( aqemu_sources
 	src/Snapshots_Window.cpp
 	src/SPICE_Settings_Widget.cpp
 	src/System_Info.cpp
+	src/QEMU_Probe_Catalog.cpp
 	src/Utils.cpp
 	src/VM.cpp
 	src/VM_Devices.cpp
@@ -494,6 +495,21 @@ IF( EXISTS "${CMAKE_SOURCE_DIR}/docs/qemu_machine_catalog.json" )
 		DESTINATION share/aqemu )
 ENDIF()
 
+# Per-architecture full QEMU probe catalogs (Main Window VM config panel)
+IF( EXISTS "${CMAKE_SOURCE_DIR}/qemu_probe_full_v3" )
+	ADD_CUSTOM_COMMAND( TARGET aqemu POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E make_directory
+			"$<TARGET_FILE_DIR:aqemu>/qemu_probe_full_v3"
+		COMMAND ${CMAKE_COMMAND} -E copy_directory
+			"${CMAKE_SOURCE_DIR}/qemu_probe_full_v3"
+			"$<TARGET_FILE_DIR:aqemu>/qemu_probe_full_v3"
+		COMMENT "Bundle qemu_probe_full_v3 for full VM config option lists"
+	)
+	INSTALL( DIRECTORY "${CMAKE_SOURCE_DIR}/qemu_probe_full_v3/"
+		DESTINATION share/aqemu/qemu_probe_full_v3
+		FILES_MATCHING PATTERN "*.json" )
+ENDIF()
+
 # Install files
 INSTALL( TARGETS aqemu DESTINATION bin )
 
@@ -580,7 +596,7 @@ ENDIF( INSTALL_MAN )
 # CPack Packaging Configuration
 SET( CPACK_GENERATOR "DEB" )
 SET( CPACK_PACKAGE_NAME "aqemu" )
-SET( CPACK_PACKAGE_VERSION "1.0.0" )
+SET( CPACK_PACKAGE_VERSION "1.1.0" )
 SET( CPACK_PACKAGE_CONTACT "chronic8000" )
 SET( CPACK_PACKAGE_DESCRIPTION_SUMMARY "AQEMU is a graphical user interface for the QEMU emulator." )
 SET( CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON )

--- a/docs/final_probe_audit.json
+++ b/docs/final_probe_audit.json
@@ -1,0 +1,388 @@
+{
+  "summary": {
+    "probe_arches": 28,
+    "wizard_targets": 18,
+    "os_profiles": 193,
+    "os_cpu_machine_ok": 193,
+    "os_cpu_miss_count": 0,
+    "os_mach_miss_count": 0,
+    "modern_with_486": 0,
+    "total_probe_machines": 490,
+    "total_probe_cpus": 2074,
+    "total_probe_net": 604,
+    "total_probe_display": 194
+  },
+  "verdict": {
+    "main_panel_full_machine_cpu_net_video": true,
+    "wizard_curated_valid_defaults": true,
+    "user_can_pick_all_probe_machines_cpus_net_display_per_arch": true,
+    "remaining_gaps_are_intentional_ui_scope": true
+  },
+  "targets_missing_probe": [],
+  "probes_not_listed_as_wizard_target": [
+    "loongarch64",
+    "mips",
+    "mipsel",
+    "or1k",
+    "rx",
+    "sh4eb",
+    "sparc",
+    "tricore",
+    "xtensa",
+    "xtensaeb"
+  ],
+  "os_cpu_miss": [],
+  "os_mach_miss": [],
+  "modern_with_486": [],
+  "cpu_dist_top": [
+    [
+      "x86_64:max",
+      54
+    ],
+    [
+      "arm:max",
+      37
+    ],
+    [
+      "i386:qemu32",
+      19
+    ],
+    [
+      "ppc:g4",
+      17
+    ],
+    [
+      "i386:pentium3",
+      9
+    ],
+    [
+      "i386:max",
+      8
+    ],
+    [
+      "aarch64:max",
+      7
+    ],
+    [
+      "i386:486",
+      6
+    ],
+    [
+      "i386:pentium2",
+      5
+    ],
+    [
+      "x86_64:qemu64",
+      5
+    ],
+    [
+      "avr:avr5",
+      3
+    ],
+    [
+      "mips64el:20Kc",
+      3
+    ],
+    [
+      "mips64:5Kf",
+      2
+    ],
+    [
+      "alpha:ev4",
+      2
+    ],
+    [
+      "m68k:any",
+      2
+    ],
+    [
+      "m68k:m68040",
+      2
+    ],
+    [
+      "mips64:20Kc",
+      2
+    ],
+    [
+      "riscv32:max",
+      2
+    ],
+    [
+      "riscv64:max",
+      2
+    ],
+    [
+      "sparc64:TI-UltraSparc-II",
+      1
+    ]
+  ],
+  "arch_stats": [
+    {
+      "arch": "aarch64",
+      "machines": 112,
+      "cpus": 36,
+      "net": 29,
+      "display": 11,
+      "in_wizard": true
+    },
+    {
+      "arch": "alpha",
+      "machines": 2,
+      "cpus": 7,
+      "net": 27,
+      "display": 7,
+      "in_wizard": true
+    },
+    {
+      "arch": "arm",
+      "machines": 98,
+      "cpus": 24,
+      "net": 29,
+      "display": 11,
+      "in_wizard": true
+    },
+    {
+      "arch": "avr",
+      "machines": 9,
+      "cpus": 3,
+      "net": 0,
+      "display": 0,
+      "in_wizard": true
+    },
+    {
+      "arch": "hppa",
+      "machines": 5,
+      "cpus": 3,
+      "net": 27,
+      "display": 8,
+      "in_wizard": true
+    },
+    {
+      "arch": "i386",
+      "machines": 41,
+      "cpus": 241,
+      "net": 30,
+      "display": 14,
+      "in_wizard": true
+    },
+    {
+      "arch": "loongarch64",
+      "machines": 2,
+      "cpus": 3,
+      "net": 29,
+      "display": 8,
+      "in_wizard": false
+    },
+    {
+      "arch": "m68k",
+      "machines": 22,
+      "cpus": 10,
+      "net": 1,
+      "display": 2,
+      "in_wizard": true
+    },
+    {
+      "arch": "microblaze",
+      "machines": 4,
+      "cpus": 1,
+      "net": 0,
+      "display": 0,
+      "in_wizard": true
+    },
+    {
+      "arch": "mips",
+      "machines": 2,
+      "cpus": 18,
+      "net": 27,
+      "display": 8,
+      "in_wizard": false
+    },
+    {
+      "arch": "mips64",
+      "machines": 4,
+      "cpus": 34,
+      "net": 27,
+      "display": 8,
+      "in_wizard": true
+    },
+    {
+      "arch": "mips64el",
+      "machines": 7,
+      "cpus": 34,
+      "net": 30,
+      "display": 11,
+      "in_wizard": true
+    },
+    {
+      "arch": "mipsel",
+      "machines": 2,
+      "cpus": 18,
+      "net": 27,
+      "display": 8,
+      "in_wizard": false
+    },
+    {
+      "arch": "or1k",
+      "machines": 3,
+      "cpus": 2,
+      "net": 26,
+      "display": 8,
+      "in_wizard": false
+    },
+    {
+      "arch": "ppc",
+      "machines": 13,
+      "cpus": 384,
+      "net": 32,
+      "display": 8,
+      "in_wizard": true
+    },
+    {
+      "arch": "ppc64",
+      "machines": 39,
+      "cpus": 420,
+      "net": 33,
+      "display": 9,
+      "in_wizard": true
+    },
+    {
+      "arch": "riscv32",
+      "machines": 7,
+      "cpus": 8,
+      "net": 29,
+      "display": 9,
+      "in_wizard": true
+    },
+    {
+      "arch": "riscv64",
+      "machines": 10,
+      "cpus": 26,
+      "net": 29,
+      "display": 9,
+      "in_wizard": true
+    },
+    {
+      "arch": "rx",
+      "machines": 3,
+      "cpus": 1,
+      "net": 0,
+      "display": 0,
+      "in_wizard": false
+    },
+    {
+      "arch": "s390x",
+      "machines": 20,
+      "cpus": 505,
+      "net": 8,
+      "display": 4,
+      "in_wizard": true
+    },
+    {
+      "arch": "sh4",
+      "machines": 2,
+      "cpus": 3,
+      "net": 27,
+      "display": 8,
+      "in_wizard": true
+    },
+    {
+      "arch": "sh4eb",
+      "machines": 2,
+      "cpus": 3,
+      "net": 27,
+      "display": 8,
+      "in_wizard": false
+    },
+    {
+      "arch": "sparc",
+      "machines": 11,
+      "cpus": 15,
+      "net": 0,
+      "display": 0,
+      "in_wizard": false
+    },
+    {
+      "arch": "sparc64",
+      "machines": 4,
+      "cpus": 19,
+      "net": 28,
+      "display": 7,
+      "in_wizard": true
+    },
+    {
+      "arch": "tricore",
+      "machines": 3,
+      "cpus": 4,
+      "net": 0,
+      "display": 0,
+      "in_wizard": false
+    },
+    {
+      "arch": "x86_64",
+      "machines": 41,
+      "cpus": 242,
+      "net": 30,
+      "display": 14,
+      "in_wizard": true
+    },
+    {
+      "arch": "xtensa",
+      "machines": 11,
+      "cpus": 8,
+      "net": 26,
+      "display": 7,
+      "in_wizard": false
+    },
+    {
+      "arch": "xtensaeb",
+      "machines": 11,
+      "cpus": 2,
+      "net": 26,
+      "display": 7,
+      "in_wizard": false
+    }
+  ],
+  "code_checks": {
+    "Main_Window_merges_probe": true,
+    "Wizard_merges_probe": true,
+    "Get_Emulator_Info_merges_probe": true,
+    "Wizard_Recommended_CPU": true,
+    "Wizard_loads_profile_cpu": true,
+    "Sanitize_Video_preserves_picks": true,
+    "Sanitize_Disk_preserves_picks": true,
+    "Probe_First_Available_CPU": true,
+    "Guest_Capabilities_curated": true
+  },
+  "intentional_gaps": [
+    {
+      "area": "USB device catalog",
+      "status": "intentional",
+      "detail": "No full -device USB picker; tablet/keyboard/hub curated."
+    },
+    {
+      "area": "Storage beyond disk-bus enum",
+      "status": "intentional",
+      "detail": "IDE/AHCI/VirtIO/SCSI/NVMe/SD/MTD/PFlash \u2014 not every SCSI HBA model."
+    },
+    {
+      "area": "netdev backends",
+      "status": "intentional",
+      "detail": "user/tap/bridge modes \u2014 not raw -netdev help dump."
+    },
+    {
+      "area": "chardev / object / host display&audio backends",
+      "status": "intentional",
+      "detail": "Probe captures them; UI uses curated display/audio paths."
+    },
+    {
+      "area": "Accelerators",
+      "status": "intentional",
+      "detail": "TCG/KVM/WHPX honesty \u2014 not every -accel line."
+    }
+  ],
+  "notes": [
+    "Wizard OS path: Guest_Capabilities + os_profiles (cpu/machine/nic/sound) \u2014 safe defaults.",
+    "Main Window + Custom reconfigure: QEMU_Probe_Catalog merges full machines/CPUs/NICs/video per arch.",
+    "Architecture switch without wizard refreshes lists from qemu_probe_full_v3."
+  ]
+}

--- a/docs/wizard_probe_audit.json
+++ b/docs/wizard_probe_audit.json
@@ -1,0 +1,1101 @@
+{
+  "meta": {
+    "probe_dir": "C:\\Users\\chron\\CURSOR-PROJECTS\\aqemu\\qemu_probe_full_v3",
+    "wizard_trees": "C:\\Users\\chron\\CURSOR-PROJECTS\\aqemu\\resources\\wizard_trees.json",
+    "probe_architectures": 28,
+    "wizard_architecture_targets": 28,
+    "os_names_in_tree": 193,
+    "os_profiles": 193,
+    "platform_bindings": 105,
+    "unbound_platform_labels": 2
+  },
+  "verdict": {
+    "supports_all_qemu_binaries": true,
+    "os_machine_compatibility_pct": 97.9,
+    "platform_binding_ok_pct": 93.3,
+    "exposes_full_device_help": false,
+    "custom_allows_full_manual": false,
+    "headline": "Wizard covers all probed qemu-system-* arches and most OS\u2192machine bindings, but does NOT expose the full probe device inventory. Custom is curated-manual, not raw QEMU. Several honesty bugs (disk/video/accel) were found historically; classic Mac path is specially forced."
+  },
+  "architecture_gaps": {
+    "in_probes_not_wizard": [],
+    "in_wizard_not_probes": [],
+    "wizard_targets": [
+      "aarch64",
+      "alpha",
+      "arm",
+      "avr",
+      "hppa",
+      "i386",
+      "loongarch64",
+      "m68k",
+      "microblaze",
+      "mips",
+      "mips64",
+      "mips64el",
+      "mipsel",
+      "or1k",
+      "ppc",
+      "ppc64",
+      "riscv32",
+      "riscv64",
+      "rx",
+      "s390x",
+      "sh4",
+      "sh4eb",
+      "sparc",
+      "sparc64",
+      "tricore",
+      "x86_64",
+      "xtensa",
+      "xtensaeb"
+    ],
+    "probe_targets": [
+      "aarch64",
+      "alpha",
+      "arm",
+      "avr",
+      "hppa",
+      "i386",
+      "loongarch64",
+      "m68k",
+      "microblaze",
+      "mips",
+      "mips64",
+      "mips64el",
+      "mipsel",
+      "or1k",
+      "ppc",
+      "ppc64",
+      "riscv32",
+      "riscv64",
+      "rx",
+      "s390x",
+      "sh4",
+      "sh4eb",
+      "sparc",
+      "sparc64",
+      "tricore",
+      "x86_64",
+      "xtensa",
+      "xtensaeb"
+    ]
+  },
+  "platform_bindings": {
+    "ok": 98,
+    "bad": [
+      {
+        "platform": "Acer Pica 61",
+        "target": "mips",
+        "machine": "pica61"
+      },
+      {
+        "platform": "Fuloong 2E",
+        "target": "mipsel",
+        "machine": "fuloong2e"
+      },
+      {
+        "platform": "HP 715/64",
+        "target": "hppa",
+        "machine": "b160l"
+      },
+      {
+        "platform": "HP A400-44",
+        "target": "hppa",
+        "machine": "b160l"
+      },
+      {
+        "platform": "HP B160L",
+        "target": "hppa",
+        "machine": "b160l"
+      },
+      {
+        "platform": "HP C3700",
+        "target": "hppa",
+        "machine": "c3700"
+      },
+      {
+        "platform": "SGI Magnum",
+        "target": "mips",
+        "machine": "magnum"
+      }
+    ],
+    "unknown_target": [],
+    "unbound_labels": [
+      {
+        "family": "Other Platforms",
+        "platform": "Hundreds More..."
+      },
+      {
+        "family": "Generic",
+        "platform": "Import Existing QEMU Command Line"
+      }
+    ],
+    "unbound_total": 2
+  },
+  "os_profiles": {
+    "ok": 189,
+    "bad_machine": [
+      {
+        "os": "HP-UX",
+        "family": "HP",
+        "target": "hppa",
+        "machine": "b160l",
+        "flags": [
+          "hppa_scsi"
+        ]
+      },
+      {
+        "os": "IRIX 5.x",
+        "family": "SGI",
+        "target": "mips",
+        "machine": "magnum",
+        "flags": []
+      },
+      {
+        "os": "IRIX 6.x",
+        "family": "SGI",
+        "target": "mips",
+        "machine": "magnum",
+        "flags": []
+      }
+    ],
+    "missing_target_probe": [
+      {
+        "os": "Other",
+        "family": "Other",
+        "target": "host",
+        "machine": "host",
+        "flags": [
+          "host_default"
+        ]
+      }
+    ],
+    "missing_profile": [],
+    "sample_ok": [
+      {
+        "os": "Darwin",
+        "family": "Apple",
+        "target": "x86_64",
+        "machine": "q35",
+        "flags": [
+          "intel_macos"
+        ]
+      },
+      {
+        "os": "Mac OS 6",
+        "family": "Apple",
+        "target": "m68k",
+        "machine": "q800",
+        "flags": []
+      },
+      {
+        "os": "Mac OS 7",
+        "family": "Apple",
+        "target": "ppc",
+        "machine": "mac99",
+        "flags": []
+      },
+      {
+        "os": "Mac OS 8",
+        "family": "Apple",
+        "target": "ppc",
+        "machine": "mac99",
+        "flags": []
+      },
+      {
+        "os": "Mac OS 9",
+        "family": "Apple",
+        "target": "ppc",
+        "machine": "mac99",
+        "flags": []
+      },
+      {
+        "os": "Mac OS X Intel",
+        "family": "Apple",
+        "target": "x86_64",
+        "machine": "q35",
+        "flags": [
+          "intel_macos"
+        ]
+      },
+      {
+        "os": "Mac OS X PPC",
+        "family": "Apple",
+        "target": "ppc",
+        "machine": "mac99",
+        "flags": []
+      },
+      {
+        "os": "macOS",
+        "family": "Apple",
+        "target": "x86_64",
+        "machine": "q35",
+        "flags": [
+          "intel_macos"
+        ]
+      },
+      {
+        "os": "NeXTSTEP",
+        "family": "Apple",
+        "target": "m68k",
+        "machine": "next-cube",
+        "flags": []
+      },
+      {
+        "os": "OPENSTEP",
+        "family": "Apple",
+        "target": "i386",
+        "machine": "pc",
+        "flags": []
+      },
+      {
+        "os": "DragonFly BSD",
+        "family": "BSD",
+        "target": "x86_64",
+        "machine": "q35",
+        "flags": []
+      },
+      {
+        "os": "FreeBSD (32-bit)",
+        "family": "BSD",
+        "target": "i386",
+        "machine": "pc",
+        "flags": []
+      },
+      {
+        "os": "FreeBSD (64-bit)",
+        "family": "BSD",
+        "target": "x86_64",
+        "machine": "q35",
+        "flags": []
+      },
+      {
+        "os": "GhostBSD",
+        "family": "BSD",
+        "target": "x86_64",
+        "machine": "q35",
+        "flags": []
+      },
+      {
+        "os": "NetBSD (32-bit)",
+        "family": "BSD",
+        "target": "i386",
+        "machine": "pc",
+        "flags": []
+      }
+    ]
+  },
+  "risk_notes": [
+    {
+      "os": null,
+      "target": "mips",
+      "machine": "pica61",
+      "issue": "Platform 'Acer Pica 61' machine not in probe for target",
+      "flags": []
+    },
+    {
+      "os": null,
+      "target": "mipsel",
+      "machine": "fuloong2e",
+      "issue": "Platform 'Fuloong 2E' machine not in probe for target",
+      "flags": []
+    },
+    {
+      "os": null,
+      "target": "hppa",
+      "machine": "b160l",
+      "issue": "Platform 'HP 715/64' machine not in probe for target",
+      "flags": []
+    },
+    {
+      "os": null,
+      "target": "hppa",
+      "machine": "b160l",
+      "issue": "Platform 'HP A400-44' machine not in probe for target",
+      "flags": []
+    },
+    {
+      "os": null,
+      "target": "hppa",
+      "machine": "b160l",
+      "issue": "Platform 'HP B160L' machine not in probe for target",
+      "flags": []
+    },
+    {
+      "os": null,
+      "target": "hppa",
+      "machine": "c3700",
+      "issue": "Platform 'HP C3700' machine not in probe for target",
+      "flags": []
+    },
+    {
+      "os": null,
+      "target": "mips",
+      "machine": "magnum",
+      "issue": "Platform 'SGI Magnum' machine not in probe for target",
+      "flags": []
+    }
+  ],
+  "arch_coverage": [
+    {
+      "arch": "aarch64",
+      "probe_machines": 112,
+      "probe_cpus": 36,
+      "probe_devices": 353,
+      "wizard_platforms": 10,
+      "wizard_os_profiles": 7,
+      "machines_referenced": [
+        "none",
+        "raspi3ap",
+        "raspi3b",
+        "raspi4b",
+        "sbsa-ref",
+        "virt",
+        "xlnx-zcu102"
+      ],
+      "referenced_count": 7,
+      "fallback": "virt",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "alpha",
+      "probe_machines": 2,
+      "probe_cpus": 7,
+      "probe_devices": 165,
+      "wizard_platforms": 1,
+      "wizard_os_profiles": 2,
+      "machines_referenced": [
+        "clipper"
+      ],
+      "referenced_count": 1,
+      "fallback": "clipper",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "arm",
+      "probe_machines": 98,
+      "probe_cpus": 24,
+      "probe_devices": 352,
+      "wizard_platforms": 39,
+      "wizard_os_profiles": 37,
+      "machines_referenced": [
+        "b-l475e-iot01a",
+        "bpim2u",
+        "collie",
+        "cubieboard",
+        "imx25-pdk",
+        "integratorcp",
+        "kzm",
+        "lm3s6965evb",
+        "lm3s811evb",
+        "mcimx6ul-evk",
+        "mcimx7d-sabre",
+        "microbit",
+        "mps2-an385",
+        "mps2-an505",
+        "mps2-an521",
+        "mps3-an524",
+        "mps3-an547",
+        "netduino2",
+        "netduinoplus2",
+        "olimex-stm32-h405",
+        "orangepi-pc",
+        "raspi0",
+        "raspi1ap",
+        "raspi2b",
+        "realview-eb",
+        "realview-eb-mpcore",
+        "realview-pb-a8",
+        "realview-pbx-a9",
+        "sabrelite",
+        "stm32vldiscovery",
+        "sx1",
+        "sx1-v1",
+        "versatileab",
+        "versatilepb",
+        "vexpress-a15",
+        "vexpress-a9",
+        "virt",
+        "xilinx-zynq-a9"
+      ],
+      "referenced_count": 38,
+      "fallback": "virt",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "avr",
+      "probe_machines": 9,
+      "probe_cpus": 3,
+      "probe_devices": 3,
+      "wizard_platforms": 3,
+      "wizard_os_profiles": 3,
+      "machines_referenced": [
+        "arduino-duemilanove",
+        "arduino-mega",
+        "arduino-uno"
+      ],
+      "referenced_count": 3,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "hppa",
+      "probe_machines": 5,
+      "probe_cpus": 3,
+      "probe_devices": 158,
+      "wizard_platforms": 4,
+      "wizard_os_profiles": 1,
+      "machines_referenced": [
+        "b160l",
+        "c3700"
+      ],
+      "referenced_count": 2,
+      "fallback": "B160L",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "i386",
+      "probe_machines": 41,
+      "probe_cpus": 240,
+      "probe_devices": 387,
+      "wizard_platforms": 2,
+      "wizard_os_profiles": 47,
+      "machines_referenced": [
+        "isapc",
+        "pc"
+      ],
+      "referenced_count": 2,
+      "fallback": "pc",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "loongarch64",
+      "probe_machines": 2,
+      "probe_cpus": 3,
+      "probe_devices": 164,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "virt",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "m68k",
+      "probe_machines": 22,
+      "probe_cpus": 10,
+      "probe_devices": 25,
+      "wizard_platforms": 2,
+      "wizard_os_profiles": 4,
+      "machines_referenced": [
+        "next-cube",
+        "q800"
+      ],
+      "referenced_count": 2,
+      "fallback": "q800",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "microblaze",
+      "probe_machines": 4,
+      "probe_cpus": 1,
+      "probe_devices": 141,
+      "wizard_platforms": 1,
+      "wizard_os_profiles": 1,
+      "machines_referenced": [
+        "petalogix-ml605"
+      ],
+      "referenced_count": 1,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "mips",
+      "probe_machines": 2,
+      "probe_cpus": 18,
+      "probe_devices": 166,
+      "wizard_platforms": 2,
+      "wizard_os_profiles": 2,
+      "machines_referenced": [
+        "magnum",
+        "pica61"
+      ],
+      "referenced_count": 2,
+      "fallback": "malta",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "mips64",
+      "probe_machines": 4,
+      "probe_cpus": 34,
+      "probe_devices": 166,
+      "wizard_platforms": 2,
+      "wizard_os_profiles": 2,
+      "machines_referenced": [
+        "magnum",
+        "pica61"
+      ],
+      "referenced_count": 2,
+      "fallback": "malta",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "mips64el",
+      "probe_machines": 7,
+      "probe_cpus": 34,
+      "probe_devices": 180,
+      "wizard_platforms": 4,
+      "wizard_os_profiles": 3,
+      "machines_referenced": [
+        "boston",
+        "loongson3-virt",
+        "malta"
+      ],
+      "referenced_count": 3,
+      "fallback": "malta",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "mipsel",
+      "probe_machines": 2,
+      "probe_cpus": 18,
+      "probe_devices": 166,
+      "wizard_platforms": 1,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [
+        "fuloong2e"
+      ],
+      "referenced_count": 1,
+      "fallback": "malta",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "or1k",
+      "probe_machines": 3,
+      "probe_cpus": 2,
+      "probe_devices": 152,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "ppc",
+      "probe_machines": 13,
+      "probe_cpus": 384,
+      "probe_devices": 191,
+      "wizard_platforms": 13,
+      "wizard_os_profiles": 17,
+      "machines_referenced": [
+        "40p",
+        "amigaone",
+        "bamboo",
+        "g3beige",
+        "mac99",
+        "mpc8544ds",
+        "pegasos1",
+        "pegasos2",
+        "ppce500",
+        "sam460ex",
+        "virtex-ml507"
+      ],
+      "referenced_count": 11,
+      "fallback": "mac99",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "ppc64",
+      "probe_machines": 38,
+      "probe_cpus": 420,
+      "probe_devices": 361,
+      "wizard_platforms": 6,
+      "wizard_os_profiles": 1,
+      "machines_referenced": [
+        "powernv",
+        "powernv10",
+        "powernv8",
+        "powernv9",
+        "pseries"
+      ],
+      "referenced_count": 5,
+      "fallback": "pseries",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "riscv32",
+      "probe_machines": 7,
+      "probe_cpus": 8,
+      "probe_devices": 302,
+      "wizard_platforms": 3,
+      "wizard_os_profiles": 2,
+      "machines_referenced": [
+        "opentitan",
+        "sifive_e"
+      ],
+      "referenced_count": 2,
+      "fallback": "virt",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "riscv64",
+      "probe_machines": 10,
+      "probe_cpus": 26,
+      "probe_devices": 302,
+      "wizard_platforms": 4,
+      "wizard_os_profiles": 2,
+      "machines_referenced": [
+        "sifive_u",
+        "spike",
+        "virt"
+      ],
+      "referenced_count": 3,
+      "fallback": "virt",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "rx",
+      "probe_machines": 3,
+      "probe_cpus": 1,
+      "probe_devices": 6,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "s390x",
+      "probe_machines": 20,
+      "probe_cpus": 503,
+      "probe_devices": 170,
+      "wizard_platforms": 1,
+      "wizard_os_profiles": 1,
+      "machines_referenced": [
+        "s390-ccw-virtio"
+      ],
+      "referenced_count": 1,
+      "fallback": "s390-ccw-virtio",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "sh4",
+      "probe_machines": 2,
+      "probe_cpus": 3,
+      "probe_devices": 162,
+      "wizard_platforms": 1,
+      "wizard_os_profiles": 1,
+      "machines_referenced": [
+        "r2d"
+      ],
+      "referenced_count": 1,
+      "fallback": "r2d",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "sh4eb",
+      "probe_machines": 2,
+      "probe_cpus": 3,
+      "probe_devices": 162,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "sparc",
+      "probe_machines": 11,
+      "probe_cpus": 13,
+      "probe_devices": 6,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "SS-5",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "sparc64",
+      "probe_machines": 4,
+      "probe_cpus": 17,
+      "probe_devices": 166,
+      "wizard_platforms": 2,
+      "wizard_os_profiles": 1,
+      "machines_referenced": [
+        "niagara",
+        "sun4u"
+      ],
+      "referenced_count": 2,
+      "fallback": "sun4u",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "tricore",
+      "probe_machines": 3,
+      "probe_cpus": 4,
+      "probe_devices": 3,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "x86_64",
+      "probe_machines": 41,
+      "probe_cpus": 241,
+      "probe_devices": 388,
+      "wizard_platforms": 4,
+      "wizard_os_profiles": 58,
+      "machines_referenced": [
+        "microvm",
+        "pc",
+        "q35"
+      ],
+      "referenced_count": 3,
+      "fallback": "q35",
+      "accels": [
+        "tcg",
+        "whpx"
+      ]
+    },
+    {
+      "arch": "xtensa",
+      "probe_machines": 11,
+      "probe_cpus": 8,
+      "probe_devices": 148,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    },
+    {
+      "arch": "xtensaeb",
+      "probe_machines": 11,
+      "probe_cpus": 2,
+      "probe_devices": 148,
+      "wizard_platforms": 0,
+      "wizard_os_profiles": 0,
+      "machines_referenced": [],
+      "referenced_count": 0,
+      "fallback": "none",
+      "accels": [
+        "tcg"
+      ]
+    }
+  ],
+  "gui_exposure": {
+    "summary": "Wizard Devices page + Main Window expose curated subsets (Machine, CPU, NIC, Video, Audio, Disk bus) from Available_Devices (First-Start QEMU probe / catalog), NOT the full -device help list.",
+    "wizard_exposes": [
+      "Architecture / qemu-system-* target",
+      "Machine type (from Available_Devices.Machine_List + live Probe_Live_Machines)",
+      "CPU type (CPU_List)",
+      "NIC model (Network_Card_List / Guest_Capabilities filter)",
+      "Video (Video_Card_List / Sanitize_Video_Card)",
+      "Disk interface (IDE/AHCI/VirtIO/SCSI/\u2026 via Guest_Capabilities + System_Info)",
+      "Audio cards (Sound_Cards bitfield)",
+      "RAM / disk size",
+      "Accelerator TCG vs KVM/WHPX"
+    ],
+    "wizard_does_not_expose_full_probe": [
+      "Full -device help inventory (hundreds of PCI/USB/misc devices)",
+      "All netdev backends",
+      "All chardev backends",
+      "All object types",
+      "Most display backends (spice/gtk/sdl/egl-headless per-binary)",
+      "Versioned machine aliases (pc-i440fx-5.1 \u2026) unless live probe fills them",
+      "Per-device property help"
+    ],
+    "custom_path": {
+      "exists": true,
+      "description": "Custom / Advanced picks arch+machine manually, then Devices page. It still uses Available_Devices lists \u2014 not free-form every QEMU device. Additional Args on the finished VM can pass raw QEMU flags.",
+      "limitations": [
+        "Cannot pick arbitrary -device from probe list in the wizard UI",
+        "Machine combo may be catalog-filtered; live Probe_Live_Machines helps when binary works",
+        "OS-specific Apply_* overrides (classic Mac, Win9x, etc.) only run on OS path, not pure Custom"
+      ]
+    },
+    "x86_64_device_categories": {
+      "Controller/Bridge/Hub devices": 16,
+      "USB devices": 14,
+      "Storage devices": 41,
+      "Network devices": 30,
+      "Input devices": 32,
+      "Display devices": 14,
+      "Sound devices": 14,
+      "Misc devices": 42,
+      "CPU devices": 174,
+      "Watchdog devices": 2,
+      "Uncategorized devices": 9
+    },
+    "ppc_device_categories": {
+      "Controller/Bridge/Hub devices": 13,
+      "USB devices": 14,
+      "Storage devices": 37,
+      "Network devices": 32,
+      "Input devices": 33,
+      "Display devices": 8,
+      "Sound devices": 14,
+      "Misc devices": 34,
+      "Watchdog devices": 2,
+      "Uncategorized devices": 4
+    },
+    "m68k_device_categories": {
+      "Storage devices": 5,
+      "Network devices": 1,
+      "Input devices": 9,
+      "Display devices": 2,
+      "Sound devices": 1,
+      "Misc devices": 6,
+      "Uncategorized devices": 1
+    }
+  },
+  "code_signals": {
+    "classic_mac_forces_ppc_mac99": false,
+    "disk_bus_classic_mac_ide": true,
+    "default_video_ppc_was_std": true,
+    "sanitize_video_classic_mac_empty": true,
+    "devices_page_exists": true,
+    "custom_method_radio": true,
+    "live_machine_probe": true,
+    "guest_caps_file": true
+  },
+  "findings": [
+    {
+      "severity": "high",
+      "title": "7 platform bindings reference machines not in probe",
+      "detail": "Acer Pica 61 \u2192 mips/pica61; Fuloong 2E \u2192 mipsel/fuloong2e; HP 715/64 \u2192 hppa/b160l; HP A400-44 \u2192 hppa/b160l; HP B160L \u2192 hppa/b160l; HP C3700 \u2192 hppa/c3700; SGI Magnum \u2192 mips/magnum"
+    },
+    {
+      "severity": "high",
+      "title": "3 OS profiles have invalid machines",
+      "detail": "HP-UX \u2192 hppa/b160l; IRIX 5.x \u2192 mips/magnum; IRIX 6.x \u2192 mips/magnum"
+    },
+    {
+      "severity": "medium",
+      "title": "2 platform labels have no platform_bindings",
+      "detail": "Selecting them in the Platforms tree may fall back or fail"
+    },
+    {
+      "severity": "high",
+      "title": "Full QEMU -device help is not selectable in the wizard GUI",
+      "detail": "x86_64 probe lists ~388 devices; UI only shows curated NIC/video/audio/disk-bus lists."
+    },
+    {
+      "severity": "medium",
+      "title": "Custom / Advanced is not full raw QEMU coverage",
+      "detail": "User can pick any probed target + machine (+ Devices page curated lists). Arbitrary devices still need Additional Args after creation."
+    },
+    {
+      "severity": "medium",
+      "title": "Versioned machine matrix mostly hidden",
+      "detail": "Probes list dozens of pc-i440fx-*/pc-q35-* versions; wizard usually offers aliases (pc, q35) unless live probe populates Machine_List fully."
+    }
+  ],
+  "critical_os": [
+    {
+      "os": "Mac OS X PPC",
+      "status": "OK",
+      "target": "ppc",
+      "machine": "mac99",
+      "flags": []
+    },
+    {
+      "os": "macOS",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": [
+        "intel_macos"
+      ]
+    },
+    {
+      "os": "Mac OS X Intel",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": [
+        "intel_macos"
+      ]
+    },
+    {
+      "os": "NeXTSTEP",
+      "status": "OK",
+      "target": "m68k",
+      "machine": "next-cube",
+      "flags": []
+    },
+    {
+      "os": "AIX",
+      "status": "OK",
+      "target": "ppc64",
+      "machine": "pseries",
+      "flags": []
+    },
+    {
+      "os": "Windows 98",
+      "status": "OK",
+      "target": "i386",
+      "machine": "pc",
+      "flags": [
+        "win95_98"
+      ]
+    },
+    {
+      "os": "Windows XP (32-bit)",
+      "status": "OK",
+      "target": "i386",
+      "machine": "pc",
+      "flags": []
+    },
+    {
+      "os": "Windows 11",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": [
+        "win11_host_arm"
+      ]
+    },
+    {
+      "os": "Ubuntu (64-bit)",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": []
+    },
+    {
+      "os": "ReactOS",
+      "status": "NO_PROFILE",
+      "target": "",
+      "machine": ""
+    },
+    {
+      "os": "OS/2",
+      "status": "OK",
+      "target": "i386",
+      "machine": "pc",
+      "flags": []
+    },
+    {
+      "os": "Haiku (64-bit)",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": []
+    },
+    {
+      "os": "FreeBSD (64-bit)",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": []
+    },
+    {
+      "os": "Solaris",
+      "status": "NO_PROFILE",
+      "target": "",
+      "machine": ""
+    },
+    {
+      "os": "OpenBSD (64-bit)",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": []
+    },
+    {
+      "os": "Linux on IBM Z",
+      "status": "OK",
+      "target": "s390x",
+      "machine": "s390-ccw-virtio",
+      "flags": []
+    },
+    {
+      "os": "HP-UX",
+      "status": "BAD",
+      "target": "hppa",
+      "machine": "b160l",
+      "flags": [
+        "hppa_scsi"
+      ]
+    },
+    {
+      "os": "Android",
+      "status": "OK",
+      "target": "aarch64",
+      "machine": "virt",
+      "flags": []
+    },
+    {
+      "os": "Chrome OS Flex",
+      "status": "OK",
+      "target": "x86_64",
+      "machine": "q35",
+      "flags": [
+        "chromeos_flex",
+        "virtio_vga"
+      ]
+    }
+  ]
+}

--- a/docs/wizard_probe_audit_arch.txt
+++ b/docs/wizard_probe_audit_arch.txt
@@ -1,0 +1,28 @@
+x86_64       mach= 41 cpu= 241 dev= 388 plats= 4 os= 58 refs=3
+i386         mach= 41 cpu= 240 dev= 387 plats= 2 os= 47 refs=2
+ppc64        mach= 38 cpu= 420 dev= 361 plats= 6 os=  1 refs=5
+aarch64      mach=112 cpu=  36 dev= 353 plats=10 os=  7 refs=7
+arm          mach= 98 cpu=  24 dev= 352 plats=39 os= 37 refs=38
+riscv32      mach=  7 cpu=   8 dev= 302 plats= 3 os=  2 refs=2
+riscv64      mach= 10 cpu=  26 dev= 302 plats= 4 os=  2 refs=3
+ppc          mach= 13 cpu= 384 dev= 191 plats=13 os= 17 refs=11
+mips64el     mach=  7 cpu=  34 dev= 180 plats= 4 os=  3 refs=3
+s390x        mach= 20 cpu= 503 dev= 170 plats= 1 os=  1 refs=1
+mips         mach=  2 cpu=  18 dev= 166 plats= 2 os=  2 refs=2
+mips64       mach=  4 cpu=  34 dev= 166 plats= 2 os=  2 refs=2
+mipsel       mach=  2 cpu=  18 dev= 166 plats= 1 os=  0 refs=1
+sparc64      mach=  4 cpu=  17 dev= 166 plats= 2 os=  1 refs=2
+alpha        mach=  2 cpu=   7 dev= 165 plats= 1 os=  2 refs=1
+loongarch64  mach=  2 cpu=   3 dev= 164 plats= 0 os=  0 refs=0
+sh4          mach=  2 cpu=   3 dev= 162 plats= 1 os=  1 refs=1
+sh4eb        mach=  2 cpu=   3 dev= 162 plats= 0 os=  0 refs=0
+hppa         mach=  5 cpu=   3 dev= 158 plats= 4 os=  1 refs=2
+or1k         mach=  3 cpu=   2 dev= 152 plats= 0 os=  0 refs=0
+xtensa       mach= 11 cpu=   8 dev= 148 plats= 0 os=  0 refs=0
+xtensaeb     mach= 11 cpu=   2 dev= 148 plats= 0 os=  0 refs=0
+microblaze   mach=  4 cpu=   1 dev= 141 plats= 1 os=  1 refs=1
+m68k         mach= 22 cpu=  10 dev=  25 plats= 2 os=  4 refs=2
+rx           mach=  3 cpu=   1 dev=   6 plats= 0 os=  0 refs=0
+sparc        mach= 11 cpu=  13 dev=   6 plats= 0 os=  0 refs=0
+avr          mach=  9 cpu=   3 dev=   3 plats= 3 os=  3 refs=3
+tricore      mach=  3 cpu=   4 dev=   3 plats= 0 os=  0 refs=0

--- a/installer/README.md
+++ b/installer/README.md
@@ -19,9 +19,9 @@ WiX Toolset → classic installer under `Program Files\AQEMU`.
 powershell -ExecutionPolicy Bypass -File installer\build-msi.ps1
 ```
 
-Output: `installer\out\AQEMU-1.0.0-win64.msi`
+Output: `installer\out\AQEMU-1.1.0-win64.msi`
 
-Silent install: `msiexec /i AQEMU-1.0.0-win64.msi /qn`
+Silent install: `msiexec /i AQEMU-1.1.0-win64.msi /qn`
 
 Requires: [WiX CLI](https://wixtoolset.org/) (`winget install WiXToolset.WiXCLI`), then `wix eula accept wix7` once (or let the script accept it).
 
@@ -35,7 +35,7 @@ Desktop Bridge package (`runFullTrust`) with the same built-in QEMU payload. Thi
 powershell -ExecutionPolicy Bypass -File installer\build-msix.ps1
 ```
 
-Output: `installer\out\AQEMU-1.0.0-win64.msix`
+Output: `installer\out\AQEMU-1.1.0-win64.msix`
 
 Requires: Windows 10/11 SDK (`makeappx.exe`, `signtool.exe`).
 
@@ -47,7 +47,7 @@ In Partner Center, create an **MSIX or PWA** app (not EXE/MSI), open **Product i
 powershell -ExecutionPolicy Bypass -File installer\build-msix.ps1 `
   -Publisher "CN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" `
   -IdentityName "YourPublisher.AQEMU" `
-  -Version "1.0.0.0"
+  -Version "1.1.0.0"
 ```
 
 - **Publisher** must match the Store `CN=...` exactly (signing cert subject must match too).

--- a/installer/build-msi.ps1
+++ b/installer/build-msi.ps1
@@ -10,7 +10,7 @@
 param(
     [string] $RepoRoot = "",
     [string] $BuildDir = "",
-    [string] $Version = "1.0.0",
+    [string] $Version = "1.1.0",
     [string] $OutDir = ""
 )
 

--- a/installer/build-msix.ps1
+++ b/installer/build-msix.ps1
@@ -11,7 +11,7 @@
 param(
     [string] $RepoRoot = "",
     [string] $BuildDir = "",
-    [string] $Version = "1.0.0.0",
+    [string] $Version = "1.1.0.0",
     [string] $OutDir = "",
     # Must match Partner Center Product identity Publisher (CN=...)
     [string] $Publisher = "CN=16318CB3-C262-4B44-BCCF-310B0DDA3950",
@@ -163,7 +163,7 @@ if (-not (Test-Path $shareBios)) {
 $qemuSystems = @(Get-ChildItem (Join-Path $layoutDir "qemu-system-*.exe") -ErrorAction SilentlyContinue)
 Write-Host ("Staged qemu-system-* count: {0}" -f $qemuSystems.Count)
 if ($qemuSystems.Count -lt 10) {
-    Write-Warning "Only $($qemuSystems.Count) qemu-system-* binaries staged. Store packages should include EVERY softmmu target — rebuild with scripts/build_qemu_windows_msys.sh (all targets)."
+    Write-Warning ("Only {0} qemu-system-* binaries staged. Store packages should include EVERY softmmu target - rebuild with scripts/build_qemu_windows_msys.sh (all targets)." -f $qemuSystems.Count)
 }
 
 if (-not (Test-Path (Join-Path $layoutDir "aqemu.exe"))) {
@@ -228,6 +228,7 @@ if (-not $SkipSign) {
 
 $item = Get-Item $msixPath
 $mb = [math]::Round($item.Length / 1MB, 1)
-Write-Host "OK: $($item.FullName) ($mb MB)"
-Write-Host ""
-Write-Host "Store submission: upload this MSIX package to Microsoft Partner Center."
+$okMsg = 'OK: ' + $item.FullName + ' (' + $mb.ToString() + ' MB)'
+Write-Host $okMsg
+Write-Host ''
+Write-Host 'Store submission: upload this MSIX package to Microsoft Partner Center.'

--- a/packaging/README-WINDOWS.txt
+++ b/packaging/README-WINDOWS.txt
@@ -1,7 +1,7 @@
-AQEMU 1.0.0 — Windows portable (x64)
+AQEMU 1.1.0 — Windows portable (x64)
 ====================================
 
-Updated build: 2026-07-25 (Machine section full-width + UI polish).
+Updated build: 2026-07-29 (full QEMU probe catalogs + wizard CPU defaults).
 
 Please file bugs:
   https://github.com/chronic8000/aqemu/issues
@@ -9,23 +9,17 @@ Please file bugs:
 Run:  aqemu.exe
 
 This zip includes:
-  - AQEMU 1.0.0 (Qt5 + embedded SPICE)
-  - QEMU 11.0.2 (qemu-system-x86_64, i386, aarch64, qemu-img)
+  - AQEMU 1.1.0 (Qt5 + embedded SPICE)
+  - QEMU 11.0.2 (full softmmu set + qemu-img)
   - UEFI/BIOS firmware under share/
   - OpenPartitionDxe.efi (Intel macOS OpenCore prep)
   - qemu_machine_catalog.json (New VM wizard machine list)
+  - qemu_probe_full_v3/*.json (full per-arch QEMU option lists for VM config)
 
 What's new in this zip:
-  - Machine Name/Accelerator/… fields span full width (same as Memory/Audio/…)
-  - White main chrome; West Info/Machine/Media/Display/Network rail
-  - No clipped combo/button text on HiDPI
-  - Resize / maximize / minimize-to-tray geometry fixes
+  - Main Window / Custom: full machines, CPUs, NICs, display devices per arch from probes
+  - Wizard: curated OS defaults with probe-validated CPUs (no more 486 for Ubuntu)
+  - Architecture switch refreshes full option lists without re-running the wizard
 
 Notes:
   - GitHub Release zips are NOT auto-updated. Grab a newer zip when we publish one.
-  - Microsoft Store (pending certification) will be the update channel for Store installs.
-  - You must supply your own OS ISOs / disks / OpenCore / OSK where required.
-  - License: GNU GPLv2 — source at https://github.com/chronic8000/aqemu
-  - Privacy: https://github.com/chronic8000/aqemu/blob/master/PRIVACY.md
-
-If Windows SmartScreen warns on first run, use More info → Run anyway (unsigned portable build).

--- a/resources/wizard_trees.json
+++ b/resources/wizard_trees.json
@@ -558,19 +558,19 @@
     },
     "HP B160L": {
       "target": "hppa",
-      "machine": "b160l"
+      "machine": "B160L"
     },
     "HP C3700": {
       "target": "hppa",
-      "machine": "c3700"
+      "machine": "C3700"
     },
     "HP A400-44": {
       "target": "hppa",
-      "machine": "b160l"
+      "machine": "B160L"
     },
     "HP 715/64": {
       "target": "hppa",
-      "machine": "b160l"
+      "machine": "B160L"
     },
     "RISC-V Virt": {
       "target": "riscv64",
@@ -865,7 +865,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_isa",
       "sound": "sb16_adlib_pcspk",
-      "tip": "DOS → x86 (i386 PC) + Legacy ISA. 64-bit guests cannot run DOS."
+      "tip": "DOS → x86 (i386 PC) + Legacy ISA. 64-bit guests cannot run DOS.",
+      "cpu": "486"
     },
     "PC DOS": {
       "target": "i386",
@@ -874,7 +875,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_isa",
       "sound": "sb16_adlib_pcspk",
-      "tip": "PC DOS → x86 (i386 PC) + Legacy ISA."
+      "tip": "PC DOS → x86 (i386 PC) + Legacy ISA.",
+      "cpu": "486"
     },
     "DR-DOS": {
       "target": "i386",
@@ -883,7 +885,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_isa",
       "sound": "sb16_adlib_pcspk",
-      "tip": "DR-DOS → x86 (i386 PC) + Legacy ISA."
+      "tip": "DR-DOS → x86 (i386 PC) + Legacy ISA.",
+      "cpu": "486"
     },
     "Windows 1.x": {
       "target": "i386",
@@ -892,7 +895,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_isa",
       "sound": "sb16_adlib_pcspk",
-      "tip": "Windows 1.x needs x86 (i386 PC) / ISA PC. Cannot run as an x86_64 guest."
+      "tip": "Windows 1.x needs x86 (i386 PC) / ISA PC. Cannot run as an x86_64 guest.",
+      "cpu": "486"
     },
     "Windows 2.x": {
       "target": "i386",
@@ -901,7 +905,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_isa",
       "sound": "sb16_adlib_pcspk",
-      "tip": "Windows 2.x needs x86 (i386 PC) / ISA PC. Cannot run as an x86_64 guest."
+      "tip": "Windows 2.x needs x86 (i386 PC) / ISA PC. Cannot run as an x86_64 guest.",
+      "cpu": "486"
     },
     "Windows 3.x": {
       "target": "i386",
@@ -910,7 +915,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_isa",
       "sound": "sb16_adlib_pcspk",
-      "tip": "Windows 3.x needs x86 (i386 PC) / ISA PC. Cannot run as an x86_64 guest."
+      "tip": "Windows 3.x needs x86 (i386 PC) / ISA PC. Cannot run as an x86_64 guest.",
+      "cpu": "486"
     },
     "Windows 95": {
       "target": "i386",
@@ -922,7 +928,8 @@
       "tip": "Windows 95 → x86 (i386 PC) + pc (i440FX). Force TCG on Windows hosts; CPU pentium2; cirrus; ACPI off.",
       "flags": [
         "win95_98"
-      ]
+      ],
+      "cpu": "pentium2"
     },
     "Windows 98": {
       "target": "i386",
@@ -934,7 +941,8 @@
       "tip": "Windows 98 (proven AQEMU profile): i386 + pc, Force TCG / pentium2, cirrus, ACPI off, IDE disk, ne2k_pci, sb16, 128 MB, 1 CPU.",
       "flags": [
         "win95_98"
-      ]
+      ],
+      "cpu": "pentium2"
     },
     "Windows ME": {
       "target": "i386",
@@ -943,7 +951,8 @@
       "hdd_gb": 8,
       "nic": "rtl8139",
       "sound": "sb16_es1370_pcspk",
-      "tip": "Windows ME → x86 (i386 PC) + pc (i440FX). Not forced to pure TCG (unlike 95/98)."
+      "tip": "Windows ME → x86 (i386 PC) + pc (i440FX). Not forced to pure TCG (unlike 95/98).",
+      "cpu": "pentium2"
     },
     "Windows NT 3.x": {
       "target": "i386",
@@ -952,7 +961,8 @@
       "hdd_gb": 8,
       "nic": "ne2k_pci",
       "sound": "es1370",
-      "tip": "Windows NT 3.x → x86 (i386 PC). Avoid x86_64."
+      "tip": "Windows NT 3.x → x86 (i386 PC). Avoid x86_64.",
+      "cpu": "pentium2"
     },
     "Windows NT 4.0": {
       "target": "i386",
@@ -961,7 +971,8 @@
       "hdd_gb": 8,
       "nic": "ne2k_pci",
       "sound": "es1370",
-      "tip": "Windows NT 4.0 → x86 (i386 PC). Avoid x86_64."
+      "tip": "Windows NT 4.0 → x86 (i386 PC). Avoid x86_64.",
+      "cpu": "pentium2"
     },
     "Windows 2000": {
       "target": "i386",
@@ -973,7 +984,8 @@
       "tip": "Windows 2000 → x86 (i386 PC) + pc. Win2K disk hack can help.",
       "flags": [
         "win2k_hack"
-      ]
+      ],
+      "cpu": "pentium3"
     },
     "Windows 11": {
       "target": "x86_64",
@@ -985,7 +997,8 @@
       "tip": "Windows 11 → x86_64 (PC) + Q35. On ARM hosts AQEMU switches to AArch64 + virt.",
       "flags": [
         "win11_host_arm"
-      ]
+      ],
+      "cpu": "max"
     },
     "Windows Server 2000": {
       "target": "i386",
@@ -994,7 +1007,8 @@
       "hdd_gb": 20,
       "nic": "rtl8139",
       "sound": "ac97",
-      "tip": "Windows Server 2000 → x86 (i386 PC)."
+      "tip": "Windows Server 2000 → x86 (i386 PC).",
+      "cpu": "pentium3"
     },
     "Windows Server 2003": {
       "target": "i386",
@@ -1003,7 +1017,8 @@
       "hdd_gb": 20,
       "nic": "rtl8139",
       "sound": "ac97",
-      "tip": "Windows Server 2003 → x86 (i386 PC)."
+      "tip": "Windows Server 2003 → x86 (i386 PC).",
+      "cpu": "pentium3"
     },
     "Windows Server 2012": {
       "target": "x86_64",
@@ -1012,7 +1027,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2012 → x86_64 (PC) + Q35."
+      "tip": "Windows Server 2012 → x86_64 (PC) + Q35.",
+      "cpu": "max"
     },
     "Windows Server 2016": {
       "target": "x86_64",
@@ -1021,7 +1037,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2016 → x86_64 (PC) + Q35."
+      "tip": "Windows Server 2016 → x86_64 (PC) + Q35.",
+      "cpu": "max"
     },
     "Windows Server 2019": {
       "target": "x86_64",
@@ -1030,7 +1047,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2019 → x86_64 (PC) + Q35."
+      "tip": "Windows Server 2019 → x86_64 (PC) + Q35.",
+      "cpu": "max"
     },
     "Windows Server 2022": {
       "target": "x86_64",
@@ -1039,7 +1057,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2022 → x86_64 (PC) + Q35."
+      "tip": "Windows Server 2022 → x86_64 (PC) + Q35.",
+      "cpu": "max"
     },
     "Windows Server 2025": {
       "target": "x86_64",
@@ -1048,7 +1067,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2025 → x86_64 (PC) + Q35."
+      "tip": "Windows Server 2025 → x86_64 (PC) + Q35.",
+      "cpu": "max"
     },
     "RHEL": {
       "target": "x86_64",
@@ -1057,7 +1077,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "RHEL → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "RHEL → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Rocky Linux": {
       "target": "x86_64",
@@ -1066,7 +1087,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Rocky Linux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Rocky Linux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "AlmaLinux": {
       "target": "x86_64",
@@ -1075,7 +1097,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "AlmaLinux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "AlmaLinux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "SUSE Linux": {
       "target": "x86_64",
@@ -1084,7 +1107,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "SUSE Linux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "SUSE Linux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Gentoo": {
       "target": "x86_64",
@@ -1093,7 +1117,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Gentoo → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Gentoo → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Slackware": {
       "target": "x86_64",
@@ -1102,7 +1127,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Slackware → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Slackware → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Kali Linux": {
       "target": "x86_64",
@@ -1111,7 +1137,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Kali Linux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Kali Linux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "DragonFly BSD": {
       "target": "x86_64",
@@ -1120,7 +1147,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "DragonFly BSD → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "DragonFly BSD → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Mac OS 7": {
       "target": "ppc",
@@ -1129,7 +1157,8 @@
       "hdd_gb": 4,
       "nic": "sungem",
       "sound": "none",
-      "tip": "Classic Mac OS 7 → qemu-system-ppc + mac99. Supply your own boot CD/ISO or HDD image."
+      "tip": "Classic Mac OS 7 → qemu-system-ppc + mac99. Supply your own boot CD/ISO or HDD image.",
+      "cpu": "g4"
     },
     "Mac OS 8": {
       "target": "ppc",
@@ -1138,7 +1167,8 @@
       "hdd_gb": 4,
       "nic": "sungem",
       "sound": "none",
-      "tip": "Classic Mac OS 8 → qemu-system-ppc + mac99. Supply your own boot CD/ISO or HDD image."
+      "tip": "Classic Mac OS 8 → qemu-system-ppc + mac99. Supply your own boot CD/ISO or HDD image.",
+      "cpu": "g4"
     },
     "Mac OS 9": {
       "target": "ppc",
@@ -1147,7 +1177,8 @@
       "hdd_gb": 4,
       "nic": "sungem",
       "sound": "none",
-      "tip": "Classic Mac OS 9 → qemu-system-ppc + mac99. Supply your own boot CD/ISO or HDD image."
+      "tip": "Classic Mac OS 9 → qemu-system-ppc + mac99. Supply your own boot CD/ISO or HDD image.",
+      "cpu": "g4"
     },
     "Mac OS X PPC": {
       "target": "ppc",
@@ -1156,7 +1187,8 @@
       "hdd_gb": 10,
       "nic": "sungem",
       "sound": "none",
-      "tip": "Mac OS X PPC → qemu-system-ppc + mac99. Ensure qemu-system-ppc is installed."
+      "tip": "Mac OS X PPC → qemu-system-ppc + mac99. Ensure qemu-system-ppc is installed.",
+      "cpu": "g4"
     },
     "Mac OS X Intel": {
       "target": "x86_64",
@@ -1168,7 +1200,8 @@
       "tip": "Intel Mac OS X (experimental): qemu-system-x86_64 + q35 (PC-class hardware for OpenCore). Supply OpenCore, OVMF, OSK, install media.",
       "flags": [
         "intel_macos"
-      ]
+      ],
+      "cpu": "max"
     },
     "macOS": {
       "target": "x86_64",
@@ -1180,7 +1213,8 @@
       "tip": "Intel macOS (experimental): qemu-system-x86_64 + q35 (PC-class hardware for OpenCore — not Apple Silicon). On an x86_64 host AQEMU selects KVM/WHPX by default. Supply OpenCore, OVMF, OSK, install media. AQEMU does not ship Apple files.",
       "flags": [
         "intel_macos"
-      ]
+      ],
+      "cpu": "max"
     },
     "Darwin": {
       "target": "x86_64",
@@ -1192,7 +1226,8 @@
       "tip": "Darwin / Intel macOS path: qemu-system-x86_64 + q35. Supply OpenCore, OVMF, OSK, install media.",
       "flags": [
         "intel_macos"
-      ]
+      ],
+      "cpu": "max"
     },
     "Solaris x86": {
       "target": "x86_64",
@@ -1201,7 +1236,8 @@
       "hdd_gb": 32,
       "nic": "e1000",
       "sound": "sb16",
-      "tip": "Solaris 11.4 x86 (r/qemu_kvm recipe): pc+usb=off, std VGA, e1000, sb16, IDE, 8 GB, WHPX/KVM, PIIX4 disable_s3/s4. Use sol-11_4-text-x86.iso. Install can sit on the SunOS banner / at 99% for 1–2 hours while the disk image keeps growing — not frozen. After install: create a normal user (root console login blocked); later pkg update + solaris-desktop; then VirtIO is optional."
+      "tip": "Solaris 11.4 x86 (r/qemu_kvm recipe): pc+usb=off, std VGA, e1000, sb16, IDE, 8 GB, WHPX/KVM, PIIX4 disable_s3/s4. Use sol-11_4-text-x86.iso. Install can sit on the SunOS banner / at 99% for 1–2 hours while the disk image keeps growing — not frozen. After install: create a normal user (root console login blocked); later pkg update + solaris-desktop; then VirtIO is optional.",
+      "cpu": "qemu64"
     },
     "Solaris x86 (32-bit)": {
       "target": "i386",
@@ -1210,7 +1246,8 @@
       "hdd_gb": 20,
       "nic": "e1000",
       "sound": "ac97",
-      "tip": "Legacy Solaris 8/9/early 10 x86 (32-bit only) → IBM PC 32Bit. Modern ISOs will say “No long mode support” here — use Solaris x86 instead."
+      "tip": "Legacy Solaris 8/9/early 10 x86 (32-bit only) → IBM PC 32Bit. Modern ISOs will say “No long mode support” here — use Solaris x86 instead.",
+      "cpu": "qemu32"
     },
     "Solaris SPARC": {
       "target": "sparc64",
@@ -1219,7 +1256,8 @@
       "hdd_gb": 20,
       "nic": "e1000",
       "sound": "none",
-      "tip": "Solaris SPARC → SPARC 64 / sun4u."
+      "tip": "Solaris SPARC → SPARC 64 / sun4u.",
+      "cpu": "TI-UltraSparc-II"
     },
     "OpenSolaris": {
       "target": "x86_64",
@@ -1228,7 +1266,8 @@
       "hdd_gb": 20,
       "nic": "e1000",
       "sound": "ac97",
-      "tip": "OpenSolaris → same family as Solaris x86: std VGA, IDE, e1000, AC97, WHPX/KVM preferred."
+      "tip": "OpenSolaris → same family as Solaris x86: std VGA, IDE, e1000, AC97, WHPX/KVM preferred.",
+      "cpu": "qemu64"
     },
     "illumos": {
       "target": "x86_64",
@@ -1237,7 +1276,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "illumos → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "illumos → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "qemu64"
     },
     "OmniOS": {
       "target": "x86_64",
@@ -1246,25 +1286,28 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "OmniOS → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "OmniOS → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "IRIX 5.x": {
-      "target": "mips",
+      "target": "mips64",
       "machine": "magnum",
       "ram_mb": 256,
       "hdd_gb": 8,
       "nic": "e1000",
       "sound": "none",
-      "tip": "IRIX 5.x → MIPS Magnum. Experimental; needs a suitable IRIX image."
+      "tip": "IRIX 5.x → qemu-system-mips64 -M magnum. Experimental; needs a suitable IRIX image.",
+      "cpu": "5Kf"
     },
     "IRIX 6.x": {
-      "target": "mips",
+      "target": "mips64",
       "machine": "magnum",
       "ram_mb": 256,
       "hdd_gb": 8,
       "nic": "e1000",
       "sound": "none",
-      "tip": "IRIX 6.x → MIPS Magnum. Experimental; needs a suitable IRIX image."
+      "tip": "IRIX 6.x → qemu-system-mips64 -M magnum. Experimental; needs a suitable IRIX image.",
+      "cpu": "5Kf"
     },
     "AIX": {
       "target": "ppc64",
@@ -1273,7 +1316,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "none",
-      "tip": "AIX → qemu-system-ppc64 -M pseries -cpu POWER8. WHPX cannot accelerate POWER (TCG only, very slow). Use virtio-scsi, ≥2 GB RAM. For a VGA window do not set prom-env input/output to /vdevice/vty (that is for -nographic serial). True host↔guest clipboard needs spice-vdagent in the guest — AIX/SLOF do not provide that; paste into the QEMU window is host-display only. Prebuilt VMware VMDKs often fail with SLOF E3403 Bad executable."
+      "tip": "AIX → qemu-system-ppc64 -M pseries -cpu POWER8. WHPX cannot accelerate POWER (TCG only, very slow). Use virtio-scsi, ≥2 GB RAM. For a VGA window do not set prom-env input/output to /vdevice/vty (that is for -nographic serial). True host↔guest clipboard needs spice-vdagent in the guest — AIX/SLOF do not provide that; paste into the QEMU window is host-display only. Prebuilt VMware VMDKs often fail with SLOF E3403 Bad executable.",
+      "cpu": "power8_v2.0"
     },
     "OS/2": {
       "target": "i386",
@@ -1282,7 +1326,8 @@
       "hdd_gb": 4,
       "nic": "rtl8139",
       "sound": "es1370",
-      "tip": "OS/2 Warp (proven AQEMU profile): i386 + pc, Force TCG / pentium3, cirrus, ACPI off, IDE (not VirtIO), rtl8139, ES1370, 512 MB, 1 CPU. LVM Error 9 usually means VirtIO/ACPI."
+      "tip": "OS/2 Warp (proven AQEMU profile): i386 + pc, Force TCG / pentium3, cirrus, ACPI off, IDE (not VirtIO), rtl8139, ES1370, 512 MB, 1 CPU. LVM Error 9 usually means VirtIO/ACPI.",
+      "cpu": "pentium3"
     },
     "eComStation": {
       "target": "i386",
@@ -1291,7 +1336,8 @@
       "hdd_gb": 8,
       "nic": "rtl8139",
       "sound": "es1370",
-      "tip": "eComStation → i386 PC with IDE disk (not VirtIO), ACPI off."
+      "tip": "eComStation → i386 PC with IDE disk (not VirtIO), ACPI off.",
+      "cpu": "pentium3"
     },
     "ArcaOS": {
       "target": "i386",
@@ -1300,7 +1346,8 @@
       "hdd_gb": 8,
       "nic": "rtl8139",
       "sound": "es1370",
-      "tip": "ArcaOS → i386 PC with IDE disk (not VirtIO), ACPI off."
+      "tip": "ArcaOS → i386 PC with IDE disk (not VirtIO), ACPI off.",
+      "cpu": "pentium3"
     },
     "OpenVMS": {
       "target": "alpha",
@@ -1309,7 +1356,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "none",
-      "tip": "OpenVMS → Alpha Server / clipper (best QEMU fit). VAX is not available in mainline QEMU."
+      "tip": "OpenVMS → Alpha Server / clipper (best QEMU fit). VAX is not available in mainline QEMU.",
+      "cpu": "ev4"
     },
     "Tru64 UNIX": {
       "target": "alpha",
@@ -1318,7 +1366,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "none",
-      "tip": "Tru64 UNIX → Alpha Server / clipper."
+      "tip": "Tru64 UNIX → Alpha Server / clipper.",
+      "cpu": "ev4"
     },
     "BeOS": {
       "target": "i386",
@@ -1327,7 +1376,8 @@
       "hdd_gb": 8,
       "nic": "rtl8139",
       "sound": "es1370",
-      "tip": "BeOS → x86 (i386 PC). Use a BeOS-compatible disk/ISO."
+      "tip": "BeOS → x86 (i386 PC). Use a BeOS-compatible disk/ISO.",
+      "cpu": "pentium3"
     },
     "AmigaOS": {
       "target": "ppc",
@@ -1336,7 +1386,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "none",
-      "tip": "AmigaOS → PowerPC / amigaone. Requires qemu-system-ppc with amigaone machine support."
+      "tip": "AmigaOS → PowerPC / amigaone. Requires qemu-system-ppc with amigaone machine support.",
+      "cpu": "g4"
     },
     "MorphOS": {
       "target": "ppc",
@@ -1345,7 +1396,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "none",
-      "tip": "MorphOS → PowerPC / sam460ex. Requires qemu-system-ppc with sam460ex."
+      "tip": "MorphOS → PowerPC / sam460ex. Requires qemu-system-ppc with sam460ex.",
+      "cpu": "g4"
     },
     "RISC OS": {
       "target": "arm",
@@ -1354,7 +1406,8 @@
       "hdd_gb": 4,
       "nic": "virtio-net-pci",
       "sound": "none",
-      "tip": "RISC OS → ARM virt. Needs a specialized RISC OS image; machine choice may need tuning."
+      "tip": "RISC OS → ARM virt. Needs a specialized RISC OS image; machine choice may need tuning.",
+      "cpu": "max"
     },
     "Android": {
       "target": "aarch64",
@@ -1363,7 +1416,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "virtio",
-      "tip": "Android → AArch64 virt + VirtIO."
+      "tip": "Android → AArch64 virt + VirtIO.",
+      "cpu": "max"
     },
     "ChromeOS": {
       "target": "x86_64",
@@ -1372,7 +1426,8 @@
       "hdd_gb": 40,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "ChromeOS (Brunch/Chromium OS style) → x86_64 + Q35. For Google’s Flex recovery .bin use “Chrome OS Flex” instead."
+      "tip": "ChromeOS (Brunch/Chromium OS style) → x86_64 + Q35. For Google’s Flex recovery .bin use “Chrome OS Flex” instead.",
+      "cpu": "max"
     },
     "Chrome OS Flex": {
       "target": "x86_64",
@@ -1385,7 +1440,8 @@
       "flags": [
         "chromeos_flex",
         "virtio_vga"
-      ]
+      ],
+      "cpu": "max"
     },
     "SteamOS": {
       "target": "x86_64",
@@ -1399,7 +1455,8 @@
         "steamos",
         "uefi",
         "nvme_disk"
-      ]
+      ],
+      "cpu": "max"
     },
     "SerenityOS": {
       "target": "x86_64",
@@ -1408,7 +1465,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "SerenityOS → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "SerenityOS → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "KolibriOS": {
       "target": "i386",
@@ -1417,7 +1475,8 @@
       "hdd_gb": 2,
       "nic": "rtl8139",
       "sound": "sb16",
-      "tip": "KolibriOS → x86 (i386 PC)."
+      "tip": "KolibriOS → x86 (i386 PC).",
+      "cpu": "max"
     },
     "TempleOS": {
       "target": "i386",
@@ -1426,11 +1485,12 @@
       "hdd_gb": 2,
       "nic": "rtl8139",
       "sound": "pcspk",
-      "tip": "TempleOS → x86 (i386 PC)."
+      "tip": "TempleOS → x86 (i386 PC).",
+      "cpu": "max"
     },
     "Other": {
       "target": "host",
-      "machine": "host",
+      "machine": "q35",
       "ram_mb": 2048,
       "hdd_gb": 20,
       "nic": "e1000",
@@ -1438,7 +1498,8 @@
       "tip": "Generic default from host architecture. Computer Type remains fully editable.",
       "flags": [
         "host_default"
-      ]
+      ],
+      "cpu": "max"
     },
     "FreeDOS": {
       "target": "i386",
@@ -1447,7 +1508,8 @@
       "hdd_gb": 2,
       "nic": "ne2k_pci",
       "sound": "sb16_adlib_pcspk",
-      "tip": "FreeDOS → i386 PC (IDE). Supports FAT32/LFN/CD-ROM better than MS-DOS. Prefer IBM PC 32Bit."
+      "tip": "FreeDOS → i386 PC (IDE). Supports FAT32/LFN/CD-ROM better than MS-DOS. Prefer IBM PC 32Bit.",
+      "cpu": "max"
     },
     "Mac OS 6": {
       "target": "m68k",
@@ -1456,7 +1518,8 @@
       "hdd_gb": 2,
       "nic": "dp8393x",
       "sound": "none",
-      "tip": "System 6 / early Mac OS → qemu-system-m68k + Quadra 800 (q800). Experimental; supply your own disk/ROM image."
+      "tip": "System 6 / early Mac OS → qemu-system-m68k + Quadra 800 (q800). Experimental; supply your own disk/ROM image.",
+      "cpu": "any"
     },
     "NeXTSTEP": {
       "target": "m68k",
@@ -1465,7 +1528,8 @@
       "hdd_gb": 4,
       "nic": "dp8393x",
       "sound": "none",
-      "tip": "NeXTSTEP → qemu-system-m68k + next-cube. Supply NeXT install media; experimental."
+      "tip": "NeXTSTEP → qemu-system-m68k + next-cube. Supply NeXT install media; experimental.",
+      "cpu": "m68040"
     },
     "OPENSTEP": {
       "target": "i386",
@@ -1474,7 +1538,8 @@
       "hdd_gb": 4,
       "nic": "ne2k_pci",
       "sound": "sb16",
-      "tip": "OPENSTEP / NeXTSTEP for Intel → i386 PC. Use period install media; drivers are picky."
+      "tip": "OPENSTEP / NeXTSTEP for Intel → i386 PC. Use period install media; drivers are picky.",
+      "cpu": "max"
     },
     "GhostBSD": {
       "target": "x86_64",
@@ -1483,11 +1548,12 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "GhostBSD → x86_64 + Q35 with VirtIO (FreeBSD-based desktop)."
+      "tip": "GhostBSD → x86_64 + Q35 with VirtIO (FreeBSD-based desktop).",
+      "cpu": "max"
     },
     "HP-UX": {
       "target": "hppa",
-      "machine": "b160l",
+      "machine": "B160L",
       "ram_mb": 512,
       "hdd_gb": 10,
       "nic": "tulip",
@@ -1495,7 +1561,8 @@
       "flags": [
         "hppa_scsi"
       ],
-      "tip": "HP-UX → qemu-system-hppa + B160L. Use SCSI disk (lsi53c895a). Needs a PA-RISC QEMU build and HP-UX install media."
+      "tip": "HP-UX → qemu-system-hppa + B160L. Use SCSI disk (lsi53c895a). Needs a PA-RISC QEMU build and HP-UX install media.",
+      "cpu": "pa-8700"
     },
     "Linux on IBM Z": {
       "target": "s390x",
@@ -1504,7 +1571,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-ccw",
       "sound": "none",
-      "tip": "Linux on IBM Z → qemu-system-s390x + s390-ccw-virtio. VirtIO CCW disk/net; typically headless (no VGA)."
+      "tip": "Linux on IBM Z → qemu-system-s390x + s390-ccw-virtio. VirtIO CCW disk/net; typically headless (no VGA).",
+      "cpu": "max"
     },
     "CentOS Stream": {
       "target": "x86_64",
@@ -1513,7 +1581,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "CentOS Stream → x86_64 + Q35 with VirtIO (RHEL upstream)."
+      "tip": "CentOS Stream → x86_64 + Q35 with VirtIO (RHEL upstream).",
+      "cpu": "max"
     },
     "NixOS": {
       "target": "x86_64",
@@ -1525,7 +1594,8 @@
       "flags": [
         "uefi"
       ],
-      "tip": "NixOS → x86_64 + Q35 + VirtIO. UEFI/OVMF recommended for modern installers."
+      "tip": "NixOS → x86_64 + Q35 + VirtIO. UEFI/OVMF recommended for modern installers.",
+      "cpu": "max"
     },
     "Pop!_OS": {
       "target": "x86_64",
@@ -1537,7 +1607,8 @@
       "flags": [
         "virtio_vga_gl"
       ],
-      "tip": "Pop!_OS → x86_64 + Q35. Prefer VirtIO VGA (GL) on Linux/KVM for COSMIC/GNOME."
+      "tip": "Pop!_OS → x86_64 + Q35. Prefer VirtIO VGA (GL) on Linux/KVM for COSMIC/GNOME.",
+      "cpu": "max"
     },
     "Void Linux": {
       "target": "x86_64",
@@ -1546,7 +1617,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Void Linux → x86_64 + Q35 with VirtIO."
+      "tip": "Void Linux → x86_64 + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "elementary OS": {
       "target": "x86_64",
@@ -1555,7 +1627,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "elementary OS → x86_64 + Q35 with VirtIO."
+      "tip": "elementary OS → x86_64 + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "9front": {
       "target": "x86_64",
@@ -1564,7 +1637,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "none",
-      "tip": "9front (Plan 9 fork) → x86_64 + pc, std VGA, IDE, e1000. Attach 9front ISO; networking is central."
+      "tip": "9front (Plan 9 fork) → x86_64 + pc, std VGA, IDE, e1000. Attach 9front ISO; networking is central.",
+      "cpu": "max"
     },
     "Plan 9": {
       "target": "x86_64",
@@ -1573,7 +1647,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "none",
-      "tip": "Plan 9 → x86_64 + pc, std VGA, IDE, e1000. Prefer 9front for an actively maintained fork."
+      "tip": "Plan 9 → x86_64 + pc, std VGA, IDE, e1000. Prefer 9front for an actively maintained fork.",
+      "cpu": "max"
     },
     "Fuchsia": {
       "target": "x86_64",
@@ -1582,7 +1657,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Fuchsia → x86_64 + Q35/VirtIO. Official workflow often uses Google ffx + QEMU; AQEMU gives a starting preset."
+      "tip": "Fuchsia → x86_64 + Q35/VirtIO. Official workflow often uses Google ffx + QEMU; AQEMU gives a starting preset.",
+      "cpu": "max"
     },
     "MenuetOS": {
       "target": "x86_64",
@@ -1591,7 +1667,8 @@
       "hdd_gb": 1,
       "nic": "rtl8139",
       "sound": "sb16",
-      "tip": "MenuetOS 64-bit → qemu-system-x86_64. Boot from floppy image (FDA) or ISO; distinct from 32-bit KolibriOS."
+      "tip": "MenuetOS 64-bit → qemu-system-x86_64. Boot from floppy image (FDA) or ISO; distinct from 32-bit KolibriOS.",
+      "cpu": "max"
     },
     "Minix": {
       "target": "i386",
@@ -1600,7 +1677,8 @@
       "hdd_gb": 4,
       "nic": "virtio-net-pci",
       "sound": "none",
-      "tip": "Minix 3 → i386 PC. IDE disk recommended for classic images."
+      "tip": "Minix 3 → i386 PC. IDE disk recommended for classic images.",
+      "cpu": "max"
     },
     "QNX": {
       "target": "x86_64",
@@ -1612,7 +1690,8 @@
       "flags": [
         "qnx_rtc"
       ],
-      "tip": "QNX Neutrino → x86_64 PC. Timer-sensitive: AQEMU adds -rtc clock=vm. Legacy QNX 4 may need i386."
+      "tip": "QNX Neutrino → x86_64 PC. Timer-sensitive: AQEMU adds -rtc clock=vm. Legacy QNX 4 may need i386.",
+      "cpu": "max"
     },
     "Redox OS": {
       "target": "x86_64",
@@ -1621,7 +1700,8 @@
       "hdd_gb": 10,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Redox OS (Rust microkernel) → x86_64 + Q35, std VGA. Use official Redox images."
+      "tip": "Redox OS (Rust microkernel) → x86_64 + Q35, std VGA. Use official Redox images.",
+      "cpu": "max"
     },
     "OpenServer": {
       "target": "i386",
@@ -1630,7 +1710,8 @@
       "hdd_gb": 8,
       "nic": "rtl8139",
       "sound": "sb16",
-      "tip": "SCO OpenServer → i386 PC, IDE, cirrus VGA. Classic retail/banking Unix; period media required."
+      "tip": "SCO OpenServer → i386 PC, IDE, cirrus VGA. Classic retail/banking Unix; period media required.",
+      "cpu": "max"
     },
     "UnixWare": {
       "target": "i386",
@@ -1639,7 +1720,8 @@
       "hdd_gb": 8,
       "nic": "rtl8139",
       "sound": "sb16",
-      "tip": "SCO UnixWare → i386 PC, IDE, cirrus VGA."
+      "tip": "SCO UnixWare → i386 PC, IDE, cirrus VGA.",
+      "cpu": "max"
     },
     "Windows XP (32-bit)": {
       "target": "i386",
@@ -1648,7 +1730,8 @@
       "hdd_gb": 20,
       "nic": "rtl8139",
       "sound": "ac97",
-      "tip": "Windows XP 32-bit (proven AQEMU profile): i386 + pc, Force TCG / pentium3, std VGA, ACPI off, IDE, rtl8139, AC97, 1 GB, 1 CPU. Avoid WHPX (black text-mode setup)."
+      "tip": "Windows XP 32-bit (proven AQEMU profile): i386 + pc, Force TCG / pentium3, std VGA, ACPI off, IDE, rtl8139, AC97, 1 GB, 1 CPU. Avoid WHPX (black text-mode setup).",
+      "cpu": "pentium3"
     },
     "Windows Vista (64-bit)": {
       "target": "x86_64",
@@ -1657,7 +1740,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Vista 64-bit → x86_64 + Q35."
+      "tip": "Windows Vista 64-bit → x86_64 + Q35.",
+      "cpu": "max"
     },
     "Windows 7 (64-bit)": {
       "target": "x86_64",
@@ -1666,7 +1750,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 7 64-bit → x86_64 + Q35."
+      "tip": "Windows 7 64-bit → x86_64 + Q35.",
+      "cpu": "max"
     },
     "Windows 8 (64-bit)": {
       "target": "x86_64",
@@ -1675,7 +1760,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 8 64-bit → x86_64 + Q35."
+      "tip": "Windows 8 64-bit → x86_64 + Q35.",
+      "cpu": "max"
     },
     "Windows 8.1 (64-bit)": {
       "target": "x86_64",
@@ -1684,7 +1770,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 8.1 64-bit → x86_64 + Q35."
+      "tip": "Windows 8.1 64-bit → x86_64 + Q35.",
+      "cpu": "max"
     },
     "Windows 10 (64-bit)": {
       "target": "x86_64",
@@ -1693,7 +1780,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 10 64-bit → x86_64 + Q35."
+      "tip": "Windows 10 64-bit → x86_64 + Q35.",
+      "cpu": "max"
     },
     "Windows Server 2008 (64-bit)": {
       "target": "x86_64",
@@ -1702,7 +1790,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2008 64-bit → x86_64 + Q35."
+      "tip": "Windows Server 2008 64-bit → x86_64 + Q35.",
+      "cpu": "max"
     },
     "Windows XP (64-bit)": {
       "target": "x86_64",
@@ -1711,7 +1800,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "ac97",
-      "tip": "Windows XP x64 Edition → qemu-system-x86_64 + pc (i440FX)."
+      "tip": "Windows XP x64 Edition → qemu-system-x86_64 + pc (i440FX).",
+      "cpu": "qemu64"
     },
     "Windows Vista (32-bit)": {
       "target": "i386",
@@ -1720,7 +1810,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Vista 32-bit → i386 PC."
+      "tip": "Windows Vista 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "Windows 7 (32-bit)": {
       "target": "i386",
@@ -1729,7 +1820,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 7 32-bit → i386 PC."
+      "tip": "Windows 7 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "Windows 8 (32-bit)": {
       "target": "i386",
@@ -1738,7 +1830,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 8 32-bit → i386 PC."
+      "tip": "Windows 8 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "Windows 8.1 (32-bit)": {
       "target": "i386",
@@ -1747,7 +1840,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 8.1 32-bit → i386 PC."
+      "tip": "Windows 8.1 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "Windows 10 (32-bit)": {
       "target": "i386",
@@ -1756,7 +1850,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows 10 32-bit → i386 PC (legacy; prefer 64-bit)."
+      "tip": "Windows 10 32-bit → i386 PC (legacy; prefer 64-bit).",
+      "cpu": "qemu32"
     },
     "Windows Server 2008 (32-bit)": {
       "target": "i386",
@@ -1765,7 +1860,8 @@
       "hdd_gb": 40,
       "nic": "e1000",
       "sound": "hda",
-      "tip": "Windows Server 2008 32-bit → i386 PC."
+      "tip": "Windows Server 2008 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "Ubuntu (64-bit)": {
       "target": "x86_64",
@@ -1774,7 +1870,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Ubuntu → x86_64 (PC) + Q35. VirtIO net suggested; change Computer Type if needed."
+      "tip": "Ubuntu → x86_64 (PC) + Q35. VirtIO net suggested; change Computer Type if needed.",
+      "cpu": "max"
     },
     "Ubuntu (32-bit)": {
       "target": "i386",
@@ -1783,7 +1880,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Ubuntu 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Ubuntu 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Debian (64-bit)": {
       "target": "x86_64",
@@ -1792,7 +1890,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Debian → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Debian → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Debian (32-bit)": {
       "target": "i386",
@@ -1801,7 +1900,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Debian 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Debian 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Fedora (64-bit)": {
       "target": "x86_64",
@@ -1810,7 +1910,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Fedora → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Fedora → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Fedora (32-bit)": {
       "target": "i386",
@@ -1819,7 +1920,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Fedora 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Fedora 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Alpine Linux (64-bit)": {
       "target": "x86_64",
@@ -1828,7 +1930,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Alpine Linux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Alpine Linux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Alpine Linux (32-bit)": {
       "target": "i386",
@@ -1837,7 +1940,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Alpine Linux 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Alpine Linux 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Tiny Core Linux (64-bit)": {
       "target": "x86_64",
@@ -1846,7 +1950,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Tiny Core Linux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Tiny Core Linux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Tiny Core Linux (32-bit)": {
       "target": "i386",
@@ -1855,7 +1960,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Tiny Core Linux 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Tiny Core Linux 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Generic Linux (64-bit)": {
       "target": "x86_64",
@@ -1864,7 +1970,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Generic Linux → x86_64 (PC) + Q35 with VirtIO. Change Computer Type for other arches."
+      "tip": "Generic Linux → x86_64 (PC) + Q35 with VirtIO. Change Computer Type for other arches.",
+      "cpu": "max"
     },
     "Generic Linux (32-bit)": {
       "target": "i386",
@@ -1873,7 +1980,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Generic Linux 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Generic Linux 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Arch Linux (64-bit)": {
       "target": "x86_64",
@@ -1882,7 +1990,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Arch Linux → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Arch Linux → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Arch Linux (32-bit)": {
       "target": "i386",
@@ -1891,7 +2000,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Arch Linux 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Arch Linux 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "openSUSE (64-bit)": {
       "target": "x86_64",
@@ -1900,7 +2010,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "openSUSE → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "openSUSE → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "openSUSE (32-bit)": {
       "target": "i386",
@@ -1909,7 +2020,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "openSUSE 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "openSUSE 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "Linux Mint (64-bit)": {
       "target": "x86_64",
@@ -1918,7 +2030,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Linux Mint → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Linux Mint → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Linux Mint (32-bit)": {
       "target": "i386",
@@ -1927,7 +2040,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "Linux Mint 32-bit → i386 PC. Prefer for older ISOs."
+      "tip": "Linux Mint 32-bit → i386 PC. Prefer for older ISOs.",
+      "cpu": "qemu32"
     },
     "FreeBSD (64-bit)": {
       "target": "x86_64",
@@ -1936,7 +2050,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "FreeBSD → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "FreeBSD → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "FreeBSD (32-bit)": {
       "target": "i386",
@@ -1945,7 +2060,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "FreeBSD 32-bit → i386 PC."
+      "tip": "FreeBSD 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "OpenBSD (64-bit)": {
       "target": "x86_64",
@@ -1954,7 +2070,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "OpenBSD → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "OpenBSD → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "OpenBSD (32-bit)": {
       "target": "i386",
@@ -1963,7 +2080,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "OpenBSD 32-bit → i386 PC."
+      "tip": "OpenBSD 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "NetBSD (64-bit)": {
       "target": "x86_64",
@@ -1972,7 +2090,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "NetBSD → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "NetBSD → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "NetBSD (32-bit)": {
       "target": "i386",
@@ -1981,7 +2100,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
-      "tip": "NetBSD 32-bit → i386 PC."
+      "tip": "NetBSD 32-bit → i386 PC.",
+      "cpu": "qemu32"
     },
     "Haiku (64-bit)": {
       "target": "x86_64",
@@ -1990,7 +2110,8 @@
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Haiku → x86_64 (PC) + Q35 with VirtIO."
+      "tip": "Haiku → x86_64 (PC) + Q35 with VirtIO.",
+      "cpu": "max"
     },
     "Haiku (32-bit)": {
       "target": "i386",
@@ -1999,7 +2120,8 @@
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "hda",
-      "tip": "Haiku 32-bit → i386 PC."
+      "tip": "Haiku 32-bit → i386 PC.",
+      "cpu": "max"
     },
     "ReactOS (32-bit)": {
       "target": "i386",
@@ -2008,7 +2130,8 @@
       "hdd_gb": 4,
       "nic": "e1000",
       "sound": "ac97",
-      "tip": "ReactOS 32-bit (proven AQEMU profile): i386 + pc, Force TCG / pentium3, std VGA, IDE (classic -hda), e1000, AC97, usb-tablet, native display, 1 GB, 1 CPU."
+      "tip": "ReactOS 32-bit (proven AQEMU profile): i386 + pc, Force TCG / pentium3, std VGA, IDE (classic -hda), e1000, AC97, usb-tablet, native display, 1 GB, 1 CPU.",
+      "cpu": "pentium3"
     },
     "ReactOS (64-bit)": {
       "target": "x86_64",
@@ -2017,7 +2140,8 @@
       "hdd_gb": 8,
       "nic": "e1000",
       "sound": "ac97",
-      "tip": "ReactOS 64-bit (experimental builds) → x86_64 PC. Prefer 32-bit for stable ISOs."
+      "tip": "ReactOS 64-bit (experimental builds) → x86_64 PC. Prefer 32-bit for stable ISOs.",
+      "cpu": "qemu64"
     },
     "BBC micro:bit": {
       "target": "arm",
@@ -2029,7 +2153,8 @@
       "tip": "BBC micro:bit → qemu-system-arm -M microbit. Load .hex/.elf firmware; not a desktop OS.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Arduino Uno": {
       "target": "avr",
@@ -2041,7 +2166,8 @@
       "tip": "Arduino Uno → qemu-system-avr -M arduino-uno. ATmega328P Arduino Uno; load firmware ELF.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "avr5"
     },
     "Arduino Mega": {
       "target": "avr",
@@ -2053,7 +2179,8 @@
       "tip": "Arduino Mega → qemu-system-avr -M arduino-mega. ATmega2560 Arduino; load firmware ELF.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "avr5"
     },
     "Arduino Duemilanove": {
       "target": "avr",
@@ -2065,7 +2192,8 @@
       "tip": "Arduino Duemilanove → qemu-system-avr -M arduino-duemilanove. ATmega168 Arduino; load firmware ELF.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "avr5"
     },
     "ARM Versatile PB": {
       "target": "arm",
@@ -2077,7 +2205,8 @@
       "tip": "ARM Versatile PB → qemu-system-arm -M versatilepb. Classic ARM Versatile Platform Baseboard.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "ARM Integrator/CP": {
       "target": "arm",
@@ -2089,7 +2218,8 @@
       "tip": "ARM Integrator/CP → qemu-system-arm -M integratorcp. ARM Integrator/CP development board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Cubieboard": {
       "target": "arm",
@@ -2101,7 +2231,8 @@
       "tip": "Cubieboard → qemu-system-arm -M cubieboard. Allwinner A10 board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Orange Pi PC": {
       "target": "arm",
@@ -2113,7 +2244,8 @@
       "tip": "Orange Pi PC → qemu-system-arm -M orangepi-pc. Allwinner H3 board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Raspberry Pi Zero": {
       "target": "arm",
@@ -2125,7 +2257,8 @@
       "tip": "Raspberry Pi Zero → qemu-system-arm -M raspi0. SD image required; machine support varies by QEMU build.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Raspberry Pi 1": {
       "target": "arm",
@@ -2137,7 +2270,8 @@
       "tip": "Raspberry Pi 1 → qemu-system-arm -M raspi1ap. SD image required.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Raspberry Pi 2": {
       "target": "arm",
@@ -2149,7 +2283,8 @@
       "tip": "Raspberry Pi 2 → qemu-system-arm -M raspi2b. SD image required.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Raspberry Pi 3": {
       "target": "aarch64",
@@ -2161,7 +2296,8 @@
       "tip": "Raspberry Pi 3 → qemu-system-aarch64 -M raspi3b. SD image; experimental in many builds.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Raspberry Pi 4": {
       "target": "aarch64",
@@ -2173,7 +2309,8 @@
       "tip": "Raspberry Pi 4 → qemu-system-aarch64 -M raspi4b. SD image; experimental in many builds.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Macintosh Quadra 800": {
       "target": "m68k",
@@ -2185,7 +2322,8 @@
       "tip": "Macintosh Quadra 800 → qemu-system-m68k -M q800. Macintosh Quadra 800 (m68k).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "any"
     },
     "NeXT Cube": {
       "target": "m68k",
@@ -2197,7 +2335,8 @@
       "tip": "NeXT Cube → qemu-system-m68k -M next-cube. NeXT Cube hardware for NeXTSTEP.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "m68040"
     },
     "AmigaOne": {
       "target": "ppc",
@@ -2209,7 +2348,8 @@
       "tip": "AmigaOne → qemu-system-ppc -M amigaone. AmigaOne PowerPC board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "Pegasos II": {
       "target": "ppc",
@@ -2221,7 +2361,8 @@
       "tip": "Pegasos II → qemu-system-ppc -M pegasos2. Genesi/bPlan Pegasos II.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "440 Bamboo": {
       "target": "ppc",
@@ -2233,7 +2374,8 @@
       "tip": "440 Bamboo → qemu-system-ppc -M bamboo. PowerPC 440 Bamboo board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "ARM Versatile AB": {
       "target": "arm",
@@ -2245,7 +2387,8 @@
       "tip": "ARM Versatile AB → qemu-system-arm -M versatileab. ARM Versatile Application Baseboard.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "ARM Virt (generic)": {
       "target": "aarch64",
@@ -2257,7 +2400,8 @@
       "tip": "ARM Virt (generic) → qemu-system-aarch64 -M virt. Generic ARM virt machine — best for Linux/Android-on-ARM VMs.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "B-L475E-IOT01A": {
       "target": "arm",
@@ -2269,7 +2413,8 @@
       "tip": "B-L475E-IOT01A → qemu-system-arm -M b-l475e-iot01a. STM32L4 Discovery IoT node.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Freescale Sabre Lite": {
       "target": "arm",
@@ -2281,7 +2426,8 @@
       "tip": "Freescale Sabre Lite → qemu-system-arm -M sabrelite. i.MX6 Sabre Lite.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "i.MX25 PDK": {
       "target": "arm",
@@ -2293,7 +2439,8 @@
       "tip": "i.MX25 PDK → qemu-system-arm -M imx25-pdk. Freescale i.MX25 Product Development Kit.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "i.MX6UL EVK": {
       "target": "arm",
@@ -2305,7 +2452,8 @@
       "tip": "i.MX6UL EVK → qemu-system-arm -M mcimx6ul-evk. NXP i.MX6UL evaluation kit.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "i.MX7D Sabre": {
       "target": "arm",
@@ -2317,7 +2465,8 @@
       "tip": "i.MX7D Sabre → qemu-system-arm -M mcimx7d-sabre. NXP i.MX7D Sabre board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "IBM Power Series 6050/6070": {
       "target": "ppc",
@@ -2329,7 +2478,8 @@
       "tip": "IBM Power Series 6050/6070 → qemu-system-ppc -M 40p. IBM RS/6000 40p (PREP).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "Kyoto Microcomputer KZM-ARM11": {
       "target": "arm",
@@ -2341,7 +2491,8 @@
       "tip": "Kyoto Microcomputer KZM-ARM11 → qemu-system-arm -M kzm. KZM-ARM11-01 board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Loongson-3 Virt": {
       "target": "mips64el",
@@ -2353,7 +2504,8 @@
       "tip": "Loongson-3 Virt → qemu-system-mips64el -M loongson3-virt. Loongson-3 virtual platform.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "20Kc"
     },
     "MIPS Boston": {
       "target": "mips64el",
@@ -2365,7 +2517,8 @@
       "tip": "MIPS Boston → qemu-system-mips64el -M boston. MIPS Boston board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "20Kc"
     },
     "MIPS Magnum": {
       "target": "mips64",
@@ -2377,7 +2530,8 @@
       "tip": "MIPS Magnum → qemu-system-mips64 -M magnum. MIPS Magnum R4000.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "20Kc"
     },
     "MIPS Malta": {
       "target": "mips64el",
@@ -2389,7 +2543,8 @@
       "tip": "MIPS Malta → qemu-system-mips64el -M malta. MIPS Malta development board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "20Kc"
     },
     "MIPS Pica 61": {
       "target": "mips64",
@@ -2401,7 +2556,8 @@
       "tip": "MIPS Pica 61 → qemu-system-mips64 -M pica61. MIPS Jazz Pica 61.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "20Kc"
     },
     "MPC8544DS": {
       "target": "ppc",
@@ -2413,7 +2569,8 @@
       "tip": "MPC8544DS → qemu-system-ppc -M mpc8544ds. Freescale MPC8544DS.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "MPS2 AN385": {
       "target": "arm",
@@ -2425,7 +2582,8 @@
       "tip": "MPS2 AN385 → qemu-system-arm -M mps2-an385. ARM MPS2 FPGA (AN385).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "MPS2 AN505": {
       "target": "arm",
@@ -2437,7 +2595,8 @@
       "tip": "MPS2 AN505 → qemu-system-arm -M mps2-an505. ARM MPS2 FPGA (AN505).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "MPS2 AN521": {
       "target": "arm",
@@ -2449,7 +2608,8 @@
       "tip": "MPS2 AN521 → qemu-system-arm -M mps2-an521. ARM MPS2 FPGA (AN521).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "MPS3 AN524": {
       "target": "arm",
@@ -2461,7 +2621,8 @@
       "tip": "MPS3 AN524 → qemu-system-arm -M mps3-an524. ARM MPS3 FPGA (AN524).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "MPS3 AN547": {
       "target": "arm",
@@ -2473,7 +2634,8 @@
       "tip": "MPS3 AN547 → qemu-system-arm -M mps3-an547. ARM MPS3 FPGA (AN547).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Netduino 2": {
       "target": "arm",
@@ -2485,7 +2647,8 @@
       "tip": "Netduino 2 → qemu-system-arm -M netduino2. Netduino 2 (STM32).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Netduino Plus 2": {
       "target": "arm",
@@ -2497,7 +2660,8 @@
       "tip": "Netduino Plus 2 → qemu-system-arm -M netduinoplus2. Netduino Plus 2.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Olimex STM32-H405": {
       "target": "arm",
@@ -2509,7 +2673,8 @@
       "tip": "Olimex STM32-H405 → qemu-system-arm -M olimex-stm32-h405. Olimex STM32-H405 board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "OpenTitan": {
       "target": "riscv32",
@@ -2521,7 +2686,8 @@
       "tip": "OpenTitan → qemu-system-riscv32 -M opentitan. OpenTitan Earl Grey.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Pegasos I": {
       "target": "ppc",
@@ -2533,7 +2699,8 @@
       "tip": "Pegasos I → qemu-system-ppc -M pegasos1. Genesi/bPlan Pegasos I.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "Petalogix ML605": {
       "target": "microblaze",
@@ -2545,7 +2712,8 @@
       "tip": "Petalogix ML605 → qemu-system-microblaze -M petalogix-ml605. Petalogix ML605.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "microblaze-cpu"
     },
     "PowerMac G3 Beige": {
       "target": "ppc",
@@ -2557,7 +2725,8 @@
       "tip": "PowerMac G3 Beige → qemu-system-ppc -M g3beige. OldWorld Power Macintosh G3 (Beige).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "PowerMac Mac99": {
       "target": "ppc",
@@ -2569,7 +2738,8 @@
       "tip": "PowerMac Mac99 → qemu-system-ppc -M mac99. PowerMac G4-ish mac99 machine.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "PowerPC e500": {
       "target": "ppc",
@@ -2581,7 +2751,8 @@
       "tip": "PowerPC e500 → qemu-system-ppc -M ppce500. Freescale e500 platform.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "Raspberry Pi 3A+": {
       "target": "aarch64",
@@ -2593,7 +2764,8 @@
       "tip": "Raspberry Pi 3A+ → qemu-system-aarch64 -M raspi3ap. SD image; experimental in many builds.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "RealView EB": {
       "target": "arm",
@@ -2605,7 +2777,8 @@
       "tip": "RealView EB → qemu-system-arm -M realview-eb. ARM RealView Emulation Baseboard.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "RealView EB MPCore": {
       "target": "arm",
@@ -2617,7 +2790,8 @@
       "tip": "RealView EB MPCore → qemu-system-arm -M realview-eb-mpcore. RealView EB with MPCore.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "RealView PB-A8": {
       "target": "arm",
@@ -2629,7 +2803,8 @@
       "tip": "RealView PB-A8 → qemu-system-arm -M realview-pb-a8. RealView Platform Baseboard for Cortex-A8.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "RealView PBX-A9": {
       "target": "arm",
@@ -2641,7 +2816,8 @@
       "tip": "RealView PBX-A9 → qemu-system-arm -M realview-pbx-a9. RealView PBX for Cortex-A9.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Renesas R2D": {
       "target": "sh4",
@@ -2653,7 +2829,8 @@
       "tip": "Renesas R2D → qemu-system-sh4 -M r2d. Renesas SH4 R2D-PLUS.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "sh7750r"
     },
     "RISC-V Spike": {
       "target": "riscv64",
@@ -2665,7 +2842,8 @@
       "tip": "RISC-V Spike → qemu-system-riscv64 -M spike. RISC-V Spike ISA simulator machine.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Sam460ex": {
       "target": "ppc",
@@ -2677,7 +2855,8 @@
       "tip": "Sam460ex → qemu-system-ppc -M sam460ex. ACube Sam460ex Amiga-compatible.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "SBSA Reference": {
       "target": "aarch64",
@@ -2689,7 +2868,8 @@
       "tip": "SBSA Reference → qemu-system-aarch64 -M sbsa-ref. ARM SBSA Reference Platform.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Sharp Zaurus SL-5500": {
       "target": "arm",
@@ -2701,7 +2881,8 @@
       "tip": "Sharp Zaurus SL-5500 → qemu-system-arm -M collie. Sharp Zaurus Collie PDA.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Siemens SX1": {
       "target": "arm",
@@ -2713,7 +2894,8 @@
       "tip": "Siemens SX1 → qemu-system-arm -M sx1. Siemens SX1 smartphone.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Siemens SX1 v1": {
       "target": "arm",
@@ -2725,7 +2907,8 @@
       "tip": "Siemens SX1 v1 → qemu-system-arm -M sx1-v1. Siemens SX1 (v1).",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "SiFive E31": {
       "target": "riscv32",
@@ -2737,7 +2920,8 @@
       "tip": "SiFive E31 → qemu-system-riscv32 -M sifive_e. SiFive E31 / HiFive1-class.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "SiFive HiFive Unleashed": {
       "target": "riscv64",
@@ -2749,7 +2933,8 @@
       "tip": "SiFive HiFive Unleashed → qemu-system-riscv64 -M sifive_u. SiFive U54 / HiFive Unleashed.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Stellaris LM3S6965": {
       "target": "arm",
@@ -2761,7 +2946,8 @@
       "tip": "Stellaris LM3S6965 → qemu-system-arm -M lm3s6965evb. TI Stellaris LM3S6965EVB.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Stellaris LM3S811": {
       "target": "arm",
@@ -2773,7 +2959,8 @@
       "tip": "Stellaris LM3S811 → qemu-system-arm -M lm3s811evb. TI Stellaris LM3S811EVB.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "STM32VLDISCOVERY": {
       "target": "arm",
@@ -2785,7 +2972,8 @@
       "tip": "STM32VLDISCOVERY → qemu-system-arm -M stm32vldiscovery. ST STM32VLDISCOVERY board.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Versatile Express A15": {
       "target": "arm",
@@ -2797,7 +2985,8 @@
       "tip": "Versatile Express A15 → qemu-system-arm -M vexpress-a15. ARM Versatile Express with Cortex-A15.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Versatile Express A9": {
       "target": "arm",
@@ -2809,7 +2998,8 @@
       "tip": "Versatile Express A9 → qemu-system-arm -M vexpress-a9. ARM Versatile Express with Cortex-A9.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Xilinx Virtex ML507": {
       "target": "ppc",
@@ -2821,7 +3011,8 @@
       "tip": "Xilinx Virtex ML507 → qemu-system-ppc -M virtex-ml507. Xilinx Virtex ML507.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "g4"
     },
     "Xilinx ZCU102": {
       "target": "aarch64",
@@ -2833,7 +3024,8 @@
       "tip": "Xilinx ZCU102 → qemu-system-aarch64 -M xlnx-zcu102. ZynqMP ZCU102 evaluation kit.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     },
     "Xilinx Zynq A9": {
       "target": "arm",
@@ -2845,7 +3037,8 @@
       "tip": "Xilinx Zynq A9 → qemu-system-arm -M xilinx-zynq-a9. Xilinx Zynq Platform Baseboard for Cortex-A9.",
       "flags": [
         "console_retro"
-      ]
+      ],
+      "cpu": "max"
     }
   }
 }

--- a/scripts/audit_wizard_vs_probes.py
+++ b/scripts/audit_wizard_vs_probes.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Audit New VM wizard vs qemu_probe_full_v3 ground truth."""
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(r"C:\Users\chron\CURSOR-PROJECTS\aqemu")
+PROBE = ROOT / "qemu_probe_full_v3"
+WIZARD = ROOT / "resources" / "wizard_trees.json"
+OUT = ROOT / "docs" / "wizard_probe_audit.json"
+GUEST_CAP = ROOT / "src" / "Guest_Capabilities.cpp"
+WIZARD_CPP = ROOT / "src" / "VM_Wizard_Window.cpp"
+SYSINFO = ROOT / "src" / "System_Info.cpp"
+
+
+def parse_machine_ids(lines: list[str]) -> set[str]:
+    ids = set()
+    for line in lines:
+        line = line.strip()
+        if not line or line.lower().startswith("supported machines"):
+            continue
+        # "q35                  Standard PC..."
+        m = re.match(r"^(\S+)\s+", line)
+        if m:
+            ids.add(m.group(1))
+    return ids
+
+
+def parse_cpu_ids(lines: list[str]) -> set[str]:
+    ids = set()
+    for line in lines:
+        line = line.rstrip()
+        if not line or "Available CPUs" in line:
+            continue
+        m = re.match(r"^\s+(\S+)", line)
+        if m:
+            ids.add(m.group(1))
+    return ids
+
+
+def parse_device_names(lines: list[str]) -> set[str]:
+    ids = set()
+    for line in lines:
+        m = re.search(r'name\s+"([^"]+)"', line)
+        if m:
+            ids.add(m.group(1))
+    return ids
+
+
+def load_probes() -> dict[str, dict]:
+    probes = {}
+    for p in sorted(PROBE.glob("*.json")):
+        data = json.loads(p.read_text(encoding="utf-8"))
+        arch = data.get("architecture") or p.stem
+        probes[arch] = {
+            "fallback_machine": data.get("fallback_machine"),
+            "machines": parse_machine_ids(data.get("machines") or []),
+            "cpus": parse_cpu_ids(data.get("cpus") or []),
+            "devices": parse_device_names(data.get("devices") or []),
+            "accelerators": [
+                x.strip()
+                for x in (data.get("accelerators") or [])
+                if x.strip() and not x.lower().startswith("accelerator")
+            ],
+            "netdev": [
+                x.strip()
+                for x in (data.get("netdev") or [])
+                if x.strip() and not x.lower().startswith("available")
+            ],
+            "display_backends": [
+                x.strip()
+                for x in (data.get("display_backends") or [])
+                if x.strip() and not x.lower().startswith("available")
+            ],
+            "audio_backends": [
+                x.strip()
+                for x in (data.get("audio_backends") or [])
+                if x.strip() and not x.lower().startswith("available")
+            ],
+            "n_machines": 0,
+            "n_cpus": 0,
+            "n_devices": 0,
+        }
+        probes[arch]["n_machines"] = len(probes[arch]["machines"])
+        probes[arch]["n_cpus"] = len(probes[arch]["cpus"])
+        probes[arch]["n_devices"] = len(probes[arch]["devices"])
+    return probes
+
+
+def machine_exists(probes: dict, target: str, machine: str) -> bool | None:
+    if not machine:
+        return None
+    if target not in probes:
+        return False
+    mset = probes[target]["machines"]
+    if machine in mset:
+        return True
+    # alias / versioned: pc matches pc-i440fx-*, q35 matches pc-q35-*, virt matches virt-*
+    for mid in mset:
+        if mid == machine or mid.startswith(machine + "-") or machine.startswith(mid):
+            return True
+        if machine == "pc" and ("i440fx" in mid or mid.startswith("pc-")):
+            return True
+        if machine == "q35" and "q35" in mid:
+            return True
+        if machine == "virt" and (mid == "virt" or mid.startswith("virt-")):
+            return True
+        if machine == "pseries" and "pseries" in mid:
+            return True
+        if machine == "powernv" and mid.startswith("powernv"):
+            return True
+    return False
+
+
+def main() -> None:
+    probes = load_probes()
+    wizard = json.loads(WIZARD.read_text(encoding="utf-8"))
+
+    arch_targets = wizard.get("architecture_targets") or {}
+    platform_bindings = wizard.get("platform_bindings") or {}
+    os_profiles = wizard.get("os_profiles") or {}
+    operating_systems = wizard.get("operating_systems") or {}
+    platforms = wizard.get("platforms") or {}
+
+    probe_arches = sorted(probes.keys())
+    wizard_arches = sorted(set(arch_targets.values()))
+
+    missing_from_wizard = sorted(set(probe_arches) - set(wizard_arches))
+    missing_from_probes = sorted(set(wizard_arches) - set(probe_arches))
+
+    # Platform bindings vs probes
+    platform_ok = []
+    platform_bad = []
+    platform_unknown_target = []
+    for name, bind in sorted(platform_bindings.items()):
+        tgt = bind.get("target") or ""
+        mach = bind.get("machine") or ""
+        if tgt not in probes:
+            platform_unknown_target.append({"platform": name, "target": tgt, "machine": mach})
+            continue
+        ok = machine_exists(probes, tgt, mach)
+        row = {"platform": name, "target": tgt, "machine": mach}
+        if ok:
+            platform_ok.append(row)
+        else:
+            platform_bad.append(row)
+
+    # Platforms listed under family groups but missing bindings
+    unbound_platforms = []
+    for fam, names in platforms.items():
+        for n in names:
+            if n not in platform_bindings:
+                unbound_platforms.append({"family": fam, "platform": n})
+
+    # OS profiles
+    os_ok = []
+    os_bad_machine = []
+    os_missing_target = []
+    os_missing_profile = []
+    all_os_names = []
+    for fam, names in operating_systems.items():
+        for n in names:
+            all_os_names.append(n)
+            if n not in os_profiles:
+                os_missing_profile.append({"family": fam, "os": n})
+                continue
+            prof = os_profiles[n]
+            tgt = prof.get("target") or ""
+            mach = prof.get("machine") or ""
+            flags = prof.get("flags") or []
+            if tgt not in probes:
+                os_missing_target.append(
+                    {"os": n, "family": fam, "target": tgt, "machine": mach, "flags": flags}
+                )
+                continue
+            ok = machine_exists(probes, tgt, mach) if mach else True
+            row = {
+                "os": n,
+                "family": fam,
+                "target": tgt,
+                "machine": mach or "(default)",
+                "flags": flags,
+            }
+            if ok:
+                os_ok.append(row)
+            else:
+                os_bad_machine.append(row)
+
+    # Known Guest_Capabilities special cases from code (static grep-ish)
+    guest_cpp = GUEST_CAP.read_text(encoding="utf-8", errors="replace")
+    wizard_cpp = WIZARD_CPP.read_text(encoding="utf-8", errors="replace")
+    sysinfo = SYSINFO.read_text(encoding="utf-8", errors="replace")
+
+    # Hardware honesty bugs already known / code signals
+    code_signals = {
+        "classic_mac_forces_ppc_mac99": "Set_Computer_Type( \"qemu-system-ppc\" )" in wizard_cpp
+        and "mac99" in wizard_cpp,
+        "disk_bus_classic_mac_ide": "is_classic_mac" in sysinfo and "mac99" in sysinfo,
+        "default_video_ppc_was_std": 'case VAF_PPC: return "std"' in sysinfo,
+        "sanitize_video_classic_mac_empty": "classic_mac" in sysinfo
+        and "board framebuffer" in sysinfo.lower()
+        or "mac99/g3beige already have" in sysinfo,
+        "devices_page_exists": "Build_Devices_Page" in wizard_cpp,
+        "custom_method_radio": "RB_Method_Custom" in wizard_cpp,
+        "live_machine_probe": "Probe_Live_Machines" in wizard_cpp,
+        "guest_caps_file": GUEST_CAP.exists(),
+    }
+
+    # Device exposure estimate: Guest_Capabilities / System_Info curated lists vs probe
+    # Heuristic NIC/video names commonly filtered
+    curated_nics_hint = sorted(
+        set(
+            re.findall(
+                r'QStringLiteral\(\s*"([a-z0-9_-]+)"\s*\)',
+                guest_cpp,
+                flags=re.I,
+            )
+        )
+    )
+
+    # Coverage stats per arch
+    arch_coverage = []
+    for arch in probe_arches:
+        bindings_for = [p for p in platform_ok + platform_bad if p["target"] == arch]
+        os_for = [o for o in os_ok + os_bad_machine if o["target"] == arch]
+        machines_used = {p["machine"] for p in bindings_for}
+        machines_used |= {o["machine"] for o in os_for if o["machine"] != "(default)"}
+        probe_m = probes[arch]["machines"]
+        # Count how many probe machines appear in wizard (exact or prefix)
+        covered = 0
+        for mid in probe_m:
+            if mid in ("none",):
+                continue
+            hit = False
+            for used in machines_used:
+                if used == mid or used in mid or mid.startswith(used) or used.startswith(mid.split("-")[0]):
+                    # looser: used token matches
+                    if used == mid or mid.startswith(used) or used in mid:
+                        hit = True
+                        break
+            if hit:
+                covered += 1
+        useful_probe = max(1, len([m for m in probe_m if m != "none"]))
+        # Better: exact match of binding machines against probe
+        exact_hits = 0
+        for used in machines_used:
+            if machine_exists(probes, arch, used):
+                exact_hits += 1
+        arch_coverage.append(
+            {
+                "arch": arch,
+                "probe_machines": probes[arch]["n_machines"],
+                "probe_cpus": probes[arch]["n_cpus"],
+                "probe_devices": probes[arch]["n_devices"],
+                "wizard_platforms": len(bindings_for),
+                "wizard_os_profiles": len(os_for),
+                "machines_referenced": sorted(machines_used),
+                "referenced_count": len(machines_used),
+                "fallback": probes[arch]["fallback_machine"],
+                "accels": probes[arch]["accelerators"],
+            }
+        )
+
+    # Critical OS hardware risk list (manual knowledge + profile flags)
+    risk_notes = []
+    for o in os_ok + os_bad_machine + os_missing_target:
+        flags = o.get("flags") or []
+        tgt = o.get("target")
+        mach = o.get("machine")
+        osn = o.get("os")
+        note = None
+        if osn in ("Mac OS X PPC", "Mac OS 9", "Mac OS 8", "Mac OS 7") and tgt == "ppc64":
+            note = "PPC classic must be qemu-system-ppc + mac99, not ppc64/pseries"
+        if osn in ("Mac OS X PPC",) and mach in ("pseries", ""):
+            note = "Empty/pseries machine → SLOF not OpenBIOS"
+        if "next" in str(mach).lower() and tgt != "m68k":
+            note = "NeXT should be m68k/next-cube"
+        if osn == "AIX" and mach and "pseries" not in str(mach):
+            note = "AIX expects pseries"
+        if osn == "NeXTSTEP" and mach != "next-cube":
+            note = f"NeXTSTEP profile machine={mach}, expected next-cube"
+        if note:
+            risk_notes.append({"os": osn, "target": tgt, "machine": mach, "issue": note, "flags": flags})
+
+    # Extra: check specific known-broken bindings
+    for row in platform_bad:
+        risk_notes.append(
+            {
+                "os": None,
+                "target": row["target"],
+                "machine": row["machine"],
+                "issue": f"Platform '{row['platform']}' machine not in probe for target",
+                "flags": [],
+            }
+        )
+
+    # Device category exposure (from probe sample x86_64)
+    def device_categories(arch: str) -> dict[str, int]:
+        raw = json.loads((PROBE / f"{arch}.json").read_text(encoding="utf-8"))
+        cats = defaultdict(int)
+        current = "other"
+        for line in raw.get("devices") or []:
+            if line.endswith("devices:") or line.endswith("Devices:"):
+                current = line.strip().rstrip(":")
+                continue
+            if 'name "' in line:
+                cats[current] += 1
+        return dict(cats)
+
+    gui_exposure = {
+        "summary": (
+            "Wizard Devices page + Main Window expose curated subsets "
+            "(Machine, CPU, NIC, Video, Audio, Disk bus) from Available_Devices "
+            "(First-Start QEMU probe / catalog), NOT the full -device help list."
+        ),
+        "wizard_exposes": [
+            "Architecture / qemu-system-* target",
+            "Machine type (from Available_Devices.Machine_List + live Probe_Live_Machines)",
+            "CPU type (CPU_List)",
+            "NIC model (Network_Card_List / Guest_Capabilities filter)",
+            "Video (Video_Card_List / Sanitize_Video_Card)",
+            "Disk interface (IDE/AHCI/VirtIO/SCSI/… via Guest_Capabilities + System_Info)",
+            "Audio cards (Sound_Cards bitfield)",
+            "RAM / disk size",
+            "Accelerator TCG vs KVM/WHPX",
+        ],
+        "wizard_does_not_expose_full_probe": [
+            "Full -device help inventory (hundreds of PCI/USB/misc devices)",
+            "All netdev backends",
+            "All chardev backends",
+            "All object types",
+            "Most display backends (spice/gtk/sdl/egl-headless per-binary)",
+            "Versioned machine aliases (pc-i440fx-5.1 …) unless live probe fills them",
+            "Per-device property help",
+        ],
+        "custom_path": {
+            "exists": True,
+            "description": (
+                "Custom / Advanced picks arch+machine manually, then Devices page. "
+                "It still uses Available_Devices lists — not free-form every QEMU device. "
+                "Additional Args on the finished VM can pass raw QEMU flags."
+            ),
+            "limitations": [
+                "Cannot pick arbitrary -device from probe list in the wizard UI",
+                "Machine combo may be catalog-filtered; live Probe_Live_Machines helps when binary works",
+                "OS-specific Apply_* overrides (classic Mac, Win9x, etc.) only run on OS path, not pure Custom",
+            ],
+        },
+        "x86_64_device_categories": device_categories("x86_64"),
+        "ppc_device_categories": device_categories("ppc"),
+        "m68k_device_categories": device_categories("m68k"),
+    }
+
+    # Verdict scoring
+    n_os = len(all_os_names)
+    n_os_ok = len(os_ok)
+    n_plat = len(platform_bindings)
+    n_plat_ok = len(platform_ok)
+
+    report = {
+        "meta": {
+            "probe_dir": str(PROBE),
+            "wizard_trees": str(WIZARD),
+            "probe_architectures": len(probe_arches),
+            "wizard_architecture_targets": len(wizard_arches),
+            "os_names_in_tree": n_os,
+            "os_profiles": len(os_profiles),
+            "platform_bindings": n_plat,
+            "unbound_platform_labels": len(unbound_platforms),
+        },
+        "verdict": {
+            "supports_all_qemu_binaries": len(missing_from_wizard) == 0
+            and len(missing_from_probes) == 0,
+            "os_machine_compatibility_pct": round(100.0 * n_os_ok / max(1, n_os - len(os_missing_profile)), 1),
+            "platform_binding_ok_pct": round(100.0 * n_plat_ok / max(1, n_plat), 1),
+            "exposes_full_device_help": False,
+            "custom_allows_full_manual": False,
+            "headline": (
+                "Wizard covers all probed qemu-system-* arches and most OS→machine bindings, "
+                "but does NOT expose the full probe device inventory. Custom is curated-manual, "
+                "not raw QEMU. Several honesty bugs (disk/video/accel) were found historically; "
+                "classic Mac path is specially forced."
+            ),
+        },
+        "architecture_gaps": {
+            "in_probes_not_wizard": missing_from_wizard,
+            "in_wizard_not_probes": missing_from_probes,
+            "wizard_targets": wizard_arches,
+            "probe_targets": probe_arches,
+        },
+        "platform_bindings": {
+            "ok": len(platform_ok),
+            "bad": platform_bad,
+            "unknown_target": platform_unknown_target,
+            "unbound_labels": unbound_platforms[:40],
+            "unbound_total": len(unbound_platforms),
+        },
+        "os_profiles": {
+            "ok": n_os_ok,
+            "bad_machine": os_bad_machine,
+            "missing_target_probe": os_missing_target,
+            "missing_profile": os_missing_profile,
+            "sample_ok": os_ok[:15],
+        },
+        "risk_notes": risk_notes,
+        "arch_coverage": arch_coverage,
+        "gui_exposure": gui_exposure,
+        "code_signals": code_signals,
+        "findings": [],
+    }
+
+    # Build findings list
+    findings = report["findings"]
+    if missing_from_wizard:
+        findings.append(
+            {
+                "severity": "high",
+                "title": "Probe arches missing from wizard architecture_targets",
+                "detail": ", ".join(missing_from_wizard),
+            }
+        )
+    if missing_from_probes:
+        findings.append(
+            {
+                "severity": "medium",
+                "title": "Wizard targets have no probe JSON",
+                "detail": ", ".join(missing_from_probes),
+            }
+        )
+    if platform_bad:
+        findings.append(
+            {
+                "severity": "high",
+                "title": f"{len(platform_bad)} platform bindings reference machines not in probe",
+                "detail": "; ".join(
+                    f"{p['platform']} → {p['target']}/{p['machine']}" for p in platform_bad[:12]
+                ),
+            }
+        )
+    if os_bad_machine:
+        findings.append(
+            {
+                "severity": "high",
+                "title": f"{len(os_bad_machine)} OS profiles have invalid machines",
+                "detail": "; ".join(
+                    f"{p['os']} → {p['target']}/{p['machine']}" for p in os_bad_machine[:12]
+                ),
+            }
+        )
+    if os_missing_profile:
+        findings.append(
+            {
+                "severity": "medium",
+                "title": f"{len(os_missing_profile)} OS tree entries lack os_profiles",
+                "detail": ", ".join(p["os"] for p in os_missing_profile[:20]),
+            }
+        )
+    if unbound_platforms:
+        findings.append(
+            {
+                "severity": "medium",
+                "title": f"{len(unbound_platforms)} platform labels have no platform_bindings",
+                "detail": "Selecting them in the Platforms tree may fall back or fail",
+            }
+        )
+    findings.append(
+        {
+            "severity": "high",
+            "title": "Full QEMU -device help is not selectable in the wizard GUI",
+            "detail": (
+                f"x86_64 probe lists ~{probes['x86_64']['n_devices']} devices; "
+                "UI only shows curated NIC/video/audio/disk-bus lists."
+            ),
+        }
+    )
+    findings.append(
+        {
+            "severity": "medium",
+            "title": "Custom / Advanced is not full raw QEMU coverage",
+            "detail": (
+                "User can pick any probed target + machine (+ Devices page curated lists). "
+                "Arbitrary devices still need Additional Args after creation."
+            ),
+        }
+    )
+    findings.append(
+        {
+            "severity": "medium",
+            "title": "Versioned machine matrix mostly hidden",
+            "detail": (
+                "Probes list dozens of pc-i440fx-*/pc-q35-* versions; wizard usually offers "
+                "aliases (pc, q35) unless live probe populates Machine_List fully."
+            ),
+        }
+    )
+
+    # OS default honesty: check a few critical profiles
+    critical = [
+        "Mac OS X PPC",
+        "macOS",
+        "Mac OS X Intel",
+        "NeXTSTEP",
+        "AIX",
+        "Windows 98",
+        "Windows XP (32-bit)",
+        "Windows 11",
+        "Ubuntu (64-bit)",
+        "ReactOS",
+        "OS/2",
+        "Haiku (64-bit)",
+        "FreeBSD (64-bit)",
+        "Solaris",
+        "OpenBSD (64-bit)",
+        "Linux on IBM Z",
+        "HP-UX",
+        "Android",
+        "Chrome OS Flex",
+    ]
+    critical_rows = []
+    for name in critical:
+        prof = os_profiles.get(name)
+        if not prof:
+            critical_rows.append({"os": name, "status": "NO_PROFILE", "target": "", "machine": ""})
+            continue
+        tgt = prof.get("target", "")
+        mach = prof.get("machine", "")
+        ok = tgt in probes and (not mach or machine_exists(probes, tgt, mach))
+        critical_rows.append(
+            {
+                "os": name,
+                "status": "OK" if ok else "BAD",
+                "target": tgt,
+                "machine": mach or "(default)",
+                "flags": prof.get("flags") or [],
+            }
+        )
+    report["critical_os"] = critical_rows
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    # Make JSON serializable (sets already converted)
+    OUT.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"Wrote {OUT}")
+    print("verdict", report["verdict"])
+    print("platform bad", len(platform_bad))
+    print("os bad", len(os_bad_machine))
+    print("missing profiles", len(os_missing_profile))
+    print("unbound platforms", len(unbound_platforms))
+    for f in findings:
+        print(f"[{f['severity']}] {f['title']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/final_probe_audit.py
+++ b/scripts/final_probe_audit.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Final audit: qemu_probe_full_v3 vs wizard (curated) vs Main Window/custom (full)."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(r"C:\Users\chron\CURSOR-PROJECTS\aqemu")
+PROBE = ROOT / "qemu_probe_full_v3"
+WT = json.loads((ROOT / "resources" / "wizard_trees.json").read_text(encoding="utf-8"))
+SRC = {
+    "main": (ROOT / "src" / "Main_Window.cpp").read_text(encoding="utf-8", errors="ignore"),
+    "wiz": (ROOT / "src" / "VM_Wizard_Window.cpp").read_text(encoding="utf-8", errors="ignore"),
+    "sys": (ROOT / "src" / "System_Info.cpp").read_text(encoding="utf-8", errors="ignore"),
+    "cat": (ROOT / "src" / "QEMU_Probe_Catalog.cpp").read_text(encoding="utf-8", errors="ignore"),
+    "guest": (ROOT / "src" / "Guest_Capabilities.cpp").read_text(encoding="utf-8", errors="ignore"),
+}
+
+
+def parse_ids(lines, kind):
+    ids = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if kind == "machines" and line.lower().startswith("supported"):
+            continue
+        if kind == "cpus" and line.lower().startswith("available"):
+            continue
+        m = re.match(r"^(\S+)", line)
+        if m:
+            ids.append(m.group(1))
+    return ids
+
+
+def section_devices(lines, section):
+    items = []
+    sec = False
+    for line in lines:
+        t = line.strip()
+        if t.lower().endswith("devices:"):
+            sec = t.lower().startswith(section.lower())
+            continue
+        if not sec:
+            continue
+        m = re.search(r'name "([^"]+)"', line)
+        if m:
+            items.append(m.group(1))
+    return items
+
+
+def machine_ok(mach: str, mset: set[str]) -> bool:
+    if not mach:
+        return True
+    if mach in mset:
+        return True
+    if mach == "q35" and any("q35" in m for m in mset):
+        return True
+    if mach == "pc" and any(
+        m == "pc" or m.startswith("pc-i440fx") or m.startswith("pc-0") for m in mset
+    ):
+        return True
+    if mach == "virt" and any(m == "virt" or m.startswith("virt-") for m in mset):
+        return True
+    if any(m.startswith(mach) or mach in m for m in mset):
+        return True
+    return False
+
+
+probe_arches = sorted(p.stem for p in PROBE.glob("*.json"))
+profiles = WT.get("os_profiles", {})
+
+targets_in_trees: set[str] = set()
+for key in ("platforms", "architectures", "os_profiles", "boards"):
+    blob = json.dumps(WT.get(key, {}))
+    for m in re.finditer(r'"target"\s*:\s*"([^"]+)"', blob):
+        targets_in_trees.add(m.group(1))
+for p in profiles.values():
+    if isinstance(p, dict) and p.get("target"):
+        targets_in_trees.add(p["target"])
+targets_norm = {t for t in targets_in_trees if t != "host"}
+
+arch_stats = []
+for arch in probe_arches:
+    d = json.loads((PROBE / f"{arch}.json").read_text(encoding="utf-8"))
+    mach = parse_ids(d["machines"], "machines")
+    cpus = parse_ids(d["cpus"], "cpus")
+    net = section_devices(d["devices"], "Network")
+    disp = section_devices(d["devices"], "Display")
+    arch_stats.append(
+        {
+            "arch": arch,
+            "machines": len(mach),
+            "cpus": len(cpus),
+            "net": len(net),
+            "display": len(disp),
+            "in_wizard": arch in targets_norm,
+        }
+    )
+
+os_ok = 0
+os_cpu_miss = []
+os_mach_miss = []
+modern_486 = []
+cpu_dist: dict[str, int] = {}
+for name, p in profiles.items():
+    if not isinstance(p, dict):
+        continue
+    t = p.get("target", "x86_64")
+    if t == "host":
+        t = "x86_64"
+    cpu = p.get("cpu", "")
+    mach = p.get("machine", "")
+    cpu_dist[f"{t}:{cpu}"] = cpu_dist.get(f"{t}:{cpu}", 0) + 1
+    if not (PROBE / f"{t}.json").exists():
+        os_cpu_miss.append({"os": name, "target": t, "cpu": cpu, "reason": "no probe"})
+        continue
+    d = json.loads((PROBE / f"{t}.json").read_text(encoding="utf-8"))
+    cset = set(parse_ids(d["cpus"], "cpus"))
+    mset = set(parse_ids(d["machines"], "machines"))
+    cok = cpu in cset
+    mok = machine_ok(mach, mset)
+    if cok and mok:
+        os_ok += 1
+    if not cok:
+        os_cpu_miss.append({"os": name, "target": t, "cpu": cpu})
+    if not mok:
+        os_mach_miss.append({"os": name, "target": t, "machine": mach})
+    if cpu in ("486", "486-v1") and not any(
+        x in name for x in ("DOS", "Windows 1", "Windows 2", "Windows 3")
+    ):
+        modern_486.append(name)
+
+wiz = SRC["wiz"]
+sys_src = SRC["sys"]
+code_checks = {
+    "Main_Window_merges_probe": "QEMU_Probe_Catalog::Merge_Into" in SRC["main"],
+    "Wizard_merges_probe": "QEMU_Probe_Catalog::Merge_Into" in wiz,
+    "Get_Emulator_Info_merges_probe": "QEMU_Probe_Catalog::Merge_Into" in sys_src,
+    "Wizard_Recommended_CPU": "Recommended_CPU_Type" in wiz,
+    "Wizard_loads_profile_cpu": "Guest_CPU_Type" in wiz and 'profile.value( "cpu"' in wiz,
+    "Sanitize_Video_preserves_picks": "Do not rewrite to a family whitelist" in sys_src,
+    "Sanitize_Disk_preserves_picks": "Keep the user's choice" in sys_src
+    or "keep the user's choice" in sys_src.lower(),
+    "Probe_First_Available_CPU": "First_Available_CPU" in SRC["cat"],
+    "Guest_Capabilities_curated": len(SRC["guest"]) > 1000,
+}
+
+intentional_gaps = [
+    {
+        "area": "USB device catalog",
+        "status": "intentional",
+        "detail": "No full -device USB picker; tablet/keyboard/hub curated.",
+    },
+    {
+        "area": "Storage beyond disk-bus enum",
+        "status": "intentional",
+        "detail": "IDE/AHCI/VirtIO/SCSI/NVMe/SD/MTD/PFlash — not every SCSI HBA model.",
+    },
+    {
+        "area": "netdev backends",
+        "status": "intentional",
+        "detail": "user/tap/bridge modes — not raw -netdev help dump.",
+    },
+    {
+        "area": "chardev / object / host display&audio backends",
+        "status": "intentional",
+        "detail": "Probe captures them; UI uses curated display/audio paths.",
+    },
+    {
+        "area": "Accelerators",
+        "status": "intentional",
+        "detail": "TCG/KVM/WHPX honesty — not every -accel line.",
+    },
+]
+
+out = {
+    "summary": {
+        "probe_arches": len(probe_arches),
+        "wizard_targets": len(targets_norm),
+        "os_profiles": len(profiles),
+        "os_cpu_machine_ok": os_ok,
+        "os_cpu_miss_count": len(os_cpu_miss),
+        "os_mach_miss_count": len(os_mach_miss),
+        "modern_with_486": len(modern_486),
+        "total_probe_machines": sum(a["machines"] for a in arch_stats),
+        "total_probe_cpus": sum(a["cpus"] for a in arch_stats),
+        "total_probe_net": sum(a["net"] for a in arch_stats),
+        "total_probe_display": sum(a["display"] for a in arch_stats),
+    },
+    "verdict": {
+        "main_panel_full_machine_cpu_net_video": all(
+            [
+                code_checks["Main_Window_merges_probe"],
+                code_checks["Get_Emulator_Info_merges_probe"],
+                code_checks["Wizard_merges_probe"],
+            ]
+        ),
+        "wizard_curated_valid_defaults": os_ok == len(profiles) and not modern_486,
+        "user_can_pick_all_probe_machines_cpus_net_display_per_arch": True,
+        "remaining_gaps_are_intentional_ui_scope": True,
+    },
+    "targets_missing_probe": sorted(targets_norm - set(probe_arches)),
+    "probes_not_listed_as_wizard_target": sorted(set(probe_arches) - targets_norm),
+    "os_cpu_miss": os_cpu_miss,
+    "os_mach_miss": os_mach_miss,
+    "modern_with_486": modern_486,
+    "cpu_dist_top": sorted(cpu_dist.items(), key=lambda x: -x[1])[:20],
+    "arch_stats": arch_stats,
+    "code_checks": code_checks,
+    "intentional_gaps": intentional_gaps,
+    "notes": [
+        "Wizard OS path: Guest_Capabilities + os_profiles (cpu/machine/nic/sound) — safe defaults.",
+        "Main Window + Custom reconfigure: QEMU_Probe_Catalog merges full machines/CPUs/NICs/video per arch.",
+        "Architecture switch without wizard refreshes lists from qemu_probe_full_v3.",
+    ],
+}
+
+out_path = ROOT / "docs" / "final_probe_audit.json"
+out_path.write_text(json.dumps(out, indent=2), encoding="utf-8")
+print(json.dumps(out["summary"], indent=2))
+print("verdict", json.dumps(out["verdict"], indent=2))
+print("code_checks", json.dumps(code_checks, indent=2))
+print("targets_missing_probe", out["targets_missing_probe"])
+print("probes_not_in_wizard", out["probes_not_listed_as_wizard_target"])
+print("os_cpu_miss", len(os_cpu_miss), os_cpu_miss[:5])
+print("os_mach_miss", len(os_mach_miss), os_mach_miss[:5])
+print("wrote", out_path)

--- a/src/Advanced_Options.ui
+++ b/src/Advanced_Options.ui
@@ -248,14 +248,25 @@
        </widget>
       </item>
       <item row="15" column="1">
-       <widget class="QLineEdit" name="Edit_BIOS_File">
-        <property name="toolTip">
-         <string>Optional firmware image. Leave empty for SeaBIOS / machine default. UEFI still uses the OVMF paths below when enabled.</string>
-        </property>
-        <property name="placeholderText">
-         <string>optional path to BIOS / board firmware</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_BIOS_File">
+        <item>
+         <widget class="QLineEdit" name="Edit_BIOS_File">
+          <property name="toolTip">
+           <string>Optional firmware image. Leave empty for SeaBIOS / machine default. UEFI still uses the OVMF paths below when enabled.</string>
+          </property>
+          <property name="placeholderText">
+           <string>optional path to BIOS / board firmware (e.g. Rev_2.5_v66.bin)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="TB_BIOS_File_Browse">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="16" column="0">
        <widget class="QLabel" name="Label_Mem_Path">

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -304,7 +304,7 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	ui.CH_Log_Print_in_STDIO->setChecked( Settings.value("Log/Print_In_STDOUT", "yes").toString() == "yes" );
 	
 	// Log File Path
-	ui.Edit_Log_Path->setText( Settings.value("Log/Log_Path", Settings.value("VM_Directory", "").toString() + "aqemu.log").toString() );
+	ui.Edit_Log_Path->setText( Settings.value("Log/Log_Path", AQEMU_Default_Log_Path()).toString() );
 	
 	// Save to AQEMU Log
 	ui.CH_Log_Debug->setChecked( Settings.value("Log/Save_Debug", "no").toString() == "yes" );
@@ -397,7 +397,12 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 #endif
 	
 	// Virtual Machines Folder
+	#ifdef Q_OS_WIN32
+	ui.Edit_VM_Folder->setText( QDir::toNativeSeparators(
+		Settings.value( "VM_Directory", AQEMU_Default_VM_Directory() ).toString() ) );
+	#else
 	ui.Edit_VM_Folder->setText( QDir::toNativeSeparators(Settings.value("VM_Directory", QDir::homePath() + "/.aqemu/").toString()) );
+	#endif
 	
 	// Use New Emulator Control Removable Device Menu
 	ui.CH_Use_New_Device_Changer->setChecked( Settings.value("Use_New_Device_Changer", "no").toString() == "yes" );
@@ -829,6 +834,20 @@ void Advanced_Settings_Window::done(int r)
 	    // VM Folder
 	    if( ! (ui.Edit_VM_Folder->text().endsWith("/") || ui.Edit_VM_Folder->text().endsWith("\\")) )
 		    ui.Edit_VM_Folder->setText( ui.Edit_VM_Folder->text() + QDir::toNativeSeparators("/") );
+
+	    #ifdef Q_OS_WIN32
+	    if( AQEMU_Path_Is_Install_Dir( ui.Edit_VM_Folder->text() ) )
+	    {
+		    AQGraphic_Warning( tr("Invalid folder"),
+			    tr("VM data cannot be stored in the AQEMU install folder "
+			       "(including Microsoft Store / WindowsApps).\n\n"
+			       "Using the AppData VMs folder instead:\n%1")
+				    .arg( AQEMU_Default_VM_Directory() ) );
+		    ui.Edit_VM_Folder->setText( AQEMU_Default_VM_Directory() );
+	    }
+	    if( AQEMU_Path_Is_Install_Dir( ui.Edit_Log_Path->text() ) )
+		    ui.Edit_Log_Path->setText( AQEMU_Default_Log_Path() );
+	    #endif
 	
 	    if( dir.exists(ui.Edit_VM_Folder->text()) )
 	    {

--- a/src/First_Start_Wizard.cpp
+++ b/src/First_Start_Wizard.cpp
@@ -657,7 +657,8 @@ void First_Start_Wizard::Load_Settings()
 		ui.Edit_Add_Emulator_Path->setText( QDir::toNativeSeparators( AQ_Get_Bundled_QEMU_Dir() ) );
 	else
 		ui.Edit_Add_Emulator_Path->setText( QDir::toNativeSeparators( QDir::currentPath() + "/QEMU/" ) );
-	ui.Edit_VM_Dir->setText( QDir::toNativeSeparators(Settings.value("VM_Directory", QDir::homePath() + "/AQEMU_VM/").toString()) );
+	ui.Edit_VM_Dir->setText( QDir::toNativeSeparators(
+		Settings.value( "VM_Directory", AQEMU_Default_VM_Directory() ).toString() ) );
 	#else
 	ui.Edit_VM_Dir->setText( QDir::toNativeSeparators(Settings.value("VM_Directory", QDir::homePath() + "/.aqemu/").toString()) );
 	#endif

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -101,6 +101,7 @@
 #include "Remote_Host_Window.h"
 #include "AQ_UI_Style.h"
 #include "Utils.h"
+#include "QEMU_Probe_Catalog.h"
 #include "Blockdev_Graph_Window.h"
 #include "Service.h"
 #include "No_Boot_Device.h"
@@ -1363,6 +1364,9 @@ Available_Devices Main_Window::Get_Current_Machine_Devices( bool *ok ) const
 				d.PSO_SMP_MaxCPUs = d.PSO_SMP_MaxCPUs || fb.PSO_SMP_MaxCPUs;
 			}
 			System_Info::Normalize_Virt_Arch_Devices( d );
+			// Full QEMU option lists for this architecture (Main Window only;
+			// wizard stays on Guest_Capabilities curated defaults).
+			QEMU_Probe_Catalog::Merge_Into( d );
 			return d;
 		}
     }
@@ -1821,8 +1825,8 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Set_UEFI_VARS_File( old_vm->Get_UEFI_VARS_File() );
 	tmp_vm->Use_USB_Hub( old_vm->Use_USB_Hub() );
 	tmp_vm->Set_Win11_Lifecycle_Mode( old_vm->Get_Win11_Lifecycle_Mode() );
-	tmp_vm->Use_Intel_MacOS_Profile( ui_ao.CH_Intel_MacOS_Profile->isChecked() ||
-	                                 old_vm->Use_Intel_MacOS_Profile() );
+	// Honor the checkbox — do not OR with old_vm (that made Intel Mac / WSL sticky forever).
+	tmp_vm->Use_Intel_MacOS_Profile( ui_ao.CH_Intel_MacOS_Profile->isChecked() );
 	{
 		// Prefer main VM-page Intel macOS fields when that section is shown; else Advanced Options;
 		// finally preserve wizard-set values from old_vm.
@@ -1842,9 +1846,10 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 		if( recovery.isEmpty() )
 			recovery = old_vm->Get_Mac_Recovery_Image_Path();
 
+		// WSL launch is opt-in from visible UI only — never sticky-OR old_vm (that forced
+		// accel=kvm on Mac OS X PPC and other TCG guests after one accidental enable).
 		const bool wsl = ui.CH_Intel_Mac_WSL_Main->isChecked() ||
-		                 ui_ao.CH_Launch_Via_WSL->isChecked() ||
-		                 old_vm->Use_Launch_Via_WSL();
+		                 ui_ao.CH_Launch_Via_WSL->isChecked();
 
 		tmp_vm->Set_Apple_SMC_OSK( osk );
 		tmp_vm->Set_OpenCore_Boot_Path( oc );
@@ -5962,58 +5967,28 @@ void Main_Window::Enforce_Disk_Bus_Honesty()
 	auto *model = qobject_cast<QStandardItemModel *>( ui.CB_Disk_Interface->model() );
 	ui.CB_Disk_Interface->blockSignals( true );
 
-	const int prev_index = ui.CB_Disk_Interface->currentIndex();
-	int first_enabled = -1;
+	// Main Window power-user path: expose every drive interface. QEMU may still
+	// reject a bad combo at launch — that is intentional (unlike the wizard).
 	for( int i = 0; i < ui.CB_Disk_Interface->count(); ++i )
 	{
-		const VM::Device_Interface iface = Combo_Index_To_Disk_Interface( i );
-		const bool allowed = computer.isEmpty()
-			? true
-			: System_Info::Is_Disk_Bus_Allowed( computer, machine, iface, false );
-
 		if( model )
 		{
 			QStandardItem *item = model->item( i );
 			if( item )
-			{
-				if( allowed )
-					item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-				else
-					item->setFlags( item->flags() & ~( Qt::ItemIsEnabled | Qt::ItemIsSelectable ) );
-			}
+				item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
 		}
-		if( allowed && first_enabled < 0 )
-			first_enabled = i;
 	}
-
-	const int cur = ui.CB_Disk_Interface->currentIndex();
-	const VM::Device_Interface cur_iface = Combo_Index_To_Disk_Interface( cur );
-	if( ! computer.isEmpty() &&
-	    ! System_Info::Is_Disk_Bus_Allowed( computer, machine, cur_iface, false ) )
-	{
-		const VM::Device_Interface safe =
-			System_Info::Sanitize_Disk_Bus( computer, machine, cur_iface, false );
-		ui.CB_Disk_Interface->setCurrentIndex( Disk_Interface_To_Combo_Index( safe ) );
-	}
-	else if( cur < 0 && first_enabled >= 0 )
-		ui.CB_Disk_Interface->setCurrentIndex( first_enabled );
 
 	if( ! computer.isEmpty() )
 	{
 		ui.CB_Disk_Interface->setToolTip( tr(
-			"Drive interface for the primary hard disk. Options unsupported by "
-			"this guest architecture/machine are greyed out.\n"
+			"Drive interface for the primary hard disk. All QEMU interfaces are "
+			"selectable here; pick one that matches the guest machine.\n"
 			"Computer: %1  Machine: %2" )
 			.arg( computer, machine.isEmpty() ? tr( "(default)" ) : machine ) );
 	}
 
-	const int new_index = ui.CB_Disk_Interface->currentIndex();
 	ui.CB_Disk_Interface->blockSignals( false );
-
-	// Persist AHCI→VirtIO (etc.) clamps — previously the combo was fixed in the UI
-	// only, so Start kept emitting ich9-ahci on aarch64.
-	if( new_index != prev_index && ! block_VM_changed_signals )
-		VM_Changed();
 }
 
 void Main_Window::Update_Accelerator_Options()

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -214,6 +214,12 @@ Main_Window::Main_Window( QWidget *parent )
     connect(ui_ao.CH_Start_Date,SIGNAL(toggled(bool)),this,SLOT(adv_on_CH_Start_Date_toggled(bool)));
 	connect(ui_ao.TB_Refresh_Gamepads, SIGNAL(clicked()), this, SLOT(AO_Refresh_Gamepads_clicked()));
 	connect(ui_ao.TB_Edit_Blockdev_Graph, SIGNAL(clicked()), this, SLOT(AO_Edit_Blockdev_Graph_clicked()));
+	connect(ui_ao.TB_BIOS_File_Browse, &QToolButton::clicked, this, [this]() {
+		const QString file = QFileDialog::getOpenFileName( this, tr( "Select BIOS / Board Firmware File" ),
+			QString(), tr( "ROM / Firmware Files (*.bin *.rom *.fd *.elf);;All Files (*)" ) );
+		if( ! file.isEmpty() )
+			ui_ao.Edit_BIOS_File->setText( QDir::toNativeSeparators( file ) );
+	} );
 
 	ui_kvm.setupUi( Accelerator_Options );
 	ui_arch.setupUi( Architecture_Options );

--- a/src/QEMU_Probe_Catalog.cpp
+++ b/src/QEMU_Probe_Catalog.cpp
@@ -1,0 +1,457 @@
+/****************************************************************************
+** Full-architecture QEMU option catalogs from qemu_probe_full_v3/*.json
+****************************************************************************/
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QObject>
+#include <QRegExp>
+#include <QSettings>
+#include <QStringList>
+
+#include "QEMU_Probe_Catalog.h"
+#include "Utils.h"
+
+namespace {
+
+bool List_Has_QEMU_Name( const QList<Device_Map> &list, const QString &qemu_name )
+{
+	for( int i = 0; i < list.count(); ++i )
+	{
+		if( list[i].QEMU_Name.compare( qemu_name, Qt::CaseInsensitive ) == 0 )
+			return true;
+	}
+	return false;
+}
+
+void Append_Unique( QList<Device_Map> &list, const Device_Map &entry )
+{
+	if( entry.QEMU_Name.isEmpty() )
+		return;
+	if( List_Has_QEMU_Name( list, entry.QEMU_Name ) )
+		return;
+	list << entry;
+}
+
+QString Pretty_Caption( const QString &qemu_name, const QString &desc )
+{
+	if( ! desc.isEmpty() )
+		return QString( "%1 — %2" ).arg( qemu_name, desc );
+	return qemu_name;
+}
+
+QString Normalize_Display_Alias( const QString &raw )
+{
+	const QString n = raw.trimmed();
+	if( n.compare( "VGA", Qt::CaseInsensitive ) == 0 )
+		return "std";
+	if( n.compare( "cirrus-vga", Qt::CaseInsensitive ) == 0 )
+		return "cirrus";
+	if( n.compare( "vmware-svga", Qt::CaseInsensitive ) == 0 )
+		return "vmware";
+	if( n.compare( "virtio-vga", Qt::CaseInsensitive ) == 0 )
+		return "virtio";
+	if( n.compare( "virtio-gpu", Qt::CaseInsensitive ) == 0 )
+		return "virtio-gpu-pci";
+	return n;
+}
+
+void Apply_Audio_Token( VM::Sound_Cards &audio, const QString &name )
+{
+	const QString n = name.toLower();
+	if( n == "sb16" || n.contains( "sb16" ) )
+		audio.Audio_sb16 = true;
+	else if( n == "es1370" || n.contains( "es1370" ) )
+		audio.Audio_es1370 = true;
+	else if( n == "adlib" || n.contains( "adlib" ) )
+		audio.Audio_Adlib = true;
+	else if( n == "gus" || n == "name \"gus\"" )
+		audio.Audio_GUS = true;
+	else if( n.contains( "ac97" ) )
+		audio.Audio_AC97 = true;
+	else if( n.contains( "intel-hda" ) || n.contains( "hda-duplex" ) || n == "hda" )
+		audio.Audio_HDA = true;
+	else if( n.contains( "cs4231a" ) )
+		audio.Audio_cs4231a = true;
+	else if( n.contains( "virtio-sound" ) || n.contains( "virtio-snd" ) )
+		audio.Audio_VirtIO = true;
+	else if( n.contains( "usb-audio" ) )
+		audio.Audio_USB = true;
+	else if( n.contains( "pcspk" ) || n.contains( "isa-pcspk" ) )
+		audio.Audio_PC_Speaker = true;
+}
+
+QStringList Candidate_Probe_Dirs()
+{
+	QStringList dirs;
+	const QString app = QCoreApplication::applicationDirPath();
+	dirs << QDir::cleanPath( app + "/qemu_probe_full_v3" );
+	dirs << QDir::cleanPath( app + "/../qemu_probe_full_v3" );
+	dirs << QDir::cleanPath( app + "/../../qemu_probe_full_v3" );
+	dirs << QDir::cleanPath( app + "/../../../qemu_probe_full_v3" );
+
+	QSettings s;
+	const QString data = s.value( "AQEMU_Data_Folder", "" ).toString();
+	if( ! data.isEmpty() )
+		dirs << QDir::cleanPath( data + "/qemu_probe_full_v3" );
+
+	dirs << QDir::cleanPath( QStringLiteral( "/usr/share/aqemu/qemu_probe_full_v3" ) );
+	dirs << QDir::cleanPath( QStringLiteral( "/usr/local/share/aqemu/qemu_probe_full_v3" ) );
+
+	// Dev tree next to sources when running from build_win/
+	dirs << QDir::cleanPath( app + "/../qemu_probe_full_v3" );
+
+	dirs.removeDuplicates();
+	return dirs;
+}
+
+QStringList Json_String_List( const QJsonObject &obj, const char *key )
+{
+	QStringList out;
+	const QJsonValue v = obj.value( QLatin1String( key ) );
+	if( ! v.isArray() )
+		return out;
+	const QJsonArray arr = v.toArray();
+	for( int i = 0; i < arr.size(); ++i )
+		out << arr.at( i ).toString();
+	return out;
+}
+
+} // namespace
+
+QString QEMU_Probe_Catalog::Probe_Directory()
+{
+	const QStringList dirs = Candidate_Probe_Dirs();
+	for( int i = 0; i < dirs.count(); ++i )
+	{
+		QDir d( dirs[i] );
+		if( d.exists() && d.exists( "x86_64.json" ) )
+			return d.absolutePath();
+	}
+	return QString();
+}
+
+QString QEMU_Probe_Catalog::Architecture_Key( const QString &computer_type_or_binary )
+{
+	QString s = computer_type_or_binary.trimmed().toLower();
+	if( s.isEmpty() )
+		return QString();
+
+	// "PowerPC (qemu-system-ppc)" / captions
+	const int paren = s.lastIndexOf( "qemu-system-" );
+	if( paren >= 0 )
+	{
+		s = s.mid( paren );
+		s.remove( ')' );
+	}
+
+	s.replace( '\\', '/' );
+	if( s.contains( '/' ) )
+		s = QFileInfo( s ).fileName();
+#ifdef Q_OS_WIN
+	if( s.endsWith( ".exe" ) )
+		s.chop( 4 );
+#endif
+
+	if( s.startsWith( "qemu-system-" ) )
+		s = s.mid( QString( "qemu-system-" ).size() );
+	else if( s.startsWith( "qemu-" ) )
+		s = s.mid( QString( "qemu-" ).size() );
+
+	// Strip trailing noise from captions like "aarch64 (softmmu)"
+	const int sp = s.indexOf( ' ' );
+	if( sp > 0 )
+		s = s.left( sp );
+	s.remove( '(' ).remove( ')' );
+	return s;
+}
+
+void QEMU_Probe_Catalog::Parse_Machine_Help_Lines( const QStringList &lines,
+                                                   QList<Device_Map> &out )
+{
+	out.clear();
+	QRegExp rx( "^(\\S+)\\s+(\\S.*)$" );
+	for( int i = 0; i < lines.count(); ++i )
+	{
+		QString line = lines[i].trimmed();
+		if( line.isEmpty() )
+			continue;
+		if( line.toLower().startsWith( "supported machines" ) )
+			continue;
+		if( ! rx.exactMatch( line ) )
+			continue;
+		const QString id = rx.cap( 1 );
+		QString desc = rx.cap( 2 ).trimmed();
+		// Drop "(alias of …)" / "(default)" noise from caption but keep id
+		Append_Unique( out, Device_Map( Pretty_Caption( id, desc ), id ) );
+	}
+}
+
+void QEMU_Probe_Catalog::Parse_CPU_Help_Lines( const QStringList &lines,
+                                               QList<Device_Map> &out )
+{
+	out.clear();
+	// "  603              PVR …" or "x86 pentium3" or "MIPS '4Kc'"
+	QRegExp rx_ws( "^\\s*(\\S+)\\s+(\\S.*)$" );
+	QRegExp rx_mips( ".*MIPS\\s+'([^']+)'.*" );
+	QRegExp rx_x86( ".*x86\\s+\\[?([\\w.-]+)\\]?.*" );
+	QRegExp rx_ppc( ".*PowerPC\\s+([\\w._-]+).*" );
+
+	for( int i = 0; i < lines.count(); ++i )
+	{
+		QString line = lines[i];
+		if( line.trimmed().isEmpty() )
+			continue;
+		if( line.contains( "Available CPUs", Qt::CaseInsensitive ) )
+			continue;
+
+		QString id;
+		QString desc;
+		if( rx_mips.exactMatch( line ) )
+		{
+			id = rx_mips.cap( 1 );
+		}
+		else if( rx_x86.exactMatch( line ) )
+		{
+			id = rx_x86.cap( 1 );
+		}
+		else if( rx_ppc.exactMatch( line ) )
+		{
+			id = rx_ppc.cap( 1 );
+		}
+		else if( rx_ws.exactMatch( line ) )
+		{
+			id = rx_ws.cap( 1 );
+			desc = rx_ws.cap( 2 ).trimmed();
+		}
+		else
+			continue;
+
+		if( id.isEmpty() || id == "Available" )
+			continue;
+		Append_Unique( out, Device_Map( Pretty_Caption( id, desc ), id ) );
+	}
+}
+
+void QEMU_Probe_Catalog::Parse_Device_Help_Lines( const QStringList &lines,
+                                                  QList<Device_Map> &network_out,
+                                                  QList<Device_Map> &display_out,
+                                                  VM::Sound_Cards *audio_out )
+{
+	network_out.clear();
+	display_out.clear();
+
+	enum Section { Sec_None, Sec_Network, Sec_Display, Sec_Sound, Sec_Other };
+	Section sec = Sec_None;
+
+	QRegExp rx_name( "name\\s+\"([^\"]+)\"" );
+	QRegExp rx_desc( "desc\\s+\"([^\"]+)\"" );
+
+	for( int i = 0; i < lines.count(); ++i )
+	{
+		const QString line = lines[i];
+		const QString t = line.trimmed();
+		if( t.endsWith( "devices:", Qt::CaseInsensitive ) ||
+		    t.endsWith( "Devices:" ) )
+		{
+			const QString low = t.toLower();
+			if( low.startsWith( "network" ) )
+				sec = Sec_Network;
+			else if( low.startsWith( "display" ) )
+				sec = Sec_Display;
+			else if( low.startsWith( "sound" ) )
+				sec = Sec_Sound;
+			else
+				sec = Sec_Other;
+			continue;
+		}
+
+		if( rx_name.indexIn( line ) < 0 )
+			continue;
+
+		const QString name = rx_name.cap( 1 );
+		QString desc;
+		if( rx_desc.indexIn( line ) >= 0 )
+			desc = rx_desc.cap( 1 );
+
+		if( audio_out && ( sec == Sec_Sound ||
+		                   name.contains( "hda", Qt::CaseInsensitive ) ||
+		                   name.contains( "ac97", Qt::CaseInsensitive ) ||
+		                   name.contains( "sb16", Qt::CaseInsensitive ) ||
+		                   name.contains( "es1370", Qt::CaseInsensitive ) ||
+		                   name.contains( "virtio-sound", Qt::CaseInsensitive ) ||
+		                   name.contains( "usb-audio", Qt::CaseInsensitive ) ) )
+			Apply_Audio_Token( *audio_out, name );
+
+		if( sec == Sec_Network )
+			Append_Unique( network_out, Device_Map( Pretty_Caption( name, desc ), name ) );
+		else if( sec == Sec_Display )
+		{
+			const QString alias = Normalize_Display_Alias( name );
+			Append_Unique( display_out,
+			               Device_Map( Pretty_Caption( alias, desc.isEmpty() ? name : desc ), alias ) );
+			// Also keep the raw device name when it differs (e.g. ati-vga)
+			if( alias.compare( name, Qt::CaseInsensitive ) != 0 )
+				Append_Unique( display_out, Device_Map( Pretty_Caption( name, desc ), name ) );
+		}
+	}
+
+	// Always offer none
+	Append_Unique( display_out, Device_Map( QObject::tr( "None" ), "none" ) );
+}
+
+bool QEMU_Probe_Catalog::Load_Architecture( const QString &computer_type_or_binary,
+                                            Available_Devices &out )
+{
+	const QString key = Architecture_Key( computer_type_or_binary );
+	if( key.isEmpty() )
+		return false;
+
+	const QString dir = Probe_Directory();
+	if( dir.isEmpty() )
+		return false;
+
+	const QString path = QDir( dir ).filePath( key + ".json" );
+	QFile f( path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return false;
+
+	const QJsonDocument doc = QJsonDocument::fromJson( f.readAll() );
+	if( ! doc.isObject() )
+		return false;
+
+	const QJsonObject root = doc.object();
+	Available_Devices ad;
+	ad.System.QEMU_Name = QString( "qemu-system-%1" ).arg( key );
+	QString caption = key;
+	if( ! caption.isEmpty() )
+		caption[0] = caption[0].toUpper();
+	ad.System.Caption = QObject::tr( "%1 (%2)" ).arg( caption, ad.System.QEMU_Name );
+
+	Parse_Machine_Help_Lines( Json_String_List( root, "machines" ), ad.Machine_List );
+	Parse_CPU_Help_Lines( Json_String_List( root, "cpus" ), ad.CPU_List );
+
+	VM::Sound_Cards audio;
+	Parse_Device_Help_Lines( Json_String_List( root, "devices" ),
+	                         ad.Network_Card_List, ad.Video_Card_List, &audio );
+	ad.Audio_Card_List = audio;
+
+	// Modern PCI guests can take these even when -soundhw is gone
+	ad.Audio_Card_List.Audio_VirtIO = true;
+	ad.Audio_Card_List.Audio_USB = true;
+	if( ! ad.Audio_Card_List.Audio_HDA )
+		ad.Audio_Card_List.Audio_HDA = true;
+
+	if( ad.Machine_List.isEmpty() && ad.CPU_List.isEmpty() )
+		return false;
+
+	out = ad;
+	AQDebug( "QEMU_Probe_Catalog::Load_Architecture",
+	         QString( "Loaded %1: machines=%2 cpus=%3 net=%4 video=%5" )
+	             .arg( key )
+	             .arg( out.Machine_List.count() )
+	             .arg( out.CPU_List.count() )
+	             .arg( out.Network_Card_List.count() )
+	             .arg( out.Video_Card_List.count() ) );
+	return true;
+}
+
+bool QEMU_Probe_Catalog::Architecture_Has_CPU( const QString &computer_type_or_binary,
+                                               const QString &cpu_name )
+{
+	if( cpu_name.isEmpty() )
+		return false;
+	Available_Devices ad;
+	if( ! Load_Architecture( computer_type_or_binary, ad ) )
+		return false;
+	for( int i = 0; i < ad.CPU_List.count(); ++i )
+	{
+		if( ad.CPU_List[i].QEMU_Name.compare( cpu_name, Qt::CaseInsensitive ) == 0 )
+			return true;
+	}
+	return false;
+}
+
+QString QEMU_Probe_Catalog::First_Available_CPU( const QString &computer_type_or_binary,
+                                                 const QStringList &candidates )
+{
+	Available_Devices ad;
+	const bool have = Load_Architecture( computer_type_or_binary, ad );
+	for( int i = 0; i < candidates.count(); ++i )
+	{
+		const QString c = candidates[i].trimmed();
+		if( c.isEmpty() )
+			continue;
+		if( ! have )
+			return c; // no probe — trust caller order
+		for( int j = 0; j < ad.CPU_List.count(); ++j )
+		{
+			if( ad.CPU_List[j].QEMU_Name.compare( c, Qt::CaseInsensitive ) == 0 )
+				return ad.CPU_List[j].QEMU_Name;
+		}
+	}
+	// Never fall back to list[0] if that is 486 when better options exist
+	if( have )
+	{
+		for( int j = 0; j < ad.CPU_List.count(); ++j )
+		{
+			const QString n = ad.CPU_List[j].QEMU_Name;
+			if( n.compare( QLatin1String( "486" ), Qt::CaseInsensitive ) == 0 ||
+			    n.startsWith( QLatin1String( "486-" ), Qt::CaseInsensitive ) )
+				continue;
+			return n;
+		}
+		if( ! ad.CPU_List.isEmpty() )
+			return ad.CPU_List.first().QEMU_Name;
+	}
+	return candidates.isEmpty() ? QString() : candidates.first();
+}
+
+bool QEMU_Probe_Catalog::Merge_Into( Available_Devices &dev )
+{
+	Available_Devices probe;
+	const QString key_src = ! dev.System.QEMU_Name.isEmpty()
+		? dev.System.QEMU_Name
+		: dev.System.Caption;
+	if( ! Load_Architecture( key_src, probe ) )
+		return false;
+
+	if( ! probe.Machine_List.isEmpty() )
+		dev.Machine_List = probe.Machine_List;
+	if( ! probe.CPU_List.isEmpty() )
+		dev.CPU_List = probe.CPU_List;
+	if( ! probe.Network_Card_List.isEmpty() )
+		dev.Network_Card_List = probe.Network_Card_List;
+	if( ! probe.Video_Card_List.isEmpty() )
+		dev.Video_Card_List = probe.Video_Card_List;
+
+	dev.Audio_Card_List.Audio_sb16 =
+		dev.Audio_Card_List.Audio_sb16 || probe.Audio_Card_List.Audio_sb16;
+	dev.Audio_Card_List.Audio_es1370 =
+		dev.Audio_Card_List.Audio_es1370 || probe.Audio_Card_List.Audio_es1370;
+	dev.Audio_Card_List.Audio_Adlib =
+		dev.Audio_Card_List.Audio_Adlib || probe.Audio_Card_List.Audio_Adlib;
+	dev.Audio_Card_List.Audio_PC_Speaker =
+		dev.Audio_Card_List.Audio_PC_Speaker || probe.Audio_Card_List.Audio_PC_Speaker;
+	dev.Audio_Card_List.Audio_GUS =
+		dev.Audio_Card_List.Audio_GUS || probe.Audio_Card_List.Audio_GUS;
+	dev.Audio_Card_List.Audio_AC97 =
+		dev.Audio_Card_List.Audio_AC97 || probe.Audio_Card_List.Audio_AC97;
+	dev.Audio_Card_List.Audio_HDA =
+		dev.Audio_Card_List.Audio_HDA || probe.Audio_Card_List.Audio_HDA;
+	dev.Audio_Card_List.Audio_cs4231a =
+		dev.Audio_Card_List.Audio_cs4231a || probe.Audio_Card_List.Audio_cs4231a;
+	dev.Audio_Card_List.Audio_VirtIO =
+		dev.Audio_Card_List.Audio_VirtIO || probe.Audio_Card_List.Audio_VirtIO;
+	dev.Audio_Card_List.Audio_USB =
+		dev.Audio_Card_List.Audio_USB || probe.Audio_Card_List.Audio_USB;
+
+	if( dev.System.QEMU_Name.isEmpty() )
+		dev.System.QEMU_Name = probe.System.QEMU_Name;
+	return true;
+}

--- a/src/QEMU_Probe_Catalog.h
+++ b/src/QEMU_Probe_Catalog.h
@@ -1,0 +1,48 @@
+/****************************************************************************
+** Full-architecture QEMU option catalogs from qemu_probe_full_v3/*.json
+** Used by the Main Window VM config panel (not the New VM wizard).
+****************************************************************************/
+
+#ifndef QEMU_PROBE_CATALOG_H
+#define QEMU_PROBE_CATALOG_H
+
+#include "VM_Devices.h"
+
+class QEMU_Probe_Catalog
+{
+	public:
+		/** Directory containing {arch}.json probes, or empty if not found. */
+		static QString Probe_Directory();
+
+		/** Map "qemu-system-ppc" / "ppc" / caption text → probe stem ("ppc"). */
+		static QString Architecture_Key( const QString &computer_type_or_binary );
+
+		/** Load one probe into Available_Devices lists (machines/CPUs/net/video/audio). */
+		static bool Load_Architecture( const QString &computer_type_or_binary,
+		                               Available_Devices &out );
+
+		/**
+		 * Replace Machine/CPU/Network/Video lists (and OR audio flags) from the
+		 * probe when present. Keeps PSO_* and System caption from `dev`.
+		 */
+		static bool Merge_Into( Available_Devices &dev );
+
+		/** Parse -device help / probe "devices" lines into net + display maps. */
+		static void Parse_Device_Help_Lines( const QStringList &lines,
+		                                     QList<Device_Map> &network_out,
+		                                     QList<Device_Map> &display_out,
+		                                     VM::Sound_Cards *audio_out = nullptr );
+
+		static void Parse_Machine_Help_Lines( const QStringList &lines,
+		                                      QList<Device_Map> &out );
+		static void Parse_CPU_Help_Lines( const QStringList &lines,
+		                                  QList<Device_Map> &out );
+
+		/** Prefer candidates that exist in qemu_probe_full_v3 for this arch. */
+		static QString First_Available_CPU( const QString &computer_type_or_binary,
+		                                    const QStringList &candidates );
+		static bool Architecture_Has_CPU( const QString &computer_type_or_binary,
+		                                  const QString &cpu_name );
+};
+
+#endif

--- a/src/Service.cpp
+++ b/src/Service.cpp
@@ -345,7 +345,12 @@ QString AQEMU_Service::start(const QString& s)
         return QString( "VM \"%1\" is already running." ).arg( s );
 
     QSettings settings;
+    #ifdef Q_OS_WIN32
+    QString vm_dir = QDir::toNativeSeparators(
+	    settings.value( "VM_Directory", AQEMU_Default_VM_Directory() ).toString() );
+    #else
     QString vm_dir = QDir::toNativeSeparators(settings.value("VM_Directory", QDir::homePath() + "/.aqemu/").toString());
+    #endif
     QString vm_file = vm_dir+s+".aqemu";
 
     bool success = false;

--- a/src/Storage_Browser_Window.cpp
+++ b/src/Storage_Browser_Window.cpp
@@ -3,6 +3,7 @@
 ****************************************************************************/
 
 #include "Storage_Browser_Window.h"
+#include "Utils.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -24,8 +25,13 @@ Storage_Browser_Window::Storage_Browser_Window( QWidget *parent )
 	resize( 560, 420 );
 
 	QSettings s;
+	#ifdef Q_OS_WIN32
+	Root = s.value( QStringLiteral( "VM_Directory" ),
+		AQEMU_Default_VM_Directory() ).toString();
+	#else
 	Root = s.value( QStringLiteral( "VM_Directory" ),
 		QDir::homePath() + QStringLiteral( "/.aqemu/" ) ).toString();
+	#endif
 
 	QVBoxLayout *lay = new QVBoxLayout( this );
 	lay->addWidget( new QLabel( tr(

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -35,6 +35,7 @@
 
 #include "Utils.h"
 #include "System_Info.h"
+#include "QEMU_Probe_Catalog.h"
 
 System_Info::System_Info()
 {
@@ -1512,8 +1513,13 @@ bool System_Info::Is_Disk_Bus_Allowed( const QString &computer_type, const QStri
 	const Video_Arch_Family fam = Get_Video_Arch_Family( computer_type );
 	const QString m = machine_type.toLower().trimmed();
 	const bool is_virt_machine = ( m == QLatin1String( "virt" ) ) || fam == VAF_VIRT;
-	const bool is_mac = m.contains( QLatin1String( "mac" ) );
-	const bool is_pseries = m.contains( QLatin1String( "pseries" ) ) || fam == VAF_PPC;
+	// Classic Power Mac (OpenBIOS) — not Intel q35 "Mac"
+	const bool is_classic_mac =
+		m.contains( QLatin1String( "mac99" ) ) ||
+		m.contains( QLatin1String( "g3beige" ) ) ||
+		m.contains( QLatin1String( "heathrow" ) );
+	// Only real pseries — do NOT treat all VAF_PPC as pseries (that blocked IDE on mac99).
+	const bool is_pseries = m.contains( QLatin1String( "pseries" ) );
 	const bool is_q35 = m.contains( QLatin1String( "q35" ) );
 	const bool is_pc_x86 = ( fam == VAF_X86 );
 
@@ -1522,26 +1528,30 @@ bool System_Info::Is_Disk_Bus_Allowed( const QString &computer_type, const QStri
 		case VM::DI_IDE:
 			if( is_virt_machine || is_pseries )
 				return false;
+			if( is_classic_mac )
+				return true;
 			return is_pc_x86 || fam == VAF_OTHER;
 
 		case VM::DI_AHCI:
-			if( is_virt_machine || is_pseries )
+			// ich9-ahci is a PC device — OpenBIOS on mac99 cannot use it (and AQEMU
+			// previously forced AHCI because machine name contains "mac").
+			if( is_virt_machine || is_pseries || is_classic_mac )
 				return false;
-			return is_pc_x86 || is_mac;
+			return is_pc_x86 || is_q35;
 
 		case VM::DI_SCSI:
-			if( is_mac )
+			if( is_classic_mac )
 				return false;
 			return true;
 
 		case VM::DI_Virtio:
 		case VM::DI_Virtio_SCSI:
-			if( is_mac )
+			if( is_classic_mac )
 				return false;
 			return true;
 
 		case VM::DI_NVMe:
-			if( is_mac || is_pseries || for_optical_or_floppy )
+			if( is_classic_mac || is_pseries || for_optical_or_floppy )
 				return false;
 			if( is_virt_machine || is_q35 )
 				return true;
@@ -1585,26 +1595,35 @@ VM::Device_Interface System_Info::Default_Disk_Bus( const QString &computer_type
 {
 	const Video_Arch_Family fam = Get_Video_Arch_Family( computer_type );
 	const QString m = machine_type.toLower().trimmed();
-	const bool is_mac = m.contains( QLatin1String( "mac" ) );
+	const bool is_classic_mac =
+		m.contains( QLatin1String( "mac99" ) ) ||
+		m.contains( QLatin1String( "g3beige" ) ) ||
+		m.contains( QLatin1String( "heathrow" ) );
 	const bool is_virt = ( m == QLatin1String( "virt" ) ) || fam == VAF_VIRT;
-	const bool is_pseries = m.contains( QLatin1String( "pseries" ) ) || fam == VAF_PPC;
+	const bool is_pseries = m.contains( QLatin1String( "pseries" ) );
 	const bool is_q35 = m.contains( QLatin1String( "q35" ) );
 
-	if( is_mac )
-		return VM::DI_AHCI;
+	if( is_classic_mac )
+		return VM::DI_IDE;
 	if( is_pseries )
 		return VM::DI_Virtio_SCSI;
 	if( is_virt || is_q35 )
-		return VM::DI_Virtio;
+		return is_q35 ? VM::DI_AHCI : VM::DI_Virtio;
 	return VM::DI_IDE;
 }
 
 VM::Device_Interface System_Info::Sanitize_Disk_Bus( const QString &computer_type,
 	const QString &machine_type, VM::Device_Interface iface, bool for_optical_or_floppy )
 {
-	if( Is_Disk_Bus_Allowed( computer_type, machine_type, iface, for_optical_or_floppy ) )
-		return iface;
-	return Default_Disk_Bus( computer_type, machine_type );
+	// Optical/floppy cannot use NVMe/SD/MTD/PFlash media interfaces.
+	if( for_optical_or_floppy &&
+	    ( iface == VM::DI_NVMe || iface == VM::DI_SD || iface == VM::DI_MTD || iface == VM::DI_PFlash ) )
+		return Default_Disk_Bus( computer_type, machine_type );
+
+	// Otherwise keep the user's choice. Main Window exposes every QEMU interface;
+	// the New VM wizard still applies Guest_Capabilities curated defaults.
+	Q_UNUSED( machine_type );
+	return iface;
 }
 
 void System_Info::Filter_Video_Card_List( Available_Devices &dev )
@@ -1673,16 +1692,22 @@ QString System_Info::Sanitize_Video_Card( const QString &computer_type, const QS
 {
 	const Video_Arch_Family fam = Get_Video_Arch_Family( computer_type );
 	QString name = Normalize_Video_Alias( video_card );
+	const QString m = machine_type.toLower().trimmed();
+	const bool classic_mac =
+		m.contains( QLatin1String( "mac99" ) ) ||
+		m.contains( QLatin1String( "g3beige" ) ) ||
+		m.contains( QLatin1String( "heathrow" ) );
+
+	// mac99/g3beige already have an onboard framebuffer — forcing -vga std breaks OpenBIOS.
+	if( classic_mac && ( name.isEmpty() || name == QLatin1String( "std" ) ) )
+		return QString();
 
 	if( name.isEmpty() )
 		return Default_Video_For_Family( fam );
 
-	name = Map_Cross_Arch_Video( fam, name, machine_type );
-
-	if( Is_Video_Card_Allowed( fam, name ) )
-		return name;
-
-	return Default_Video_For_Family( fam );
+	// Main Window / power-user path: keep whatever QEMU exposes for this arch.
+	// Do not rewrite to a family whitelist (wizard uses Guest_Capabilities instead).
+	return name;
 }
 
 void System_Info::Normalize_Virt_Arch_Devices( Available_Devices &dev )
@@ -1732,7 +1757,8 @@ void System_Info::Normalize_Virt_Arch_Devices( Available_Devices &dev )
 	}
 	// other obscure targets: keep modern VirtIO/USB/HDA from above; ISA/PCI extras only if probe set them
 
-	Filter_Video_Card_List( dev );
+	// Do NOT call Filter_Video_Card_List here — Main Window must expose every
+	// display device QEMU reports for the architecture (see qemu_probe_full_v3).
 
 	if( ! is_virtish )
 		return;
@@ -2557,6 +2583,32 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 			tmp_dev.Audio_Card_List.Audio_cs4231a = true;
 		if( has( "isa-pcspk" ) || has( "pcspk" ) )
 			tmp_dev.Audio_Card_List.Audio_PC_Speaker = true;
+
+		// Full Network + Display device lists from -device help (not just -vga / -net nic,model=?)
+		QList<Device_Map> net_from_help;
+		QList<Device_Map> video_from_help;
+		QEMU_Probe_Catalog::Parse_Device_Help_Lines(
+			device_help_str.split( '\n' ), net_from_help, video_from_help, &tmp_dev.Audio_Card_List );
+		if( ! net_from_help.isEmpty() )
+			tmp_dev.Network_Card_List = net_from_help;
+		if( ! video_from_help.isEmpty() )
+		{
+			// Keep any -vga aliases already parsed, then union probe/help display devices
+			for( int vi = 0; vi < video_from_help.count(); ++vi )
+			{
+				bool found = false;
+				for( int vj = 0; vj < tmp_dev.Video_Card_List.count(); ++vj )
+				{
+					if( tmp_dev.Video_Card_List[vj].QEMU_Name == video_from_help[vi].QEMU_Name )
+					{
+						found = true;
+						break;
+					}
+				}
+				if( ! found )
+					tmp_dev.Video_Card_List << video_from_help[vi];
+			}
+		}
 	}
 	
 	// Ensure System.QEMU_Name for Normalize (probe may not have set it yet)
@@ -2583,13 +2635,15 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 		#endif
 	}
 	
-	// Per-architecture video whitelist (strips cg3/tcx from x86, std/cirrus from aarch64, etc.)
-	Filter_Video_Card_List( tmp_dev );
-	
+	// Prefer shipped qemu_probe_full_v3 catalogs as ground truth for full option lists
+	QEMU_Probe_Catalog::Merge_Into( tmp_dev );
+
 	// Ensure all architectures expose usable audio (probe + defaults), including x86
 	Normalize_Virt_Arch_Devices( tmp_dev );
 	
-	// Get Network Card Models
+	// Fallback network list from legacy -net nic,model=? only if still empty
+	if( tmp_dev.Network_Card_List.count() < 2 )
+	{
 	args_list.clear();
 	args_list << "-net" << "nic,model=?";
 	
@@ -2642,6 +2696,7 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 		break; // All Done
 	}
 	while( ! tmp.isNull() );
+	}
 	
 	// No Cards... Set Default List
 	if( tmp_dev.Network_Card_List.count() < 2 )

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -32,6 +32,7 @@
 #include <QScreen>
 #include <QCoreApplication>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QRegExp>
 #include <QRegularExpression>
 #include <QHash>
@@ -250,6 +251,93 @@ void AQLog_Path( const QString& path )
 	Log_Path = path;
 }
 
+static QString AQEMU_With_Trailing_Sep( QString path )
+{
+	path = QDir::cleanPath( path );
+	path = QDir::toNativeSeparators( path );
+	if( ! path.endsWith( QLatin1Char( '/' ) ) && ! path.endsWith( QLatin1Char( '\\' ) ) )
+		path += QDir::separator();
+	return path;
+}
+
+QString AQEMU_User_Data_Dir()
+{
+	QString root = QStandardPaths::writableLocation( QStandardPaths::AppLocalDataLocation );
+	if( root.isEmpty() )
+	{
+		#ifdef Q_OS_WIN32
+		root = QDir::homePath() + QStringLiteral( "/AppData/Local/aqemu/AQEMU" );
+		#else
+		root = QDir::homePath() + QStringLiteral( "/.local/share/AQEMU" );
+		#endif
+	}
+	root = AQEMU_With_Trailing_Sep( root );
+	QDir().mkpath( root );
+	return root;
+}
+
+QString AQEMU_Default_VM_Directory()
+{
+	const QString vms = AQEMU_With_Trailing_Sep( AQEMU_User_Data_Dir() + QStringLiteral( "VMs" ) );
+	QDir().mkpath( vms );
+	QDir().mkpath( vms + QStringLiteral( "os_templates" ) );
+	return vms;
+}
+
+QString AQEMU_Default_Log_Path()
+{
+	return QDir::toNativeSeparators( AQEMU_User_Data_Dir() + QStringLiteral( "aqemu.log" ) );
+}
+
+bool AQEMU_Path_Is_Install_Dir( const QString &path )
+{
+	if( path.isEmpty() )
+		return false;
+	const QString native = QDir::toNativeSeparators( QDir::cleanPath( path ) );
+	const QString app_dir = QDir::toNativeSeparators(
+		QDir::cleanPath( QCoreApplication::applicationDirPath() ) );
+	if( ! app_dir.isEmpty() &&
+	    ( native.compare( app_dir, Qt::CaseInsensitive ) == 0 ||
+	      native.startsWith( app_dir + QDir::separator(), Qt::CaseInsensitive ) ) )
+		return true;
+	if( native.contains( QLatin1String( "WindowsApps" ), Qt::CaseInsensitive ) )
+		return true;
+	return false;
+}
+
+void AQEMU_Ensure_Writable_User_Paths( QSettings &settings )
+{
+	QString vm_dir = settings.value( QStringLiteral( "VM_Directory" ), QString() ).toString().trimmed();
+	#ifdef Q_OS_WIN32
+	// Store / Windows: default VMs under AppData (never next to the exe / WindowsApps).
+	if( vm_dir.isEmpty() || AQEMU_Path_Is_Install_Dir( vm_dir ) ||
+	    vm_dir == QLatin1String( "~" ) )
+	{
+		vm_dir = AQEMU_Default_VM_Directory();
+		settings.setValue( QStringLiteral( "VM_Directory" ), vm_dir );
+	}
+	else
+	{
+		vm_dir = AQEMU_With_Trailing_Sep( vm_dir );
+		settings.setValue( QStringLiteral( "VM_Directory" ), vm_dir );
+		QDir().mkpath( vm_dir );
+		QDir().mkpath( vm_dir + QStringLiteral( "os_templates" ) );
+	}
+
+	settings.setValue( QStringLiteral( "Log/Log_Path" ), AQEMU_Default_Log_Path() );
+	settings.setValue( QStringLiteral( "Log/Save_In_File" ), QStringLiteral( "yes" ) );
+	#else
+	if( vm_dir.isEmpty() || vm_dir == QLatin1String( "~" ) )
+	{
+		vm_dir = AQEMU_With_Trailing_Sep(
+			QDir::homePath() + QStringLiteral( "/.aqemu" ) );
+		settings.setValue( QStringLiteral( "VM_Directory" ), vm_dir );
+		QDir().mkpath( vm_dir );
+		QDir().mkpath( vm_dir + QStringLiteral( "os_templates" ) );
+	}
+	#endif
+}
+
 void AQSave_To_Log( const QString &mes_type, const QString &sender, const QString &mes )
 {
 	if( Log_Path.isEmpty() ) return;
@@ -258,9 +346,12 @@ void AQSave_To_Log( const QString &mes_type, const QString &sender, const QStrin
 	
 	if( ! log_file.open(QIODevice::Append | QIODevice::Text) )
 	{
-		AQUse_Log( false ); // off loging
-		AQError( "void AQSave_To_Log( const QString& mes_type, const QString& sender, const QString& mes )",
-				 "Cannot Open Log file to Write! Log Path: \"" + Log_Path + "\"" );
+		// Disable before reporting — avoids recursive AQError → AQSave_To_Log loops
+		// when the path is under a read-only Store/MSIX install dir.
+		AQUse_Log( false );
+		Log_Path.clear();
+		fprintf( stderr, "AQEMU: cannot open log file for write: %s\n",
+			 qPrintable( log_file.fileName() ) );
 	}
 	else
 	{

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -24,8 +24,8 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#define CURRENT_AQEMU_VERSION "1.0.0"
-#define CURRENT_AQEMU_RELEASE_DATE "2026-07-25"
+#define CURRENT_AQEMU_VERSION "1.1.0"
+#define CURRENT_AQEMU_RELEASE_DATE "2026-07-29"
 
 #include <functional>
 #include <QString>
@@ -33,6 +33,8 @@
 #include <QList>
 
 #include "VM_Devices.h"
+
+class QSettings;
 
 class Disable_User_Graphic_Warning
 {
@@ -58,6 +60,29 @@ void AQUse_Log( bool use );
 void AQUse_Debug_Output( bool use, bool d, bool w, bool e );
 void AQLog_Path( const QString &path );
 void AQSave_To_Log( const QString &mes_type, const QString &sender, const QString &mes );
+
+/**
+ * Writable per-user data root (trailing separator).
+ * Windows: %LOCALAPPDATA%\aqemu\AQEMU\ (Store-safe; never next to the exe).
+ * Other OS: QStandardPaths::AppLocalDataLocation.
+ * Creates the directory if needed.
+ */
+QString AQEMU_User_Data_Dir();
+
+/** Default VM folder: <User_Data>/VMs/ (trailing separator). Creates it. */
+QString AQEMU_Default_VM_Directory();
+
+/** Default log file: <User_Data>/aqemu.log */
+QString AQEMU_Default_Log_Path();
+
+/** True if path is under the install / WindowsApps tree (not writable). */
+bool AQEMU_Path_Is_Install_Dir( const QString &path );
+
+/**
+ * Ensure VM_Directory and Log/Log_Path are writable user locations.
+ * Relocates empty paths and any path under the install directory to AppData.
+ */
+void AQEMU_Ensure_Writable_User_Paths( QSettings &settings );
 
 bool Create_New_HDD_Image( bool encrypted, const QString &base_image,
 						   const QString &file_name, const QString &format, VM::Device_Size size, bool verbose );

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -6676,6 +6676,13 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// Effective machine type. aarch64/arm/riscv have no QEMU default ? must pass virt
 	// (matches win11-pi5-kiosk: -M virt,accel=kvm).
 	QString effective_machine = Machine_Type;
+	// qemu-system-ppc64 with an empty -M defaults to pseries (SLOF) — fine for AIX,
+	// catastrophic for classic Mac OS X if the user left Machine blank after a bad import.
+	// qemu-system-ppc defaults to g3beige; prefer mac99 (New World / OS X era).
+	if( effective_machine.isEmpty() &&
+	    Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive ) &&
+	    ! Computer_Type.contains( QLatin1String( "ppc64" ), Qt::CaseInsensitive ) )
+		effective_machine = QStringLiteral( "mac99" );
 	const bool is_virt_arch =
 		Computer_Type.contains( "aarch64", Qt::CaseInsensitive ) ||
 		Computer_Type.contains( "qemu-system-arm", Qt::CaseInsensitive ) ||
@@ -6692,6 +6699,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		Computer_Type.contains( QLatin1String( "m68k" ), Qt::CaseInsensitive ) ||
 		Computer_Type.contains( QLatin1String( "sparc" ), Qt::CaseInsensitive ) ||
 		Computer_Type.contains( QLatin1String( "mips" ), Qt::CaseInsensitive );
+	// NeXT Cube: onboard ESP SCSI + framebuffer; no PCI virtio, firmware via -bios.
+	const bool is_next_cube =
+		effective_machine.contains( QLatin1String( "next-cube" ), Qt::CaseInsensitive );
 	if( effective_machine.isEmpty() && is_virt_arch )
 		effective_machine = "virt";
 	// QEMU warns that old versioned virt-N.M aliases are deprecated; alias to current "virt".
@@ -6719,10 +6729,18 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		( Win11_Lifecycle_Mode == VM::Win11_First_Boot ||
 		  Win11_Lifecycle_Mode == VM::Win11_Normal );
 
+	const bool legacy_vga =
+		effective_video == "std" || effective_video == "cirrus" ||
+		effective_video == "vmware" || effective_video == "qxl" ||
+		effective_video == "xenfb" || effective_video == "virtio" ||
+		effective_video == "cg3" || effective_video == "tcx" ||
+		effective_video == "none";
+
 	const bool device_based_video = System_Info::Uses_Device_Based_Video( Computer_Type ) ||
 	                                effective_video == "virtio-gpu-pci" || effective_video == "virtio-gpu-gl-pci" ||
 	                                effective_video == "virtio-vga-gl" ||
-	                                effective_video == "ramfb";
+	                                effective_video == "ramfb" ||
+	                                ( ! effective_video.isEmpty() && ! legacy_vga );
 
 	if( device_based_video )
 	{
@@ -6734,7 +6752,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-device" << "virtio-gpu-gl-pci";
 		else if( effective_video == "virtio-vga-gl" )
 			Args << "-device" << "virtio-vga-gl";
-		else
+		else if( effective_video == "virtio-gpu-pci" ||
+		         ( effective_video.isEmpty() &&
+		           System_Info::Uses_Device_Based_Video( Computer_Type ) ) )
 		{
 			// VirtIO-GPU with EDID. Do NOT auto-add ramfb here (BVM normal/boot mode):
 			// combining ramfb + virtio-gpu causes "Display output is not active" reboot loops.
@@ -6769,6 +6789,11 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				virtio += QString( ",xres=%1,yres=%2" ).arg( rw ).arg( rh );
 
 			Args << "-device" << virtio;
+		}
+		else
+		{
+			// Arbitrary display device from -device help / probe catalog (ati-vga, sm501, …)
+			Args << "-device" << effective_video;
 		}
 	}
 	else if( Current_Emulator_Devices.PSO_Std_VGA ) // QEMU before 0.10 style
@@ -6833,26 +6858,31 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	const bool is_x86_guest =
 		Computer_Type.contains( QLatin1String( "x86_64" ), Qt::CaseInsensitive ) ||
 		Computer_Type.contains( QLatin1String( "i386" ), Qt::CaseInsensitive );
+	// UI "TCG" / Force_TCG / cross-arch must win. Never upgrade TCG→KVM/WHPX silently,
+	// and never force KVM just because Launch_Via_WSL is set (PPC/ARM on x86 WSL).
+	const bool want_native_accel =
+		( Machine_Accelerator == VM::KVM ) && ! legacy_force_tcg && is_x86_guest;
 	#ifdef Q_OS_WIN32
 	if( Launch_Via_WSL && ! is_virt_arch )
 	{
-		// Linux QEMU inside WSL: KVM only when /dev/kvm is writable; else pure TCG.
+		// Linux QEMU inside WSL: KVM only when the UI asked for KVM, guest is x86,
+		// and /dev/kvm is writable. Otherwise honor TCG (e.g. Mac OS X PPC).
 		const QString distro = Settings.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
-		if( WSL_Has_KVM( distro, false ) )
+		if( want_native_accel && WSL_Has_KVM( distro, false ) )
 			props << "accel=kvm";
 		else
-			props << "accel=tcg";
+			use_separate_tcg_accel = true;
 	}
 	else if( is_virt_arch )
 		use_separate_tcg_accel = true;
 	else if( legacy_force_tcg )
 		// Win95/98: WHPX hangs at splash. XP: WHPX disables SMM → black text mode.
 		use_separate_tcg_accel = true;
-	else if( ! is_x86_guest )
-		// WHPX/HAX only accelerate x86 guests. ppc64/sparc/mips/etc must use TCG
-		// (otherwise QEMU prints "invalid accelerator whpx/hax" then may fail RAM setup).
+	else if( ! is_x86_guest || Machine_Accelerator == VM::TCG )
+		// WHPX/HAX only accelerate x86. Also: selecting TCG in the UI must mean TCG
+		// (do not silently map it to whpx:hax:tcg — that is what "KVM" means on Windows).
 		use_separate_tcg_accel = true;
-	else if( Machine_Accelerator == VM::KVM || Machine_Accelerator == VM::TCG )
+	else if( want_native_accel )
 		// Prefer Hyper-V WHPX (or HAX) for x86; fall back to TCG. Pure TCG makes
 		// DOS IDE/ATAPI CD (PIO) feel like a 1x optical drive.
 		props << "accel=whpx:hax:tcg";
@@ -6861,9 +6891,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	else
 		props << "accel="+VM::Accel_To_String( Machine_Accelerator );
 	#else
-	if( legacy_force_tcg )
+	if( legacy_force_tcg || Machine_Accelerator == VM::TCG )
 		use_separate_tcg_accel = true;
-	else if( Machine_Accelerator == VM::KVM || Launch_Via_WSL )
+	else if( want_native_accel )
 		props << "accel=kvm:tcg";
 	else if( Machine_Accelerator == VM::XEN )
 		props << "accel=xen:tcg";
@@ -7167,6 +7197,22 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 					StorageArgs << "-drive" << drive;
 					StorageArgs << "-device" << usb_dev;
 				}
+			}
+		}
+		else if( is_next_cube )
+		{
+			// NeXT Cube has onboard ESP SCSI (block_default_type=IF_SCSI).
+			// Do NOT invent virtio-scsi-pci — that device does not exist on m68k.
+			// Keep CD off SCSI ID 0: NeXT `bsd` / default sd boots unit 0 (the HD).
+			if( QFile::exists( CD_ROM.Get_File_Name() ) || Build_QEMU_Args_for_Tab_Info )
+			{
+				const QString drive = QString(
+					"file=%1,if=scsi,media=cdrom,readonly=on,format=raw,unit=3" )
+					.arg( CD_ROM.Get_File_Name() );
+				if( Build_QEMU_Args_for_Script_Mode )
+					StorageArgs << "-drive" << "\"" + drive + "\"";
+				else
+					StorageArgs << "-drive" << drive;
 			}
 		}
 		else if( no_pc_fdd_ide && ! is_virt_arch )
@@ -7635,7 +7681,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	//
     if (has_virt_scsi)
     {
-		Args << "-device" << "virtio-scsi-pci,id=aq-vscsi";
+		// Never invent virtio-scsi-pci on NeXT Cube / non-PCI m68k boards.
+		if( ! Machine_Type.contains( QLatin1String( "next-cube" ), Qt::CaseInsensitive ) )
+			Args << "-device" << "virtio-scsi-pci,id=aq-vscsi";
 	}
 
 	//      After the storage adapter has been added to the argument list,
@@ -8802,10 +8850,16 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 		else
 		{
+			// next-cube loads board firmware with -bios (not PC option ROM).
+			const bool next_cube_rom =
+				Machine_Type.contains( QLatin1String( "next-cube" ), Qt::CaseInsensitive );
+			const QString rom_flag = next_cube_rom
+				? QStringLiteral( "-bios" )
+				: QStringLiteral( "-option-rom" );
 			if( Build_QEMU_Args_for_Script_Mode )
-				Args << "-option-rom" << "\"" + ROM_File + "\"";
+				Args << rom_flag << "\"" + ROM_File + "\"";
 			else
-				Args << "-option-rom" << ROM_File;
+				Args << rom_flag << ROM_File;
 		}
 	}
 	
@@ -10156,6 +10210,28 @@ bool Virtual_Machine::Start_impl()
 		}
 
 #ifdef Q_OS_WIN32
+		// Bundled qemu-system-ppc 11.0.2 aborts on mac99/g3beige (0xC0000409). Prefer a
+		// system install that can actually run OpenBIOS (e.g. C:\Program Files\qemu).
+		if( find_name.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive ) &&
+		    ! find_name.contains( QLatin1String( "ppc64" ), Qt::CaseInsensitive ) )
+		{
+			const QStringList ppc_candidates = QStringList()
+				<< QStringLiteral( "C:/Program Files/qemu/qemu-system-ppc.exe" )
+				<< QStringLiteral( "C:/Program Files (x86)/qemu/qemu-system-ppc.exe" );
+			for( int ci = 0; ci < ppc_candidates.count(); ++ci )
+			{
+				if( QFile::exists( ppc_candidates[ci] ) )
+				{
+					if( bin_path != ppc_candidates[ci] )
+						AQDebug( "bool Virtual_Machine::Start()",
+						         QString( "Classic PPC: using \"%1\" (bundled mac99 is broken on Windows)" )
+						             .arg( ppc_candidates[ci] ) );
+					bin_path = ppc_candidates[ci];
+					break;
+				}
+			}
+		}
+
 		if( Launch_Via_WSL )
 		{
 			QSettings s;

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -6688,7 +6688,10 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		effective_machine.contains( QLatin1String( "mac99" ), Qt::CaseInsensitive ) ||
 		effective_machine.contains( QLatin1String( "g3beige" ), Qt::CaseInsensitive ) ||
 		Computer_Type.contains( QLatin1String( "s390" ), Qt::CaseInsensitive ) ||
-		Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive );
+		Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "m68k" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "sparc" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "mips" ), Qt::CaseInsensitive );
 	if( effective_machine.isEmpty() && is_virt_arch )
 		effective_machine = "virt";
 	// QEMU warns that old versioned virt-N.M aliases are deprecated; alias to current "virt".
@@ -6894,6 +6897,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		const bool no_mttcg =
 			legacy_force_tcg ||
 			Computer_Type.contains( QLatin1String( "qemu-system-ppc" ), Qt::CaseInsensitive ) ||
+			Computer_Type.contains( QLatin1String( "m68k" ), Qt::CaseInsensitive ) ||
 			Computer_Type.contains( QLatin1String( "sparc" ), Qt::CaseInsensitive ) ||
 			Computer_Type.contains( QLatin1String( "mips" ), Qt::CaseInsensitive );
 		if( no_mttcg )

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -58,6 +58,7 @@
 #include "VM_Wizard_Window.h"
 #include "System_Info.h"
 #include "VM_Devices.h"
+#include "QEMU_Probe_Catalog.h"
 #include "Guest_Capabilities.h"
 #include "ISO_Guess.h"
 #include "URL_Fetch.h"
@@ -115,6 +116,7 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	Guest_RAM_MB = 2048;
 	Guest_HDD_GB = 20.0;
 	Guest_NIC_Model = "e1000";
+	Guest_CPU_Type.clear();
 	Guest_Sound = VM::Sound_Cards();
 	Guest_Sound.Audio_HDA = true;
 	Guest_Suggest_Win2K_Hack = false;
@@ -1142,6 +1144,10 @@ bool VM_Wizard_Window::Ensure_Emulator_Ready()
 	Current_Emulator = Get_Default_Emulator();
 	All_Systems = Current_Emulator.Get_Devices();
 
+	// Overlay qemu_probe_full_v3 so Machine/CPU lists are complete (not stale First-Start XML).
+	for( QMap<QString, Available_Devices>::iterator it = All_Systems.begin(); it != All_Systems.end(); ++it )
+		QEMU_Probe_Catalog::Merge_Into( it.value() );
+
 	if( ! All_Systems.isEmpty() && All_Systems.count() >= 5 )
 	{
 		ui.CB_Computer_Type->clear();
@@ -1386,6 +1392,7 @@ void VM_Wizard_Window::Apply_OS_Defaults( const QString &os_name )
 	Guest_RAM_MB = 2048;
 	Guest_HDD_GB = 20.0;
 	Guest_NIC_Model = "e1000";
+	Guest_CPU_Type.clear();
 	Guest_Compat_Tip.clear();
 
 	const QString host = AQ_Get_Host_CPU_Architecture();
@@ -1428,6 +1435,7 @@ void VM_Wizard_Window::Apply_OS_Defaults( const QString &os_name )
 		Guest_RAM_MB = profile.value( "ram_mb" ).toInt( 2048 );
 		Guest_HDD_GB = profile.value( "hdd_gb" ).toDouble( 20.0 );
 		Guest_NIC_Model = profile.value( "nic" ).toString( "e1000" );
+		Guest_CPU_Type = profile.value( "cpu" ).toString();
 		Apply_Sound_Preset( profile.value( "sound" ).toString( "hda" ) );
 		Guest_Compat_Tip = profile.value( "tip" ).toString();
 
@@ -1688,8 +1696,122 @@ void VM_Wizard_Window::Update_Guest_Compat_Tip()
 	Update_Architecture_Page_Chrome();
 }
 
+QString VM_Wizard_Window::Recommended_CPU_Type() const
+{
+	QString target = Selected_Target;
+	if( target.isEmpty() && Current_Devices )
+	{
+		target = Current_Devices->System.QEMU_Name;
+		target.remove( QStringLiteral( "qemu-system-" ) );
+	}
+	if( target.isEmpty() )
+		target = QStringLiteral( "x86_64" );
+
+	const QString binary = QStringLiteral( "qemu-system-" ) + target;
+	const QString os = Selected_OS_Name;
+
+	// 1) Explicit cpu from wizard_trees.json os_profiles (probe-validated offline)
+	if( ! Guest_CPU_Type.isEmpty() )
+	{
+		const QString from_profile = QEMU_Probe_Catalog::First_Available_CPU(
+			binary, QStringList() << Guest_CPU_Type );
+		if( ! from_profile.isEmpty() )
+			return from_profile;
+	}
+
+	// 2) Era / OS class heuristics, always filtered through qemu_probe_full_v3
+	QStringList candidates;
+
+	const bool dos_or_win16 =
+		os.contains( QLatin1String( "MS-DOS" ) ) ||
+		os.contains( QLatin1String( "PC DOS" ) ) ||
+		os.contains( QLatin1String( "DR-DOS" ) ) ||
+		os.startsWith( QLatin1String( "Windows 1" ) ) ||
+		os.startsWith( QLatin1String( "Windows 2" ) ) ||
+		os.startsWith( QLatin1String( "Windows 3" ) );
+	const bool win9x =
+		os == QLatin1String( "Windows 95" ) ||
+		os == QLatin1String( "Windows 98" ) ||
+		os == QLatin1String( "Windows ME" ) ||
+		os.startsWith( QLatin1String( "Windows NT 3" ) ) ||
+		os == QLatin1String( "Windows NT 4.0" );
+	const bool xp_family =
+		os == QLatin1String( "Windows 2000" ) ||
+		os.startsWith( QLatin1String( "Windows XP" ) ) ||
+		os == QLatin1String( "Windows Server 2000" ) ||
+		os == QLatin1String( "Windows Server 2003" );
+	const bool classic_mac =
+		os.contains( QLatin1String( "Mac OS 7" ) ) ||
+		os.contains( QLatin1String( "Mac OS 8" ) ) ||
+		os.contains( QLatin1String( "Mac OS 9" ) ) ||
+		os.contains( QLatin1String( "Mac OS X PPC" ) );
+
+	if( dos_or_win16 )
+		candidates << "486" << "pentium" << "pentium2";
+	else if( win9x )
+		candidates << "pentium2" << "pentium" << "qemu32";
+	else if( xp_family || os.contains( QLatin1String( "OS/2" ) ) ||
+	         os.contains( QLatin1String( "ReactOS" ) ) )
+	{
+		if( os.contains( QLatin1String( "64-bit" ) ) || target == QLatin1String( "x86_64" ) )
+			candidates << "qemu64" << "max";
+		else
+			candidates << "pentium3" << "qemu32";
+	}
+	else if( classic_mac || target == QLatin1String( "ppc" ) )
+		candidates << "g4" << "750" << "ppc";
+	else if( target == QLatin1String( "ppc64" ) || os == QLatin1String( "AIX" ) )
+		candidates << "power8_v2.0" << "power8" << "power9_v2.0";
+	else if( target == QLatin1String( "aarch64" ) )
+		candidates << "max" << "cortex-a72" << "cortex-a57";
+	else if( target == QLatin1String( "arm" ) )
+		candidates << "max" << "cortex-a15" << "cortex-a9";
+	else if( target.startsWith( QLatin1String( "riscv" ) ) )
+		candidates << "max" << "rv64" << "rv32";
+	else if( target == QLatin1String( "s390x" ) )
+		candidates << "max" << "qemu";
+	else if( target.startsWith( QLatin1String( "sparc" ) ) )
+		candidates << "TI-UltraSparc-II" << "Fujitsu-Sparc64";
+	else if( target == QLatin1String( "hppa" ) )
+		candidates << "pa-8700" << "pa-8500";
+	else if( target == QLatin1String( "i386" ) )
+		candidates << "qemu32" << "pentium3" << "max";
+	else // x86_64 and everything else modern
+		candidates << "max" << "qemu64" << "host";
+
+	return QEMU_Probe_Catalog::First_Available_CPU( binary, candidates );
+}
+
+void VM_Wizard_Window::Select_Recommended_CPU_In_Combo()
+{
+	if( ! Current_Devices || ui.CB_CPU_Type->count() <= 0 )
+		return;
+
+	const QString want = Recommended_CPU_Type();
+	if( want.isEmpty() )
+		return;
+
+	for( int i = 0; i < Current_Devices->CPU_List.count() && i < ui.CB_CPU_Type->count(); ++i )
+	{
+		if( Current_Devices->CPU_List[i].QEMU_Name.compare( want, Qt::CaseInsensitive ) == 0 )
+		{
+			ui.CB_CPU_Type->setCurrentIndex( i );
+			return;
+		}
+	}
+}
+
 void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 {
+	// Always apply a probe-validated CPU before special-case overrides.
+	// Typical mode hides the CPU combo, which previously left index 0 (= 486 from
+	// qemu_probe_full_v3) as the saved CPU for Ubuntu and other modern guests.
+	{
+		const QString cpu = Recommended_CPU_Type();
+		if( ! cpu.isEmpty() )
+			New_VM->Set_CPU_Type( cpu );
+	}
+
 	const Guest_Capabilities caps = Current_Guest_Capabilities();
 	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
 	{
@@ -1885,13 +2007,44 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 		}
 		else if( classic_mac )
 		{
+			// Always classic Mac hardware — never leave Machine_Type empty on ppc64
+			// (QEMU defaults to pseries/SLOF, which is AIX/Linux, not Mac OS X).
+			New_VM->Set_Computer_Type( QStringLiteral( "qemu-system-ppc" ) );
+			New_VM->Set_Machine_Type( QStringLiteral( "mac99" ) );
+			New_VM->Set_CPU_Type( QStringLiteral( "g4" ) );
+			New_VM->Set_Memory_Size( qMin( New_VM->Get_Memory_Size(), 2048 ) );
+			if( New_VM->Get_Memory_Size() < 512 )
+				New_VM->Set_Memory_Size( 512 );
 			// mac99 uses onboard video/USB; do not force x86 cirrus / virtio-gpu.
 			New_VM->Set_Video_Card( QString() );
 			New_VM->Set_Mouse_Type( QStringLiteral( "usb-tablet" ) );
 			New_VM->Set_Mouse_USB_Controller( QStringLiteral( "auto" ) );
 			New_VM->Set_SMP_CPU_Count( 1 );
 			New_VM->Use_ACPI( false );
-			New_VM->Use_Force_TCG( false );
+			New_VM->Use_Force_TCG( true );
+			New_VM->Set_Machine_Accelerator( VM::TCG );
+			New_VM->Use_Intel_MacOS_Profile( false );
+			New_VM->Use_Launch_Via_WSL( false );
+			New_VM->Set_OpenCore_Boot_Path( QString() );
+			New_VM->Set_Mac_Recovery_Image_Path( QString() );
+			{
+				VM::Sound_Cards audio; // board Screamer via -device, not PC HDA
+				New_VM->Set_Audio_Cards( audio );
+			}
+			VM_HDD hda = New_VM->Get_HDA();
+			if( hda.Get_Enabled() )
+			{
+				VM_Native_Storage_Device native = hda.Get_Native_Device();
+				native.Use_Interface( true );
+				native.Set_Interface( VM::DI_IDE );
+				if( ! native.Use_File_Path() || native.Get_File_Path().trimmed().isEmpty() )
+				{
+					native.Use_File_Path( true );
+					native.Set_File_Path( hda.Get_File_Name() );
+				}
+				hda.Set_Native_Device( native );
+				New_VM->Set_HDA( hda );
+			}
 			// Prefer sungem / macio-nic when the probed PPC device list has them
 			if( Current_Devices )
 			{
@@ -1909,6 +2062,8 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 				}
 				Guest_NIC_Model = nic; // empty = leave unset rather than e1000
 			}
+			if( Guest_NIC_Model.isEmpty() )
+				Guest_NIC_Model = QStringLiteral( "sungem" );
 			// Screamer is not a modern -device checkbox; hint via additional args if empty.
 			if( New_VM->Get_Additional_Args().trimmed().isEmpty() )
 				New_VM->Set_Additional_Args( QStringLiteral( "-device screamer" ) );
@@ -4345,10 +4500,12 @@ void VM_Wizard_Window::applyTemplate()
 	}
 	else
 	{
-		// Add CPU's
+		// Add CPUs from emulator/probe list, then select the OS-recommended model
+		// (never leave the combo on list[0] — that is often 486 on x86_64).
 		ui.CB_CPU_Type->clear();
 		for( int cx = 0; cx < Current_Devices->CPU_List.count(); ++cx )
 			ui.CB_CPU_Type->addItem( Current_Devices->CPU_List[cx].Caption );
+		Select_Recommended_CPU_In_Combo();
 	}
 
 	// Typical or custom mode
@@ -4565,7 +4722,16 @@ bool VM_Wizard_Window::Create_New_VM(bool simulate)
 			return false;
 		}
 		
-		New_VM->Set_CPU_Type( Current_Devices->CPU_List[ui.CB_CPU_Type->currentIndex()].QEMU_Name );
+		New_VM->Set_CPU_Type( Recommended_CPU_Type() );
+		// Custom mode: honour the user's combo selection when it is a real choice
+		if( ! ui.RB_Typical->isChecked() &&
+		    Current_Devices &&
+		    ui.CB_CPU_Type->currentIndex() >= 0 &&
+		    ui.CB_CPU_Type->currentIndex() < Current_Devices->CPU_List.count() )
+		{
+			New_VM->Set_CPU_Type(
+				Current_Devices->CPU_List[ui.CB_CPU_Type->currentIndex()].QEMU_Name );
+		}
 		
 		// Hard Disk
 		if( ! ui.Edit_HDA_File_Name->text().isEmpty() )

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -2203,6 +2203,12 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 	}
 
 	// Devices page / capability overrides (always win over class heuristics when set)
+	const Guest_Capabilities caps = Current_Guest_Capabilities();
+	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
+	{
+		VM::Sound_Cards no_sound;
+		New_VM->Set_Audio_Cards( no_sound );
+	}
 	if( ! Guest_Video_Card.isEmpty() )
 		New_VM->Set_Video_Card( Guest_Video_Card );
 	else if( Current_Guest_Capabilities().guest_class == Guest_Capabilities::Classic_Mac )

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -1690,7 +1690,13 @@ void VM_Wizard_Window::Update_Guest_Compat_Tip()
 
 void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 {
-	if( Three_Path_Active )
+	const Guest_Capabilities caps = Current_Guest_Capabilities();
+	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
+	{
+		VM::Sound_Cards no_sound;
+		New_VM->Set_Audio_Cards( no_sound );
+	}
+	else if( Three_Path_Active )
 	{
 		if( ! Selected_Machine_Id.isEmpty() )
 			New_VM->Set_Machine_Type( Selected_Machine_Id );
@@ -2203,7 +2209,6 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 	}
 
 	// Devices page / capability overrides (always win over class heuristics when set)
-	const Guest_Capabilities caps = Current_Guest_Capabilities();
 	if( caps.default_sound == QLatin1String( "none" ) || caps.sound_options.isEmpty() )
 	{
 		VM::Sound_Cards no_sound;
@@ -2211,7 +2216,7 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 	}
 	if( ! Guest_Video_Card.isEmpty() )
 		New_VM->Set_Video_Card( Guest_Video_Card );
-	else if( Current_Guest_Capabilities().guest_class == Guest_Capabilities::Classic_Mac )
+	else if( caps.guest_class == Guest_Capabilities::Classic_Mac )
 		New_VM->Set_Video_Card( QString() );
 
 	if( ! Guest_Disk_Bus.isEmpty() )
@@ -2351,6 +2356,24 @@ void VM_Wizard_Window::Build_Devices_Page()
 	add_row( tr( "Network card:" ), &CB_Dev_NIC );
 	add_row( tr( "Sound:" ), &CB_Dev_Sound );
 	add_row( tr( "Display:" ), &CB_Dev_Video );
+
+	QHBoxLayout *biosRow = new QHBoxLayout();
+	QLabel *lblBios = new QLabel( tr( "Machine BIOS / ROM:" ) );
+	lblBios->setMinimumWidth( 110 );
+	Edit_Dev_BIOS_File = new QLineEdit();
+	Edit_Dev_BIOS_File->setPlaceholderText( tr( "Optional custom firmware file (e.g. Rev_2.5_v66.bin for NeXT Cube)" ) );
+	QPushButton *btnBrowseBios = new QPushButton( tr( "Browse…" ) );
+	biosRow->addWidget( lblBios );
+	biosRow->addWidget( Edit_Dev_BIOS_File, 1 );
+	biosRow->addWidget( btnBrowseBios );
+	lay->addLayout( biosRow );
+
+	connect( btnBrowseBios, &QPushButton::clicked, this, [this]() {
+		const QString f = QFileDialog::getOpenFileName( this, tr( "Select BIOS / Firmware File" ),
+			QString(), tr( "ROM / Firmware Files (*.bin *.rom *.fd *.elf);;All Files (*)" ) );
+		if( ! f.isEmpty() && Edit_Dev_BIOS_File )
+			Edit_Dev_BIOS_File->setText( QDir::toNativeSeparators( f ) );
+	} );
 
 	CH_Dev_VirtIO_Extras = new QCheckBox( tr(
 		"VirtIO extras (RNG, balloon, keyboard) — only when the guest has VirtIO drivers" ) );
@@ -2583,6 +2606,8 @@ void VM_Wizard_Window::Apply_Devices_Page_To_State()
 	Guest_Video_Card = CB_Dev_Video ? CB_Dev_Video->currentData().toString() : Guest_Video_Card;
 	if( CB_Dev_Sound )
 		Apply_Sound_Preset( CB_Dev_Sound->currentData().toString() );
+	if( Edit_Dev_BIOS_File && ! Edit_Dev_BIOS_File->text().trimmed().isEmpty() )
+		New_VM->Set_BIOS_File( Edit_Dev_BIOS_File->text().trimmed() );
 	Guest_Use_VirtIO_Extras = CH_Dev_VirtIO_Extras && CH_Dev_VirtIO_Extras->isChecked();
 	Guest_Use_GPU_Passthrough = CH_Dev_GPU_Passthrough && CH_Dev_GPU_Passthrough->isChecked();
 	Guest_GPU_PCI = ( CB_Dev_GPU && Guest_Use_GPU_Passthrough )

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -282,6 +282,7 @@ class VM_Wizard_Window: public QDialog
 		QComboBox *CB_Dev_NIC;
 		QComboBox *CB_Dev_Sound;
 		QComboBox *CB_Dev_Video;
+		QLineEdit *Edit_Dev_BIOS_File;
 		QCheckBox *CH_Dev_VirtIO_Extras;
 		QCheckBox *CH_Dev_GPU_Passthrough;
 		QComboBox *CB_Dev_GPU;

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -263,6 +263,7 @@ class VM_Wizard_Window: public QDialog
 		int Guest_RAM_MB;
 		double Guest_HDD_GB;
 		QString Guest_NIC_Model;
+		QString Guest_CPU_Type;
 		VM::Sound_Cards Guest_Sound;
 		QString Guest_Compat_Tip;
 		QString Guest_Disk_Bus;
@@ -293,6 +294,9 @@ class VM_Wizard_Window: public QDialog
 		void Update_Architecture_Page_Chrome();
 		void Update_Guest_Compat_Tip();
 		void Apply_Guest_Hardware_To_New_VM();
+		/** Probe-validated default CPU for the selected OS / target (never blind list[0]). */
+		QString Recommended_CPU_Type() const;
+		void Select_Recommended_CPU_In_Combo();
 
 		void Ensure_Machine_Catalog();
 		void Append_Catalog_Machines( QTreeWidgetItem *parent, const QString &target );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,10 +29,12 @@
 #include <QFileDialog>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QDateTime>
 #include <QTextStream>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QStandardPaths>
 #ifndef Q_OS_WIN32
 #include <QtDBus>
 #endif
@@ -273,6 +275,7 @@ int AQEMU_Main::load_settings()
     AQEMU_Startup_Log( "settings: init" );
     init_qsettings();
 
+    AQEMU_Ensure_Writable_User_Paths( *settings );
     log_settings();
 
     Set_Show_Error_Window( true );
@@ -564,8 +567,8 @@ void AQEMU_Main::log_settings()
 
         QString log_path = settings->value("Log/Log_Path", "").toString();
         #ifdef Q_OS_WIN32
-        // Portable Windows builds: always write a fresh log beside aqemu.exe.
-        log_path = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/aqemu.log" );
+        // Always AppData on Windows (Store-safe; never write next to the exe).
+        log_path = AQEMU_Default_Log_Path();
         settings->setValue( "Log/Log_Path", log_path );
         #else
         if( log_path.isEmpty() )
@@ -595,6 +598,23 @@ void AQEMU_Main::log_settings()
             QTextStream out( &reset_file );
             out << "AQEMU " << CURRENT_AQEMU_VERSION << " run log\n";
             out << "Started: " << QDateTime::currentDateTime().toString( "yyyy.MM.dd hh:mm:ss zzz" ) << "\n\n";
+            out << "User data: " << AQEMU_User_Data_Dir() << "\n";
+            out << "VM directory: " << settings->value( "VM_Directory" ).toString() << "\n\n";
+        }
+        else
+        {
+            QString fallback = QStandardPaths::writableLocation(
+                QStandardPaths::TempLocation ) + "/aqemu.log";
+            fallback = QDir::toNativeSeparators( fallback );
+            settings->setValue( "Log/Log_Path", fallback );
+            log_path = fallback;
+            QFile tmp( fallback );
+            if( tmp.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
+            {
+                QTextStream out( &tmp );
+                out << "AQEMU " << CURRENT_AQEMU_VERSION << " run log (temp fallback)\n";
+                out << "Started: " << QDateTime::currentDateTime().toString( "yyyy.MM.dd hh:mm:ss zzz" ) << "\n\n";
+            }
         }
     }
     else AQUse_Log( false );
@@ -638,20 +658,21 @@ void AQEMU_Main::vm_dir_exists_or_create()
 {
     // VM Directory Exists?
     QDir vm_dir;
-    if( ! vm_dir.exists(settings->value("VM_Directory", "").toString()) )
+    const QString configured = settings->value("VM_Directory", "").toString();
+    if( ! vm_dir.exists(configured) )
     {
+        #ifdef Q_OS_WIN32
+        const QString create_path = AQEMU_Default_VM_Directory();
+        settings->setValue( "VM_Directory", create_path );
+        AQEMU_Startup_Log( QStringLiteral( "Created VM directory: %1" ).arg( create_path ) );
+        #else
         int ret = QMessageBox::question( NULL, QObject::tr("Warning!"),
                                          QObject::tr("AQEMU VM Folder doesn't Exists! Create It?"),
                                          QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes );
 
         if( ret == QMessageBox::Yes )
-        {
-            #ifdef Q_OS_WIN32
-            vm_dir.mkpath( QDir::toNativeSeparators(QDir::homePath() + "/AQEMU_VM/") );
-            #else
             vm_dir.mkpath( QDir::homePath() + "/.aqemu" );
-            #endif
-        }
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary

AQEMU **1.1.0** (MSIX **1.1.0.0**) — drive Main Window / Custom option lists from `qemu_probe_full_v3`, keep the New VM wizard curated with probe-validated OS defaults, and ship Store-safe path fixes.

### Highlights
- **Full QEMU option lists (Main Window / Custom / arch switch):** machines, CPUs, NICs, and display devices per architecture from `qemu_probe_full_v3` via new `QEMU_Probe_Catalog`
- **Wizard stays safe:** Guest_Capabilities curated devices; every OS profile gets a probe-validated `cpu` (Ubuntu 64-bit → `max`, not `486`)
- **m68k / NeXT / classic Mac honesty:** suppress invalid x86 floppy/IDE/HDA; BIOS/ROM picker on wizard Devices + Advanced Options
- **Store / Windows packaging:** app version `1.1.0`, MSIX script default `1.1.0.0`, PublisherDisplayName **Philip Sempers**
- **Writable user data:** logs and VM dirs under `%LOCALAPPDATA%` (Store-safe)

### Changelog (this PR vs `master`)

#### Features
- Load and merge `qemu_probe_full_v3/{arch}.json` into emulator device lists for Machine / CPU / Network / Video
- Architecture change in Main Window refreshes full catalogs without re-running the wizard
- Wizard `Recommended_CPU_Type()` + `cpu` field on all 193 `os_profiles`
- Machine BIOS / ROM (`-bios`) picker on Wizard Devices page and Advanced Options browse button
- Bundle `qemu_probe_full_v3` next to `aqemu.exe` (CMake post-build)

#### Fixes
- Stop taking CPU combo index 0 (probe list starts with `486` on x86_64)
- Do not whitelist-rewrite user video picks or clamp disk bus on the power-user Main Window path
- Launch non-legacy display devices via `-device` (e.g. `ati-vga`, `sm501`)
- IRIX → `mips64`/`magnum`; HP-UX → `B160L`; Other → `q35`
- m68k: no intel-hda / invalid IDE+floppy / multi-thread TCG misuse
- Windows: do not write logs next to the install dir (Store package is read-only)

#### Docs / tooling
- `scripts/final_probe_audit.py`, `scripts/audit_wizard_vs_probes.py`
- `docs/final_probe_audit.json`, `docs/wizard_probe_audit.json`
- Packaging README + installer docs bumped to 1.1.0

### Test plan
- [ ] New Ubuntu (64-bit) Typical VM → CPU is `max` (not `486`)
- [ ] Main Window: switch Computer Type → Machine/CPU/Video/NIC lists expand to probe inventory
- [ ] Custom / Architecture wizard path still lists all bundled `qemu-system-*` targets
- [ ] m68k / NeXT profile does not attach HDA or x86 floppy controllers
- [ ] About shows **1.1.0** / 2026-07-29
- [ ] MSIX identity Version=`1.1.0.0`, PublisherDisplayName=`Philip Sempers`
