### PR TITLE
Fix VM setting persistence and wizard memory defaults

### DIFF
--- a/resources/wizard_trees.json
+++ b/resources/wizard_trees.json
@@ -1073,7 +1073,7 @@
     "RHEL": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1083,7 +1083,7 @@
     "Rocky Linux": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1093,7 +1093,7 @@
     "AlmaLinux": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1103,7 +1103,7 @@
     "SUSE Linux": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1113,7 +1113,7 @@
     "Gentoo": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1123,7 +1123,7 @@
     "Slackware": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1133,7 +1133,7 @@
     "Kali Linux": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1577,7 +1577,7 @@
     "CentOS Stream": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1613,7 +1613,7 @@
     "Void Linux": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1866,11 +1866,11 @@
     "Ubuntu (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
-      "tip": "Ubuntu → x86_64 (PC) + Q35. VirtIO net suggested; change Computer Type if needed.",
+      "tip": "Ubuntu desktop → x86_64 + Q35, 4 GB RAM recommended (GNOME live/install fails on 2 GB under TCG). Prefer WHPX/KVM; CPU max.",
       "cpu": "max"
     },
     "Ubuntu (32-bit)": {
@@ -1886,7 +1886,7 @@
     "Debian (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1906,7 +1906,7 @@
     "Fedora (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1926,7 +1926,7 @@
     "Alpine Linux (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 1024,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1936,7 +1936,7 @@
     "Alpine Linux (32-bit)": {
       "target": "i386",
       "machine": "pc",
-      "ram_mb": 1024,
+      "ram_mb": 512,
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
@@ -1946,7 +1946,7 @@
     "Tiny Core Linux (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 512,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1956,7 +1956,7 @@
     "Tiny Core Linux (32-bit)": {
       "target": "i386",
       "machine": "pc",
-      "ram_mb": 1024,
+      "ram_mb": 256,
       "hdd_gb": 10,
       "nic": "virtio-net-pci",
       "sound": "ac97",
@@ -1966,7 +1966,7 @@
     "Generic Linux (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -1986,7 +1986,7 @@
     "Arch Linux (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2006,7 +2006,7 @@
     "openSUSE (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2026,7 +2026,7 @@
     "Linux Mint (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2046,7 +2046,7 @@
     "FreeBSD (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2066,7 +2066,7 @@
     "OpenBSD (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2086,7 +2086,7 @@
     "NetBSD (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2106,7 +2106,7 @@
     "Haiku (64-bit)": {
       "target": "x86_64",
       "machine": "q35",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 20,
       "nic": "virtio-net-pci",
       "sound": "hda_virtio",
@@ -2136,7 +2136,7 @@
     "ReactOS (64-bit)": {
       "target": "x86_64",
       "machine": "pc",
-      "ram_mb": 2048,
+      "ram_mb": 4096,
       "hdd_gb": 8,
       "nic": "e1000",
       "sound": "ac97",

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -1455,41 +1455,53 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
     // Machine Accelerator (prefer UserRole id over translated text)
 	{
 		const QVariant accel_data = ui.CB_Machine_Accelerator->currentData( Qt::UserRole );
-		if( accel_data.isValid() && ! accel_data.toString().isEmpty() )
-			tmp_vm->Set_Machine_Accelerator( VM::String_To_Accel( accel_data.toString() ) );
-		else
-			tmp_vm->Set_Machine_Accelerator( VM::String_To_Accel( ui.CB_Machine_Accelerator->currentText() ) );
+		QString accel_id = accel_data.isValid() ? accel_data.toString().trimmed().toLower() : QString();
+		if( accel_id.isEmpty() )
+		{
+			const QString caption = ui.CB_Machine_Accelerator->currentText().trimmed().toLower();
+			if( caption.startsWith( QLatin1String( "tcg" ) ) || caption.contains( QLatin1String( "software" ) ) )
+				accel_id = QStringLiteral( "tcg" );
+			else if( caption.startsWith( QLatin1String( "kvm" ) ) || caption.contains( QLatin1String( "whpx" ) ) )
+				accel_id = QStringLiteral( "kvm" );
+			else if( caption.startsWith( QLatin1String( "xen" ) ) )
+				accel_id = QStringLiteral( "xen" );
+			else
+				accel_id = caption;
+		}
+		tmp_vm->Set_Machine_Accelerator( VM::String_To_Accel( accel_id ) );
 	}
 
 	// Computer Type
 	tmp_vm->Set_Computer_Type( curComp.System.QEMU_Name );
 
-	// Machine Type
-	if( ui_arch.CB_Machine_Type->currentIndex() != -1 && ui_arch.CB_Machine_Type->currentIndex() < curComp.Machine_List.count() )
+	// Machine Type — Main combo is what the user sees; keep ui_arch in sync
 	{
-		tmp_vm->Set_Machine_Type( curComp.Machine_List[ui_arch.CB_Machine_Type->currentIndex()].QEMU_Name );
-	}
-	else if( ! ui_arch.CB_Machine_Type->currentText().isEmpty() )
-	{
-		tmp_vm->Set_Machine_Type( ui_arch.CB_Machine_Type->currentText() );
-	}
-	else
-	{
-		tmp_vm->Set_Machine_Type( old_vm->Get_Machine_Type() );
+		int mi = ui.CB_Machine_Type_Main->currentIndex();
+		if( mi < 0 || mi >= curComp.Machine_List.count() )
+			mi = ui_arch.CB_Machine_Type->currentIndex();
+		if( mi >= 0 && mi < curComp.Machine_List.count() )
+			tmp_vm->Set_Machine_Type( curComp.Machine_List[mi].QEMU_Name );
+		else if( ! ui.CB_Machine_Type_Main->currentText().isEmpty() )
+			tmp_vm->Set_Machine_Type( ui.CB_Machine_Type_Main->currentText() );
+		else if( ! ui_arch.CB_Machine_Type->currentText().isEmpty() )
+			tmp_vm->Set_Machine_Type( ui_arch.CB_Machine_Type->currentText() );
+		else
+			tmp_vm->Set_Machine_Type( old_vm->Get_Machine_Type() );
 	}
 
 	// CPU Type
-	if( ui_arch.CB_CPU_Type->currentIndex() != -1 && ui_arch.CB_CPU_Type->currentIndex() < curComp.CPU_List.count() )
 	{
-		tmp_vm->Set_CPU_Type( curComp.CPU_List[ui_arch.CB_CPU_Type->currentIndex()].QEMU_Name );
-	}
-	else if( ! ui_arch.CB_CPU_Type->currentText().isEmpty() )
-	{
-		tmp_vm->Set_CPU_Type( ui_arch.CB_CPU_Type->currentText() );
-	}
-	else
-	{
-		tmp_vm->Set_CPU_Type( old_vm->Get_CPU_Type() );
+		int ci = ui.CB_CPU_Type_Main->currentIndex();
+		if( ci < 0 || ci >= curComp.CPU_List.count() )
+			ci = ui_arch.CB_CPU_Type->currentIndex();
+		if( ci >= 0 && ci < curComp.CPU_List.count() )
+			tmp_vm->Set_CPU_Type( curComp.CPU_List[ci].QEMU_Name );
+		else if( ! ui.CB_CPU_Type_Main->currentText().isEmpty() )
+			tmp_vm->Set_CPU_Type( ui.CB_CPU_Type_Main->currentText() );
+		else if( ! ui_arch.CB_CPU_Type->currentText().isEmpty() )
+			tmp_vm->Set_CPU_Type( ui_arch.CB_CPU_Type->currentText() );
+		else
+			tmp_vm->Set_CPU_Type( old_vm->Get_CPU_Type() );
 	}
 
 	// Create Emulator Info
@@ -2313,6 +2325,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 
     int found = false;
 	const QString want_accel = VM::Accel_To_String( tmp_vm->Get_Machine_Accelerator() ).toLower();
+	ui.CB_Machine_Accelerator->blockSignals( true );
 	for( int ix = 0; ix < ui.CB_Machine_Accelerator->count(); ix++ )
 	{
 		const QString id = ui.CB_Machine_Accelerator->itemData( ix, Qt::UserRole ).toString().toLower();
@@ -2329,8 +2342,10 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
     {
     	ui.CB_Machine_Accelerator->setCurrentIndex( 0 );
     }
+	ui.CB_Machine_Accelerator->blockSignals( false );
 
 	Enforce_Accel_Honesty();
+	Update_Accelerator_Options();
 
 	/*if( ui.CB_Machine_Accelerator->count() <= 0 )
 	{
@@ -5630,7 +5645,11 @@ void Main_Window::on_CB_Computer_Type_currentIndexChanged( int index )
 
 void Main_Window::on_CB_Machine_Accelerator_currentIndexChanged( int index )
 {
-	Apply_Emulator( 1 );
+	Q_UNUSED( index );
+	// Do NOT call Apply_Emulator(1): its old fall-through rebuilt computer/machine/CPU
+	// lists and auto-saved index 0, so picking TCG/KVM silently rewrote other settings.
+	Update_Accelerator_Options();
+	VM_Changed();
 }
 
 
@@ -5656,15 +5675,26 @@ void Main_Window::Computer_Type_Changed()
     ui.CB_Machine_Type_Main->blockSignals(true);
     ui.CB_Video_Card->blockSignals(true);
 
+	// Keep the user's current picks across list rebuilds (accel refresh, same-arch re-entry).
+	const QString keep_machine_caption = ui.CB_Machine_Type_Main->currentText();
+	const QString keep_cpu_caption = ui.CB_CPU_Type_Main->currentText();
+
+	curComp = Get_Current_Machine_Devices( &devOk );
+	if( ! devOk )
+	{
+		ui_arch.CB_CPU_Type->blockSignals(false);
+		ui_arch.CB_Machine_Type->blockSignals(false);
+		ui.CB_CPU_Type_Main->blockSignals(false);
+		ui.CB_Machine_Type_Main->blockSignals(false);
+		ui.CB_Video_Card->blockSignals(false);
+		return;
+	}
+
 	// CPU
 	ui_arch.CB_CPU_Type->clear();
 	ui.CB_CPU_Type_Main->clear();
 
 	cl = QStringList();
-
-	curComp = Get_Current_Machine_Devices( &devOk );
-	if( ! devOk )
-	    return;
 
 	for( int mx = 0; mx < curComp.CPU_List.count(); ++mx )
 		cl << curComp.CPU_List[mx].Caption;
@@ -5684,53 +5714,73 @@ void Main_Window::Computer_Type_Changed()
 	ui_arch.CB_Machine_Type->addItems( cl );
 	ui.CB_Machine_Type_Main->addItems( cl );
 
-	// Prefer virt / max for aarch64 (and friends) as the working default
 	const QString arch_bin = curComp.System.QEMU_Name;
 	const bool is_virt_arch =
 		arch_bin.contains( "aarch64", Qt::CaseInsensitive ) ||
 		arch_bin.contains( "qemu-system-arm", Qt::CaseInsensitive ) ||
 		arch_bin.contains( "riscv", Qt::CaseInsensitive );
 
-	if( is_virt_arch )
+	Virtual_Machine *cur_vm = Get_Current_VM();
+	QString want_machine;
+	QString want_cpu;
+	const bool same_arch = cur_vm && ( cur_vm->Get_Computer_Type() == arch_bin );
+	if( same_arch )
 	{
+		want_machine = cur_vm->Get_Machine_Type();
+		want_cpu = cur_vm->Get_CPU_Type();
+	}
+
+	auto select_machine = [&]( const QString &qemu_name ) -> bool
+	{
+		if( qemu_name.isEmpty() ) return false;
 		for( int mx = 0; mx < curComp.Machine_List.count(); ++mx )
 		{
-			if( curComp.Machine_List[mx].QEMU_Name == "virt" )
+			if( curComp.Machine_List[mx].QEMU_Name == qemu_name ||
+			    curComp.Machine_List[mx].Caption == qemu_name )
 			{
 				ui_arch.CB_Machine_Type->setCurrentIndex( mx );
 				ui.CB_Machine_Type_Main->setCurrentIndex( mx );
-				break;
+				return true;
 			}
 		}
-		QString prefer_cpu =
-		#ifdef Q_OS_WIN32
-			"max";
-		#else
-			"host";
-		#endif
-		int cpu_idx = -1;
+		return false;
+	};
+	auto select_cpu = [&]( const QString &qemu_name ) -> bool
+	{
+		if( qemu_name.isEmpty() ) return false;
 		for( int cx = 0; cx < curComp.CPU_List.count(); ++cx )
 		{
-			if( curComp.CPU_List[cx].QEMU_Name == prefer_cpu )
+			if( curComp.CPU_List[cx].QEMU_Name == qemu_name ||
+			    curComp.CPU_List[cx].Caption == qemu_name )
 			{
-				cpu_idx = cx;
-				break;
+				ui_arch.CB_CPU_Type->setCurrentIndex( cx );
+				ui.CB_CPU_Type_Main->setCurrentIndex( cx );
+				return true;
 			}
-			if( cpu_idx < 0 && curComp.CPU_List[cx].QEMU_Name == "max" )
-				cpu_idx = cx;
 		}
-		if( cpu_idx >= 0 )
+		return false;
+	};
+
+	// 1) Restore VM values when arch is unchanged
+	// 2) Else keep current UI captions if they still exist in the new list
+	// 3) Else virt/max defaults for virt arches (new arch only)
+	if( ! select_machine( want_machine ) )
+		if( ! select_machine( keep_machine_caption ) )
+			if( is_virt_arch )
+				select_machine( QStringLiteral( "virt" ) );
+
+	if( ! select_cpu( want_cpu ) )
+	{
+		if( ! select_cpu( keep_cpu_caption ) && is_virt_arch )
 		{
-			ui_arch.CB_CPU_Type->setCurrentIndex( cpu_idx );
-			ui.CB_CPU_Type_Main->setCurrentIndex( cpu_idx );
-		}
-		for( int vx = 0; vx < curComp.Video_Card_List.count(); ++vx )
-		{
-			if( curComp.Video_Card_List[vx].QEMU_Name == "virtio-gpu-pci" )
-			{
-				// Will set after video list is filled below
-				break;
-			}
+			QString prefer_cpu =
+			#ifdef Q_OS_WIN32
+				QStringLiteral( "max" );
+			#else
+				QStringLiteral( "host" );
+			#endif
+			if( ! select_cpu( prefer_cpu ) )
+				select_cpu( QStringLiteral( "max" ) );
 		}
 	}
 
@@ -5738,13 +5788,12 @@ void Main_Window::Computer_Type_Changed()
 	ui.CB_Video_Card->clear();
 
 	QString want_video = System_Info::Default_Video_Card( arch_bin );
-	Virtual_Machine *cur_vm = Get_Current_VM();
-	if( cur_vm )
+	if( cur_vm && same_arch )
 	{
+		// UI-only sanitize — never mutate the live VM until Apply/save.
 		want_video = System_Info::Sanitize_Video_Card(
-			arch_bin, cur_vm->Get_Video_Card(), cur_vm->Get_Machine_Type() );
-		if( want_video != cur_vm->Get_Video_Card() )
-			cur_vm->Set_Video_Card( want_video );
+			arch_bin, cur_vm->Get_Video_Card(),
+			want_machine.isEmpty() ? cur_vm->Get_Machine_Type() : want_machine );
 	}
 
 	for( int vx = 0; vx < curComp.Video_Card_List.count(); ++vx )
@@ -5800,6 +5849,7 @@ void Main_Window::Computer_Type_Changed()
 	Enforce_Accel_Honesty();
 	Enforce_Disk_Bus_Honesty();
 	Update_Disabled_Controls();
+	VM_Changed();
 }
 
 void Main_Window::on_CB_Machine_Type_Main_currentIndexChanged( int index )
@@ -5845,12 +5895,25 @@ void Main_Window::sync_arch_CPU_Type_changed( int index )
 
 void Main_Window::Update_Machine_Accelerators()
 {
-    ui.CB_Machine_Accelerator->blockSignals(true);
+	const QString keep = ui.CB_Machine_Accelerator->currentData( Qt::UserRole ).toString().toLower();
+
+	ui.CB_Machine_Accelerator->blockSignals( true );
 	ui.CB_Machine_Accelerator->clear();
-	ui.CB_Machine_Accelerator->addItem( tr("TCG"), QStringLiteral( "tcg" ) );
-	ui.CB_Machine_Accelerator->addItem( tr("KVM"), QStringLiteral( "kvm" ) );
-	ui.CB_Machine_Accelerator->addItem( tr("XEN"), QStringLiteral( "xen" ) );
-    ui.CB_Machine_Accelerator->blockSignals(false);
+	ui.CB_Machine_Accelerator->addItem( tr( "TCG" ), QStringLiteral( "tcg" ) );
+	ui.CB_Machine_Accelerator->addItem( tr( "KVM" ), QStringLiteral( "kvm" ) );
+	ui.CB_Machine_Accelerator->addItem( tr( "XEN" ), QStringLiteral( "xen" ) );
+
+	int restore = 0;
+	for( int i = 0; i < ui.CB_Machine_Accelerator->count(); ++i )
+	{
+		if( ui.CB_Machine_Accelerator->itemData( i, Qt::UserRole ).toString().toLower() == keep )
+		{
+			restore = i;
+			break;
+		}
+	}
+	ui.CB_Machine_Accelerator->setCurrentIndex( restore );
+	ui.CB_Machine_Accelerator->blockSignals( false );
 	Enforce_Accel_Honesty();
 }
 
@@ -5907,10 +5970,14 @@ void Main_Window::Enforce_Accel_Honesty()
 		}
 	}
 
+	bool forced_tcg = false;
 	if( ! is_native )
 	{
-		if( tcg_index >= 0 )
+		if( tcg_index >= 0 && ui.CB_Machine_Accelerator->currentIndex() != tcg_index )
+		{
 			ui.CB_Machine_Accelerator->setCurrentIndex( tcg_index );
+			forced_tcg = true;
+		}
 		ui.CB_Machine_Accelerator->setToolTip(
 			tr( "Cross-architecture emulation: host is %1, guest is %2. "
 			    "Native acceleration (KVM / WHPX / HVF) cannot run this guest. Using TCG." )
@@ -5925,6 +5992,10 @@ void Main_Window::Enforce_Accel_Honesty()
 
 	ui.CB_Machine_Accelerator->blockSignals( false );
 	Update_Accelerator_Options();
+
+	// If we had to override a impossible KVM/XEN pick, mark dirty so Apply saves TCG.
+	if( forced_tcg )
+		VM_Changed();
 }
 
 int Main_Window::Disk_Interface_To_Combo_Index( VM::Device_Interface iface ) const
@@ -6056,20 +6127,26 @@ void Main_Window::Apply_Emulator( int mode )
 	    return;
 	running = true;
 
+	// Modes are independent — no fall-through. The old cascade made mode 1
+	// (accelerator options) rebuild arch/machine/CPU and wipe the user's picks.
 	switch( mode )
 	{
 		case 0:
-			// Machine Accelerators
 			Update_Machine_Accelerators();
+			Update_Accelerator_Options();
+			Update_Computer_Types();
+			Computer_Type_Changed();
+			break;
 		case 1:
-            Update_Accelerator_Options();
+			Update_Accelerator_Options();
+			break;
 		case 2:
-			// Computer Type
-		    Update_Computer_Types();
+			Update_Computer_Types();
+			Computer_Type_Changed();
+			break;
 		case 3:
-            Computer_Type_Changed();
-            break;
-
+			Computer_Type_Changed();
+			break;
 		default:
 			AQWarning( "void Main_Window::Apply_Emulator( int mode )", "Default Section!" );
 			break;

--- a/src/VM_Devices.h
+++ b/src/VM_Devices.h
@@ -64,18 +64,17 @@ class VM
 
         static Machine_Accelerator String_To_Accel(QString accel)
         {
-            if (accel.toLower() == "qemu")
+            const QString a = accel.toLower().trimmed();
+            if (a == "qemu" || a == "tcg")
                 return VM::TCG;
-            else if (accel.toLower() == "tcg")
-                return VM::TCG;
-            else if (accel.toLower() == "kvm")
+            else if (a == "kvm" || a == "qemu-kvm" || a == "whpx" || a == "hax" || a == "hvf")
                 return VM::KVM;
-            else if (accel.toLower() == "qemu-kvm")
-                return VM::KVM;
-            else if (accel.toLower() == "xen")
+            else if (a == "xen")
                 return VM::XEN;
             else
-                return VM::KVM; //default //FIXME? is this a good default?
+                // Unknown / empty must not become KVM — that made TCG selections
+                // silently launch as WHPX/KVM when UserRole/text failed to parse.
+                return VM::TCG;
         }
 		
 		// Guest audio devices ( one or more )


### PR DESCRIPTION
## Summary
- preserve the accelerator, machine, CPU and video values selected in the main UI
- stop accelerator refreshes from falling through into architecture/machine/CPU rebuilds
- make unknown accelerator values fail safely to TCG instead of native acceleration
- persist forced TCG when the guest architecture cannot use host acceleration
- raise mainstream desktop Linux/BSD/Haiku/ReactOS wizard memory recommendations to 4 GB
- retain lightweight defaults for Alpine and Tiny Core Linux

## Root cause
`Apply_Emulator(1)` fell through its switch cases and rebuilt computer, machine and CPU controls after an accelerator change. The rebuilt controls could select index 0 and auto-save it. Unknown accelerator text also defaulted to KVM, allowing a failed parse to turn a TCG choice into WHPX/KVM.

## Validation
- `resources/wizard_trees.json` parses successfully
- `git diff --check` passes
- no IDE diagnostics in the changed files
- changed C++ objects compile; final Windows link is currently blocked because the running `aqemu.exe` locks the output binary (`Permission denied`)

## Scope
The hard-coded local audit helper `scripts/_print_audit_arch.py` is intentionally excluded.