### PR TITLE
Fix Reims Linux/WSL path and sync Apple SoC UI work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ SET( aqemu_headers
 	src/VM_Devices.h
 	src/VM_Wizard_Window.h
 	src/VNC_Password_Window.h
+	src/WSL_Wizard_Window.h
+	src/iOS_Firmware_Tool_Window.h
 	src/QMP_Client.h
 	src/QEMU_Help_Browser.h
 	src/Blockdev_Graph_Window.h
@@ -139,6 +141,7 @@ SET( aqemu_sources
 	src/HDD_Image_Info.cpp
 	src/main.cpp
 	src/Main_Window.cpp
+	src/WSL_Wizard_Window.cpp
 	src/Monitor_Window.cpp
 	src/Network_Widget.cpp
 	src/Old_Network_Widget.cpp
@@ -158,6 +161,7 @@ SET( aqemu_sources
 	src/VM_Wizard_Window.cpp
 	src/Guest_Capabilities.cpp
 	src/ISO_Guess.cpp
+	src/iOS_Firmware_Tool_Window.cpp
 	src/Storage_Browser_Window.cpp
 	src/Serial_Console_Window.cpp
 	src/URL_Fetch.cpp

--- a/README.md
+++ b/README.md
@@ -201,19 +201,24 @@ On **Raspberry Pi 5 / Linux aarch64** hosts, the same profile can lean on **KVM*
 
 ---
 
-## ⚡ Reims vGPU Acceleration Engine (`qemu-system-reimsvgpu.exe`)
+## ⚡ Reims vGPU Acceleration Engine (Linux / WSL)
 
-AQEMU now bundles **`qemu-system-reimsvgpu.exe`**, a specialized QEMU binary built from **steelbrain's `qemu-reims-vgpu`** project—the viral open-source graphics virtualization engine designed to bring **full 3D hardware-accelerated graphics to macOS guests** inside QEMU!
+AQEMU integrates **steelbrain's `qemu-reims-vgpu`** so Intel macOS guests can use Apple's built-in **`AppleParavirtGPU.kext`** with a host-side **Metal → Vulkan** translation path.
 
-### 🔮 How Reims vGPU Achieves macOS Hardware Graphics Acceleration:
-- **Zero Guest Kext Modifications**: macOS natively includes Apple's official **`AppleParavirtGPU.kext`** driver. `qemu-system-reimsvgpu.exe` exposes the MMIO/IRQ device shims that `AppleParavirtGPU` connects to out-of-the-box.
-- **Metal → Vulkan Translation Layer (`metal2vulkan`)**: The engine intercepts the guest macOS Metal GPU command streams and dynamically translates them into cross-platform Vulkan rendering calls on the host PC GPU.
-- **Native 3D Compositing & Window Server**: Enables Quartz Extreme, Metal UI animations, and smooth window compositing inside macOS VMs without requiring expensive dedicated GPU passthrough hardware!
+### Important (Windows hosts)
+- Real Reims acceleration requires the **Linux** binary **`qemu-system-reims3d`** under **WSL** (with KVM + a working Vulkan/GL stack).
+- The Windows `qemu-system-reimsvgpu.exe` helper is **not** a complete Reims build: it does **not** expose `reims-vgpu-pci`. AQEMU therefore **forces Launch via WSL** for Reims VMs and runs `/usr/local/bin/qemu-system-reims3d`.
+- Place or build `qemu-system-reims3d` inside your WSL distro (already installed at `/usr/local/bin/qemu-system-reims3d` on this development machine).
 
-### 🚀 AQEMU Integration Highlights:
-- **`macOS x86_64 vGPU (Reims)`**: Preset OS profile for running Intel macOS with native `AppleParavirtGPU` acceleration.
-- **`Windows 11 vGPU (Reims)`**: vGPU hardware passthrough/acceleration profile for Windows 11 guests.
-- **`qemu-system-reimsvgpu` Standalone Target**: Shipped as a dedicated executable alongside standard QEMU targets, pre-configured with `libslirp` User NAT networking, SPICE display, and DirectSound audio.
+### How Reims accelerates macOS graphics
+- **Zero guest kext mods**: macOS already includes **`AppleParavirtGPU.kext`**. The Reims QEMU device presents the MMIO/IRQ shims that driver expects (`-device reims-vgpu-pci`).
+- **Metal → Vulkan (`metal2vulkan`)**: guest Metal command streams are translated to host Vulkan.
+- **No dGPU VFIO required** for the paravirtual path (separate from optional AMD Metal passthrough on bare-metal Linux).
+
+### AQEMU integration
+- Wizard profiles: **`macOS x86_64 vGPU (Reims)`** (and related Reims targets)
+- Computer type: `qemu-system-reimsvgpu` (AQEMU label) → WSL launch of **`qemu-system-reims3d`**
+- Defaults: q35, OpenCore/Intel macOS profile fields, `reims-vgpu-pci`, Launch via WSL enabled
 
 ---
 

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -23,6 +23,8 @@
 
 #include <QDir>
 #include <QFileDialog>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QHeaderView>
 #include <QInputDialog>
 #include <QMessageBox>
@@ -51,7 +53,8 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 {
 	ui.setupUi( this );
 
-	AQ_Cap_Content_Width( this, 980 );
+	setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred );
+	AQ_Make_Tab_Scrollable( ui.Tab_General );
 
     settings_widget = new Settings_Widget( ui.All_Tabs, QBoxLayout::TopToBottom, true, false );
 
@@ -151,7 +154,9 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 
 	// WSL / KVM launch (Windows host)
 	CH_WSL_Launch_Enabled = nullptr;
-	Edit_WSL_Distro = nullptr;
+	CB_WSL_Distro = nullptr;
+	Edit_WSL_User = nullptr;
+	Edit_WSL_Password = nullptr;
 	Edit_WSL_Qemu_Binary = nullptr;
 	Label_WSL_KVM_Status = nullptr;
 	TB_WSL_Probe = nullptr;
@@ -162,17 +167,39 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 		CH_WSL_Launch_Enabled = new QCheckBox( tr( "Enable Launch via WSL/KVM (for Intel macOS and other VMs)" ) );
 		CH_WSL_Launch_Enabled->setChecked( Settings.value( "WSL_Launch/Enabled", false ).toBool() );
 		wslLay->addWidget( CH_WSL_Launch_Enabled );
+
 		QHBoxLayout *distroLay = new QHBoxLayout();
-		distroLay->addWidget( new QLabel( tr( "Distro (empty = default):" ) ) );
-		Edit_WSL_Distro = new QLineEdit( Settings.value( "WSL_Launch/Distro", "" ).toString() );
-		distroLay->addWidget( Edit_WSL_Distro );
+		distroLay->addWidget( new QLabel( tr( "Distro:" ) ) );
+		CB_WSL_Distro = new QComboBox();
+		CB_WSL_Distro->setEditable( true );
+		CB_WSL_Distro->addItem( "" );
+		CB_WSL_Distro->addItems( WSL_Get_Installed_Distros() );
+		const QString active_d = Settings.value( "WSL_Launch/Distro", "" ).toString();
+		CB_WSL_Distro->setCurrentText( active_d );
+		distroLay->addWidget( CB_WSL_Distro );
 		wslLay->addLayout( distroLay );
+
+		QHBoxLayout *userLay = new QHBoxLayout();
+		userLay->addWidget( new QLabel( tr( "WSL Username:" ) ) );
+		Edit_WSL_User = new QLineEdit( Settings.value( "WSL_Launch/Username", "" ).toString() );
+		userLay->addWidget( Edit_WSL_User );
+		wslLay->addLayout( userLay );
+
+		QHBoxLayout *passLay = new QHBoxLayout();
+		passLay->addWidget( new QLabel( tr( "WSL Password (optional, not saved):" ) ) );
+		Edit_WSL_Password = new QLineEdit();
+		Edit_WSL_Password->setEchoMode( QLineEdit::Password );
+		Edit_WSL_Password->setPlaceholderText( tr( "Prefer wsl -u root for admin tasks" ) );
+		passLay->addWidget( Edit_WSL_Password );
+		wslLay->addLayout( passLay );
+
 		QHBoxLayout *binLay = new QHBoxLayout();
 		binLay->addWidget( new QLabel( tr( "QEMU binary in WSL:" ) ) );
 		Edit_WSL_Qemu_Binary = new QLineEdit(
 			Settings.value( "WSL_Launch/Qemu_Binary", "qemu-system-x86_64" ).toString() );
 		binLay->addWidget( Edit_WSL_Qemu_Binary );
 		wslLay->addLayout( binLay );
+
 		QHBoxLayout *probeLay = new QHBoxLayout();
 		TB_WSL_Probe = new QToolButton();
 		TB_WSL_Probe->setText( tr( "Probe /dev/kvm" ) );
@@ -180,13 +207,17 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 		probeLay->addWidget( TB_WSL_Probe );
 		probeLay->addWidget( Label_WSL_KVM_Status, 1 );
 		wslLay->addLayout( probeLay );
+
 		QLabel *note = new QLabel( tr(
 			"SPICE/QMP stay on 127.0.0.1 — requires WSL localhostForwarding." ) );
 		note->setWordWrap( true );
 		wslLay->addWidget( note );
+
 		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.Tab_General->layout() ) )
 			gl->addWidget( wslBox, gl->rowCount(), 0, 1, gl->columnCount() );
-		connect( TB_WSL_Probe, SIGNAL(clicked()), this, SLOT(on_TB_WSL_Probe_clicked()) );
+
+		connect( TB_WSL_Probe, SIGNAL(clicked()), this, SLOT(On_TB_WSL_Probe_clicked()) );
+		connect( CB_WSL_Distro, SIGNAL(currentIndexChanged(int)), this, SLOT(On_CB_WSL_Distro_currentIndexChanged(int)) );
 	}
 #endif
 	
@@ -468,6 +499,18 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	
 	connect( ui.CB_Language, SIGNAL(currentIndexChanged(int)),
 			 this, SLOT(CB_Language_currentIndexChanged(int)) );
+
+	connect( ui.CB_Language, SIGNAL(currentIndexChanged(int)),
+			 this, SLOT(CB_Language_currentIndexChanged(int)) );
+
+	if( settings_widget )
+		AQ_Make_Tab_Scrollable( settings_widget );
+
+	const QRect scr = QGuiApplication::primaryScreen() ? QGuiApplication::primaryScreen()->availableGeometry() : QRect( 0, 0, 1024, 768 );
+	const int target_w = qMax( 950, static_cast<int>( scr.width() * 0.70 ) );
+	const int target_h = qMin( scr.height() - 100, static_cast<int>( scr.height() * 0.75 ) );
+	resize( target_w, target_h );
+	setMaximumHeight( target_h );
 }
 
 Advanced_Settings_Window::~Advanced_Settings_Window()
@@ -621,7 +664,10 @@ void Advanced_Settings_Window::done(int r)
 	    if( CH_WSL_Launch_Enabled )
 	    {
 		    Settings.setValue( "WSL_Launch/Enabled", CH_WSL_Launch_Enabled->isChecked() );
-		    Settings.setValue( "WSL_Launch/Distro", Edit_WSL_Distro ? Edit_WSL_Distro->text().trimmed() : QString() );
+		    Settings.setValue( "WSL_Launch/Distro", CB_WSL_Distro ? CB_WSL_Distro->currentText().trimmed() : QString() );
+		    Settings.setValue( "WSL_Launch/Username", Edit_WSL_User ? Edit_WSL_User->text().trimmed() : QString() );
+		    // Never persist WSL sudo passwords to disk.
+		    Settings.remove( "WSL_Launch/Password" );
 		    Settings.setValue( "WSL_Launch/Qemu_Binary",
 			    Edit_WSL_Qemu_Binary ? Edit_WSL_Qemu_Binary->text().trimmed() : QStringLiteral( "qemu-system-x86_64" ) );
 	    }
@@ -1328,7 +1374,7 @@ QStringList Advanced_Settings_Window::Get_All_Emulators_Names() const
 	return list;
 }
 
-void Advanced_Settings_Window::on_TB_WSL_Probe_clicked()
+void Advanced_Settings_Window::On_TB_WSL_Probe_clicked()
 {
 #ifdef Q_OS_WIN32
 	if( ! Label_WSL_KVM_Status )
@@ -1341,7 +1387,7 @@ void Advanced_Settings_Window::on_TB_WSL_Probe_clicked()
 			Label_WSL_KVM_Status->setText( tr( "Status: wsl.exe not available" ) );
 			return;
 		}
-		const QString distro = Edit_WSL_Distro ? Edit_WSL_Distro->text().trimmed() : QString();
+		const QString distro = CB_WSL_Distro ? CB_WSL_Distro->currentText().trimmed() : QString();
 		if( WSL_Ensure_KVM_Access( distro ) )
 			Label_WSL_KVM_Status->setText( tr( "Status: /dev/kvm OK" ) );
 		else if( WSL_Has_KVM( distro, true ) )
@@ -1351,5 +1397,23 @@ void Advanced_Settings_Window::on_TB_WSL_Probe_clicked()
 	} );
 #else
 	Q_UNUSED( 0 );
+#endif
+}
+
+void Advanced_Settings_Window::On_CB_WSL_Distro_currentIndexChanged( int index )
+{
+#ifdef Q_OS_WIN32
+	Q_UNUSED( index );
+	if( CB_WSL_Distro && Edit_WSL_User )
+	{
+		const QString distro = CB_WSL_Distro->currentText().trimmed();
+		if( ! distro.isEmpty() )
+		{
+			const QString defUser = WSL_Get_Distro_Default_User( distro );
+			Edit_WSL_User->setText( defUser );
+		}
+	}
+#else
+	Q_UNUSED( index );
 #endif
 }

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -156,7 +156,6 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	CH_WSL_Launch_Enabled = nullptr;
 	CB_WSL_Distro = nullptr;
 	Edit_WSL_User = nullptr;
-	Edit_WSL_Password = nullptr;
 	Edit_WSL_Qemu_Binary = nullptr;
 	Label_WSL_KVM_Status = nullptr;
 	TB_WSL_Probe = nullptr;
@@ -184,14 +183,6 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 		Edit_WSL_User = new QLineEdit( Settings.value( "WSL_Launch/Username", "" ).toString() );
 		userLay->addWidget( Edit_WSL_User );
 		wslLay->addLayout( userLay );
-
-		QHBoxLayout *passLay = new QHBoxLayout();
-		passLay->addWidget( new QLabel( tr( "WSL Password (optional, not saved):" ) ) );
-		Edit_WSL_Password = new QLineEdit();
-		Edit_WSL_Password->setEchoMode( QLineEdit::Password );
-		Edit_WSL_Password->setPlaceholderText( tr( "Prefer wsl -u root for admin tasks" ) );
-		passLay->addWidget( Edit_WSL_Password );
-		wslLay->addLayout( passLay );
 
 		QHBoxLayout *binLay = new QHBoxLayout();
 		binLay->addWidget( new QLabel( tr( "QEMU binary in WSL:" ) ) );
@@ -497,9 +488,6 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	connect( ui.RB_Emul_Show_VNC_In_Main_Window, SIGNAL(toggled(bool)),
 			 this, SLOT(VNC_Warning(bool)) );
 	
-	connect( ui.CB_Language, SIGNAL(currentIndexChanged(int)),
-			 this, SLOT(CB_Language_currentIndexChanged(int)) );
-
 	connect( ui.CB_Language, SIGNAL(currentIndexChanged(int)),
 			 this, SLOT(CB_Language_currentIndexChanged(int)) );
 

--- a/src/Advanced_Settings_Window.h
+++ b/src/Advanced_Settings_Window.h
@@ -72,7 +72,7 @@ class Advanced_Settings_Window: public QDialog
 		void on_Button_CDROM_Add_clicked();
 		void on_Button_CDROM_Edit_clicked();
 		void on_Button_CDROM_Delete_clicked();
-		void on_TB_WSL_Probe_clicked();
+		void On_TB_WSL_Probe_clicked();
 
 		void On_QEMU_Source_Toggled( bool checked );
 		void On_QEMU_Custom_Browse_clicked();
@@ -93,11 +93,17 @@ class Advanced_Settings_Window: public QDialog
 		QList<Emulator> Emulators;
 
 		QCheckBox *CH_WSL_Launch_Enabled;
-		QLineEdit *Edit_WSL_Distro;
+		class QComboBox *CB_WSL_Distro;
+		QLineEdit *Edit_WSL_User;
+		QLineEdit *Edit_WSL_Password;
 		QLineEdit *Edit_WSL_Qemu_Binary;
 		QLabel *Label_WSL_KVM_Status;
 		QToolButton *TB_WSL_Probe;
 
+	private slots:
+		void On_CB_WSL_Distro_currentIndexChanged( int index );
+
+	private:
 		QGroupBox *GB_QEMU_Source;
 		QRadioButton *RB_QEMU_Built_In;
 		QRadioButton *RB_QEMU_Custom;

--- a/src/Advanced_Settings_Window.h
+++ b/src/Advanced_Settings_Window.h
@@ -95,7 +95,6 @@ class Advanced_Settings_Window: public QDialog
 		QCheckBox *CH_WSL_Launch_Enabled;
 		class QComboBox *CB_WSL_Distro;
 		QLineEdit *Edit_WSL_User;
-		QLineEdit *Edit_WSL_Password;
 		QLineEdit *Edit_WSL_Qemu_Binary;
 		QLabel *Label_WSL_KVM_Status;
 		QToolButton *TB_WSL_Probe;

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -58,6 +58,7 @@
 #include <QPushButton>
 #include <QToolButton>
 #include <QAbstractButton>
+#include "iOS_Firmware_Tool_Window.h"
 #include <QStyle>
 #include <QFontMetrics>
 #include <QLineEdit>
@@ -92,6 +93,7 @@
 #include "VNC_Password_Window.h"
 #include "Copy_VM_Window.h"
 #include "Advanced_Settings_Window.h"
+#include "WSL_Wizard_Window.h"
 #include "First_Start_Wizard.h"
 #include "Emulator_Control_Window.h"
 #include "Boot_Device_Window.h"
@@ -151,6 +153,13 @@ Main_Window::Main_Window( QWidget *parent )
     ui.setupUi( this );
 	ui_ao.setupUi( Advanced_Options );
 
+	// Make the options body inside Advanced Options scrollable while keeping OK/Cancel fixed at the bottom
+	if( ui_ao.groupBox_options && ui_ao.groupBox_options->parentWidget() )
+	{
+		QWidget *container = ui_ao.groupBox_options->parentWidget();
+		AQ_Make_Tab_Scrollable( container, QStringLiteral( "AQ_Adv_Options_Inner" ) );
+	}
+
 	// File → Storage browser (VM_Directory pool)
 	{
 		QAction *actPool = new QAction( QIcon( ":/open-folder.png" ),
@@ -174,6 +183,17 @@ Main_Window::Main_Window( QWidget *parent )
 			dlg.exec();
 		} );
 		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actRemote );
+	}
+	// File → Configure WSL (Distro selection, username, password)
+	{
+		QAction *actWsl = new QAction( QIcon( ":/configure.png" ),
+			tr( "Configure &WSL…" ), this );
+		actWsl->setStatusTip( tr( "Set WSL default distribution, username, and password credentials" ) );
+		connect( actWsl, &QAction::triggered, this, [this]() {
+			WSL_Wizard_Window wizard( this );
+			wizard.exec();
+		} );
+		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actWsl );
 	}
 	if( ui.actionCopy )
 		ui.actionCopy->setText( tr( "Clone &VM…" ) );
@@ -337,6 +357,20 @@ Main_Window::Main_Window( QWidget *parent )
 
 	ui.TabWidget_Media->insertTab( 0, Dev_Manager, QIcon(":/hdd.png"), tr("Device Manager") );
     ui.TabWidget_Media->setCurrentWidget(Dev_Manager);
+
+	// Add explicit iOS Firmware tab into TabWidget_Media BEFORE Settings_Widget converts it
+	QWidget *tab_ios_fw = new QWidget();
+	QVBoxLayout *lay_fw = new QVBoxLayout( tab_ios_fw );
+	lay_fw->setContentsMargins( 20, 20, 20, 20 );
+	QLabel *lbl_fw = new QLabel( tr( "<h3>Apple iOS Firmware Unpacker & pyimg4 Tool</h3><p>Extract and decrypt IPSW archives, DeviceTree, kernelcache, and SEP payloads natively on Windows.</p>" ), tab_ios_fw );
+	lbl_fw->setWordWrap( true );
+	QPushButton *btn_open_fw = new QPushButton( QIcon( QStringLiteral( ":/default_mac.png" ) ), tr( "Launch iOS Firmware Unpacker Tool" ), tab_ios_fw );
+	btn_open_fw->setFixedHeight( 36 );
+	connect( btn_open_fw, &QPushButton::clicked, this, &Main_Window::slot_iOS_Firmware_Tool_triggered );
+	lay_fw->addWidget( lbl_fw );
+	lay_fw->addWidget( btn_open_fw );
+	lay_fw->addStretch();
+	ui.TabWidget_Media->addTab( tab_ios_fw, QIcon( QStringLiteral( ":/default_mac.png" ) ), tr( "iOS Firmware" ) );
 
     Media_Settings_Widget = new Settings_Widget( ui.TabWidget_Media, QBoxLayout::LeftToRight, true );
     Media_Settings_Widget->setIconSize( AQ_Nav_Icon_Size( this ) );
@@ -1032,6 +1066,8 @@ void Main_Window::Connect_Signals()
 	connect( ui.CH_Intel_Mac_WSL_Main, SIGNAL(toggled(bool)),
 			 this, SLOT(Update_Intel_Mac_GPU_Passthrough_Ui()) );
 	connect( ui.CH_Intel_Mac_WSL_Main, SIGNAL(toggled(bool)),
+			 this, SLOT(Update_Machine_Accelerators()) );
+	connect( ui.CH_Intel_Mac_WSL_Main, SIGNAL(toggled(bool)),
 			 this, SLOT(VM_Changed()) );
 	connect( ui.CH_Intel_Mac_GPU_Passthrough, SIGNAL(toggled(bool)),
 			 this, SLOT(VM_Changed()) );
@@ -1194,6 +1230,8 @@ void Main_Window::Connect_Signals()
 
 	connect( ui_ao.CH_Use_User_Binary, SIGNAL(clicked()),
 			 this, SLOT(VM_Changed()) );
+	connect( ui_ao.CH_Launch_Via_WSL, SIGNAL(clicked()),
+			 this, SLOT(Update_Machine_Accelerators()) );
 
 	// Hardware Virtualization Tab
 
@@ -1277,6 +1315,15 @@ void Main_Window::Connect_Signals()
 			 this, SLOT(VM_Changed()) );
 
 	connect( ui.Edit_Linux_Initrd_Path, SIGNAL(textChanged(const QString &)),
+			 this, SLOT(VM_Changed()) );
+
+	connect( ui.Edit_DeviceTree_Path, SIGNAL(textChanged(const QString &)),
+			 this, SLOT(VM_Changed()) );
+
+	connect( ui.Edit_App_Kernel_Path, SIGNAL(textChanged(const QString &)),
+			 this, SLOT(VM_Changed()) );
+
+	connect( ui.Edit_App_Kernel_Args, SIGNAL(textChanged(const QString &)),
 			 this, SLOT(VM_Changed()) );
 
 	connect( ui.Edit_Linux_Command_Line, SIGNAL(textChanged(const QString &)),
@@ -1366,6 +1413,7 @@ Available_Devices Main_Window::Get_Current_Machine_Devices( bool *ok ) const
 		}
 		System_Info::Normalize_Virt_Arch_Devices( d );
 		QEMU_Probe_Catalog::Merge_Into( d );
+		System_Info::Filter_Video_Card_List( d );
 		return d;
 	}
 
@@ -1386,6 +1434,7 @@ Available_Devices Main_Window::Get_Current_Machine_Devices( bool *ok ) const
 			}
 			System_Info::Normalize_Virt_Arch_Devices( d );
 			QEMU_Probe_Catalog::Merge_Into( d );
+			System_Info::Filter_Video_Card_List( d );
 			return d;
 		}
     }
@@ -1396,6 +1445,7 @@ Available_Devices Main_Window::Get_Current_Machine_Devices( bool *ok ) const
 		Available_Devices d = System_Info::Emulator_QEMU_2_0[ target_key ];
 		System_Info::Normalize_Virt_Arch_Devices( d );
 		QEMU_Probe_Catalog::Merge_Into( d );
+		System_Info::Filter_Video_Card_List( d );
 		return d;
 	}
 
@@ -1511,33 +1561,49 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	// Computer Type
 	tmp_vm->Set_Computer_Type( curComp.System.QEMU_Name );
 
-	// Machine Type — Main combo is what the user sees; keep ui_arch in sync
+	// Machine Type — Match selected UI text / index against QEMU_Name / Caption
 	{
-		int mi = ui.CB_Machine_Type_Main->currentIndex();
-		if( mi < 0 || mi >= curComp.Machine_List.count() )
-			mi = ui_arch.CB_Machine_Type->currentIndex();
-		if( mi >= 0 && mi < curComp.Machine_List.count() )
-			tmp_vm->Set_Machine_Type( curComp.Machine_List[mi].QEMU_Name );
-		else if( ! ui.CB_Machine_Type_Main->currentText().isEmpty() )
-			tmp_vm->Set_Machine_Type( ui.CB_Machine_Type_Main->currentText() );
-		else if( ! ui_arch.CB_Machine_Type->currentText().isEmpty() )
-			tmp_vm->Set_Machine_Type( ui_arch.CB_Machine_Type->currentText() );
-		else
+		QString machine_name = ui.CB_Machine_Type_Main->currentText().trimmed();
+		if( machine_name.isEmpty() )
+			machine_name = ui_arch.CB_Machine_Type->currentText().trimmed();
+
+		bool found = false;
+		for( int mx = 0; mx < curComp.Machine_List.count(); ++mx )
+		{
+			if( curComp.Machine_List[mx].QEMU_Name == machine_name ||
+			    curComp.Machine_List[mx].Caption == machine_name )
+			{
+				tmp_vm->Set_Machine_Type( curComp.Machine_List[mx].QEMU_Name );
+				found = true;
+				break;
+			}
+		}
+		if( ! found && ! machine_name.isEmpty() )
+			tmp_vm->Set_Machine_Type( machine_name );
+		else if( ! found )
 			tmp_vm->Set_Machine_Type( old_vm->Get_Machine_Type() );
 	}
 
-	// CPU Type
+	// CPU Type — Match selected UI text / index against QEMU_Name / Caption
 	{
-		int ci = ui.CB_CPU_Type_Main->currentIndex();
-		if( ci < 0 || ci >= curComp.CPU_List.count() )
-			ci = ui_arch.CB_CPU_Type->currentIndex();
-		if( ci >= 0 && ci < curComp.CPU_List.count() )
-			tmp_vm->Set_CPU_Type( curComp.CPU_List[ci].QEMU_Name );
-		else if( ! ui.CB_CPU_Type_Main->currentText().isEmpty() )
-			tmp_vm->Set_CPU_Type( ui.CB_CPU_Type_Main->currentText() );
-		else if( ! ui_arch.CB_CPU_Type->currentText().isEmpty() )
-			tmp_vm->Set_CPU_Type( ui_arch.CB_CPU_Type->currentText() );
-		else
+		QString cpu_name = ui.CB_CPU_Type_Main->currentText().trimmed();
+		if( cpu_name.isEmpty() )
+			cpu_name = ui_arch.CB_CPU_Type->currentText().trimmed();
+
+		bool found = false;
+		for( int cx = 0; cx < curComp.CPU_List.count(); ++cx )
+		{
+			if( curComp.CPU_List[cx].QEMU_Name == cpu_name ||
+			    curComp.CPU_List[cx].Caption == cpu_name )
+			{
+				tmp_vm->Set_CPU_Type( curComp.CPU_List[cx].QEMU_Name );
+				found = true;
+				break;
+			}
+		}
+		if( ! found && ! cpu_name.isEmpty() )
+			tmp_vm->Set_CPU_Type( cpu_name );
+		else if( ! found )
 			tmp_vm->Set_CPU_Type( old_vm->Get_CPU_Type() );
 	}
 
@@ -1850,7 +1916,13 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Set_Use_Linux_Boot( ui.CH_Use_Linux_Boot->isChecked() );
 	tmp_vm->Set_bzImage_Path( ui.Edit_Linux_bzImage_Path->text() );
 	tmp_vm->Set_Initrd_Path( ui.Edit_Linux_Initrd_Path->text() );
-	tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
+	tmp_vm->Set_DeviceTree_Path( ui.Edit_DeviceTree_Path->text() );
+	tmp_vm->Set_App_Kernel_Path( ui.Edit_App_Kernel_Path->text() );
+	// iOS/applesoc uses Edit_App_Kernel_Args; classic Linux boot uses Edit_Linux_Command_Line.
+	if( ui.Widget_DeviceTree_Main && ui.Widget_DeviceTree_Main->isVisible() )
+		tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
+	else
+		tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
 
 	// Optional Images
 	// ROM File
@@ -1876,7 +1948,9 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Use_USB_Hub( old_vm->Use_USB_Hub() );
 	tmp_vm->Set_Win11_Lifecycle_Mode( old_vm->Get_Win11_Lifecycle_Mode() );
 	// Honor the checkbox — do not OR with old_vm (that made Intel Mac / WSL sticky forever).
-	tmp_vm->Use_Intel_MacOS_Profile( ui_ao.CH_Intel_MacOS_Profile->isChecked() );
+	const bool is_reims_vm = old_vm && ( old_vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
+	                                      old_vm->Get_Machine_Name().contains( QLatin1String( "Reims" ), Qt::CaseInsensitive ) );
+	tmp_vm->Use_Intel_MacOS_Profile( ui_ao.CH_Intel_MacOS_Profile->isChecked() || is_reims_vm );
 	{
 		// Prefer main VM-page Intel macOS fields when that section is shown; else Advanced Options;
 		// finally preserve wizard-set values from old_vm.
@@ -2401,6 +2475,8 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 		curComp.PSO_SMP_MaxCPUs = curComp.PSO_SMP_MaxCPUs || fb.PSO_SMP_MaxCPUs;
 	}
 	System_Info::Normalize_Virt_Arch_Devices( curComp );
+	QEMU_Probe_Catalog::Merge_Into( curComp );
+	System_Info::Filter_Video_Card_List( curComp );
 
 	if( curComp.System.QEMU_Name.isEmpty() )
 	{
@@ -2411,6 +2487,12 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	}
 
 	// Computer Type
+	ui.CB_Computer_Type->blockSignals( true );
+	ui.CB_Machine_Type_Main->blockSignals( true );
+	ui_arch.CB_Machine_Type->blockSignals( true );
+	ui.CB_CPU_Type_Main->blockSignals( true );
+	ui_arch.CB_CPU_Type->blockSignals( true );
+
 	int compTypeIndex = ui.CB_Computer_Type->findData( tmp_vm->Get_Computer_Type(), Qt::UserRole );
 	if( compTypeIndex == -1 )
 		compTypeIndex = ui.CB_Computer_Type->findText( curComp.System.Caption );
@@ -2421,18 +2503,40 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 		ui.CB_Computer_Type->setCurrentIndex( compTypeIndex );
 	else
 	{
+		ui.CB_Computer_Type->blockSignals( false );
+		ui.CB_Machine_Type_Main->blockSignals( false );
+		ui_arch.CB_Machine_Type->blockSignals( false );
+		ui.CB_CPU_Type_Main->blockSignals( false );
+		ui_arch.CB_CPU_Type->blockSignals( false );
 		AQError( "void Main_Window::Update_VM_Ui()",
 				 "Cannot find computer type index!" );
 		setUpdatesEnabled( true );
 		return;
 	}
 
+	// Populate Machine & CPU comboboxes for current architecture
+	ui_arch.CB_CPU_Type->clear();
+	ui.CB_CPU_Type_Main->clear();
+	ui_arch.CB_Machine_Type->clear();
+	ui.CB_Machine_Type_Main->clear();
+
+	QStringList cpu_items, machine_items;
+	for( int i = 0; i < curComp.CPU_List.count(); ++i )
+		cpu_items << curComp.CPU_List[i].Caption;
+	for( int i = 0; i < curComp.Machine_List.count(); ++i )
+		machine_items << curComp.Machine_List[i].Caption;
+
+	ui_arch.CB_CPU_Type->addItems( cpu_items );
+	ui.CB_CPU_Type_Main->addItems( cpu_items );
+	ui_arch.CB_Machine_Type->addItems( machine_items );
+	ui.CB_Machine_Type_Main->addItems( machine_items );
+
 	// Machine Type
 	QString tmp_str = tmp_vm->Get_Machine_Type();
 	bool machine_found = false;
 	for( int mx = 0; mx < curComp.Machine_List.count(); ++mx )
 	{
-		if( tmp_str == curComp.Machine_List[mx].QEMU_Name )
+		if( tmp_str == curComp.Machine_List[mx].QEMU_Name || tmp_str == curComp.Machine_List[mx].Caption )
 		{
 			ui_arch.CB_Machine_Type->setCurrentIndex( mx );
 			ui.CB_Machine_Type_Main->setCurrentIndex( mx );
@@ -2453,7 +2557,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	bool cpu_found = false;
 	for( int cx = 0; cx < curComp.CPU_List.count(); ++cx )
 	{
-		if( tmp_str == curComp.CPU_List[cx].QEMU_Name )
+		if( tmp_str == curComp.CPU_List[cx].QEMU_Name || tmp_str == curComp.CPU_List[cx].Caption )
 		{
 			ui_arch.CB_CPU_Type->setCurrentIndex( cx );
 			ui.CB_CPU_Type_Main->setCurrentIndex( cx );
@@ -2468,6 +2572,12 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 		ui_arch.CB_CPU_Type->setCurrentIndex( ui_arch.CB_CPU_Type->count() - 1 );
 		ui.CB_CPU_Type_Main->setCurrentIndex( ui.CB_CPU_Type_Main->count() - 1 );
 	}
+
+	ui.CB_Computer_Type->blockSignals( false );
+	ui.CB_Machine_Type_Main->blockSignals( false );
+	ui_arch.CB_Machine_Type->blockSignals( false );
+	ui.CB_CPU_Type_Main->blockSignals( false );
+	ui_arch.CB_CPU_Type->blockSignals( false );
 
 	// Video Card
 	tmp_str = System_Info::Sanitize_Video_Card(
@@ -2883,6 +2993,9 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	ui.CH_Use_Linux_Boot->setChecked( tmp_vm->Get_Use_Linux_Boot() );
 	ui.Edit_Linux_bzImage_Path->setText( tmp_vm->Get_bzImage_Path() );
 	ui.Edit_Linux_Initrd_Path->setText( tmp_vm->Get_Initrd_Path() );
+	ui.Edit_DeviceTree_Path->setText( tmp_vm->Get_DeviceTree_Path() );
+	ui.Edit_App_Kernel_Path->setText( tmp_vm->Get_App_Kernel_Path() );
+	ui.Edit_App_Kernel_Args->setText( tmp_vm->Get_Kernel_ComLine() );
 	ui.Edit_Linux_Command_Line->setText( tmp_vm->Get_Kernel_ComLine() );
 
 	// ROM File
@@ -2955,6 +3068,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 		Update_Info_Text();
 	Update_Win11_Lifecycle_Ui();
 	Update_Intel_MacOS_Settings_Ui();
+	Update_DeviceTree_Visibility();
 	Update_Disabled_Controls(); // FIXME
 
 	// CPU count AFTER Update_Disabled_Controls — that rebuilds the combo and used to wipe this to 1.
@@ -4258,6 +4372,14 @@ bool Main_Window::Boot_Is_Correct( Virtual_Machine *tmp_vm )
 		AQError( "bool Main_Window::Boot_Is_Correct( Virtual_Machine *tmp_vm )",
 				 "tmp_vm == NULL" );
 		return false;
+	}
+
+	// Always allow applesoc / iOS VM boot configs to pass validation checks
+	if( tmp_vm->Get_Computer_Type().contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+	    tmp_vm->Get_Machine_Type().contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
+	    tmp_vm->Get_Machine_Type().contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) )
+	{
+		return true;
 	}
 
 	// Floppy A
@@ -5774,6 +5896,7 @@ void Main_Window::Computer_Type_Changed()
 	const bool is_virt_arch =
 		arch_bin.contains( "aarch64", Qt::CaseInsensitive ) ||
 		arch_bin.contains( "qemu-system-arm", Qt::CaseInsensitive ) ||
+		arch_bin.contains( "applesoc", Qt::CaseInsensitive ) ||
 		arch_bin.contains( "riscv", Qt::CaseInsensitive );
 
 	Virtual_Machine *cur_vm = Get_Current_VM();
@@ -6001,6 +6124,12 @@ void Main_Window::sync_arch_CPU_Type_changed( int index )
 	VM_Changed();
 }
 
+void Main_Window::slot_iOS_Firmware_Tool_triggered()
+{
+	iOS_Firmware_Tool_Window dlg( this );
+	dlg.exec();
+}
+
 void Main_Window::Update_Machine_Accelerators()
 {
 	const QString keep = ui.CB_Machine_Accelerator->currentData( Qt::UserRole ).toString().toLower();
@@ -6054,14 +6183,18 @@ void Main_Window::Enforce_Accel_Honesty()
 		return;
 	}
 
-	const bool is_native = AQ_Guest_Matches_Host_Architecture( guest );
+	const bool is_wsl = ui.CH_Intel_Mac_WSL_Main->isChecked() || ui_ao.CH_Launch_Via_WSL->isChecked();
+	const bool is_native = AQ_Guest_Matches_Host_Architecture( guest ) || is_wsl;
 
 	int tcg_index = -1;
+	int kvm_index = -1;
 	for( int i = 0; i < ui.CB_Machine_Accelerator->count(); ++i )
 	{
 		const QString id = ui.CB_Machine_Accelerator->itemData( i, Qt::UserRole ).toString().toLower();
 		if( id == QLatin1String( "tcg" ) )
 			tcg_index = i;
+		if( id == QLatin1String( "kvm" ) )
+			kvm_index = i;
 
 		const bool native_only =
 			( id == QLatin1String( "kvm" ) || id == QLatin1String( "xen" ) );
@@ -6079,8 +6212,19 @@ void Main_Window::Enforce_Accel_Honesty()
 	}
 
 	bool forced_tcg = false;
-	if( ! is_native )
+	if( is_wsl )
 	{
+		ui.CB_Machine_Accelerator->setEnabled( false );
+		if( kvm_index >= 0 && ui.CB_Machine_Accelerator->currentIndex() != kvm_index )
+		{
+			ui.CB_Machine_Accelerator->setCurrentIndex( kvm_index );
+		}
+		ui.CB_Machine_Accelerator->setToolTip(
+			tr( "WSL execution selected: native KVM acceleration is enforced inside the WSL VM." ) );
+	}
+	else if( ! is_native )
+	{
+		ui.CB_Machine_Accelerator->setEnabled( true );
 		if( tcg_index >= 0 && ui.CB_Machine_Accelerator->currentIndex() != tcg_index )
 		{
 			ui.CB_Machine_Accelerator->setCurrentIndex( tcg_index );
@@ -6093,6 +6237,7 @@ void Main_Window::Enforce_Accel_Honesty()
 	}
 	else
 	{
+		ui.CB_Machine_Accelerator->setEnabled( true );
 		ui.CB_Machine_Accelerator->setToolTip(
 			tr( "Host %1 matches guest %2. On Windows, KVM maps to WHPX/HAX with TCG fallback." )
 				.arg( host ).arg( guest ) );
@@ -6430,6 +6575,14 @@ void Main_Window::Discard_Changes(QDialog* dialog)
 void Main_Window::on_TB_Show_Advanced_Options_Window_clicked()
 {
 	Refresh_Gamepad_List( Get_Current_VM() ? Get_Current_VM()->Get_Gamepad_Filter_IDs() : QStringList() );
+	if( Advanced_Options )
+	{
+		const QRect scr = QGuiApplication::primaryScreen() ? QGuiApplication::primaryScreen()->availableGeometry() : QRect( 0, 0, 1024, 768 );
+		const int target_w = qMax( 900, static_cast<int>( scr.width() * 0.65 ) );
+		const int target_h = qMin( scr.height() - 100, static_cast<int>( scr.height() * 0.75 ) );
+		Advanced_Options->resize( target_w, target_h );
+		Advanced_Options->setMaximumHeight( target_h );
+	}
     Discard_Changes ( Advanced_Options );
 }
 
@@ -6710,10 +6863,9 @@ void Main_Window::Update_Win11_Lifecycle_Ui()
 void Main_Window::Update_Intel_MacOS_Settings_Ui()
 {
 	Virtual_Machine *vm = Get_Current_VM();
-	const bool is_reims = vm && ( vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
-	                              vm->Get_Machine_Name().contains( QLatin1String( "Reims" ), Qt::CaseInsensitive ) ||
-	                              vm->Get_Machine_Name().contains( QLatin1String( "macOS" ), Qt::CaseInsensitive ) ||
-	                              vm->Get_Machine_Name().contains( QLatin1String( "Mac OS" ), Qt::CaseInsensitive ) );
+	const bool is_reims = vm && (
+		vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
+		vm->Get_Machine_Name().contains( QLatin1String( "Reims" ), Qt::CaseInsensitive ) );
 	const bool show = vm && ( vm->Use_Intel_MacOS_Profile() || is_reims );
 
 	ui.label_intel_macos->setVisible( show );
@@ -6726,6 +6878,31 @@ void Main_Window::Update_Intel_MacOS_Settings_Ui()
 		Update_Intel_Mac_GPU_Passthrough_Ui();
 	else
 		ui.GB_Intel_Mac_GPU_Passthrough->setVisible( false );
+}
+
+void Main_Window::Update_DeviceTree_Visibility()
+{
+	Virtual_Machine *vm = Get_Current_VM();
+	if( ! vm )
+	{
+		ui.Widget_DeviceTree_Main->setVisible( false );
+		return;
+	}
+
+	const QString m_name = vm->Get_Machine_Name();
+	const QString c_type = vm->Get_Computer_Type();
+	const QString m_type = vm->Get_Machine_Type();
+
+	const bool is_ios = ( m_name.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) ||
+	                      m_name.contains( QLatin1String( "iPhone" ), Qt::CaseInsensitive ) ||
+	                      m_name.contains( QLatin1String( "iPad" ), Qt::CaseInsensitive ) ||
+	                      c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+	                      m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
+	                      m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) ||
+	                      m_type.contains( QLatin1String( "t8101" ), Qt::CaseInsensitive ) ) &&
+	                    ! c_type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
+
+	ui.Widget_DeviceTree_Main->setVisible( is_ios );
 }
 
 void Main_Window::Update_Intel_Mac_GPU_Passthrough_Ui()
@@ -7283,6 +7460,26 @@ void Main_Window::on_TB_Linux_Initrd_SetPath_clicked()
 
 	if( ! initrd.isEmpty() )
 		ui.Edit_Linux_Initrd_Path->setText( QDir::toNativeSeparators(initrd) );
+}
+
+void Main_Window::on_TB_DeviceTree_SetPath_clicked()
+{
+	QString dtb = QFileDialog::getOpenFileName( this, tr("Select DeviceTree File (.dtb / .im4p)"),
+												Get_Last_Dir_Path(ui.Edit_DeviceTree_Path->text()),
+												tr("DeviceTree Files (*.dtb *.im4p);;All Files (*)") );
+
+	if( ! dtb.isEmpty() )
+		ui.Edit_DeviceTree_Path->setText( QDir::toNativeSeparators(dtb) );
+}
+
+void Main_Window::on_TB_App_Kernel_SetPath_clicked()
+{
+	QString kernel = QFileDialog::getOpenFileName( this, tr("Select Kernel File (.research / .elf / kernelcache)"),
+												   Get_Last_Dir_Path(ui.Edit_App_Kernel_Path->text()),
+												   tr("Kernel Files (*.research *.elf kernelcache*);;All Files (*)") );
+
+	if( ! kernel.isEmpty() )
+		ui.Edit_App_Kernel_Path->setText( QDir::toNativeSeparators(kernel) );
 }
 
 void Main_Window::on_TB_ROM_File_Browse_clicked()

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -1919,10 +1919,18 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Set_DeviceTree_Path( ui.Edit_DeviceTree_Path->text() );
 	tmp_vm->Set_App_Kernel_Path( ui.Edit_App_Kernel_Path->text() );
 	// iOS/applesoc uses Edit_App_Kernel_Args; classic Linux boot uses Edit_Linux_Command_Line.
-	if( ui.Widget_DeviceTree_Main && ui.Widget_DeviceTree_Main->isVisible() )
-		tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
-	else
-		tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
+	// Key off computer type / iOS paths — not widget visibility (can be false for non-VM reasons).
+	{
+		const QString computer = tmp_vm->Get_Computer_Type();
+		const bool use_app_kernel_args =
+			computer.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+			! ui.Edit_DeviceTree_Path->text().trimmed().isEmpty() ||
+			! ui.Edit_App_Kernel_Path->text().trimmed().isEmpty();
+		if( use_app_kernel_args )
+			tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
+		else
+			tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
+	}
 
 	// Optional Images
 	// ROM File

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -135,6 +135,7 @@ class Main_Window: public QMainWindow
 		void on_actionShow_QEMU_Arguments_triggered();
 		void on_actionCreate_Shell_Script_triggered();
 		void on_actionShow_QEMU_Error_Log_Window_triggered();
+		void slot_iOS_Firmware_Tool_triggered();
 		
 		void on_Tabs_currentChanged( int index );
 		
@@ -169,6 +170,7 @@ class Main_Window: public QMainWindow
 		void Apply_Win11_Lifecycle_Mode( VM::Win11_Lifecycle_Mode mode );
 		void Update_Win11_Lifecycle_Ui();
 		void Update_Intel_MacOS_Settings_Ui();
+		void Update_DeviceTree_Visibility();
 		void Update_Intel_Mac_GPU_Passthrough_Ui();
 		void Apply_Intel_Mac_GPU_Passthrough_Ui_From_Cache();
 		void Start_Host_GPU_Scan();
@@ -216,6 +218,8 @@ class Main_Window: public QMainWindow
 		
 		void on_TB_Linux_bzImage_SetPath_clicked();
 		void on_TB_Linux_Initrd_SetPath_clicked();
+		void on_TB_DeviceTree_SetPath_clicked();
+		void on_TB_App_Kernel_SetPath_clicked();
 		
 		void on_TB_ROM_File_Browse_clicked();
 		void on_TB_MTDBlock_File_Browse_clicked();
@@ -274,12 +278,14 @@ class Main_Window: public QMainWindow
 		void Update_Recent_CD_ROM_Images_List();
 		void Update_Recent_Floppy_Images_List();
         void Computer_Type_Changed();
-        void Update_Machine_Accelerators();
         void Enforce_Accel_Honesty();
 	void Enforce_Disk_Bus_Honesty();
 	int Disk_Interface_To_Combo_Index( VM::Device_Interface iface ) const;
 	VM::Device_Interface Combo_Index_To_Disk_Interface( int index ) const;
         void Update_Accelerator_Options();
+
+	private slots:
+        void Update_Machine_Accelerators();
         void Update_Computer_Types();
 		void Fill_Display_Resolution_Combo();
 		void Update_Display_Resolution_Enabled();
@@ -302,6 +308,7 @@ class Main_Window: public QMainWindow
 		QString Copy_VM_Hard_Drive( const QString &vm_name, const QString &hd_name, const VM_HDD &hd );
 		QString Copy_VM_Floppy( const QString &vm_name, const QString &fd_name, const VM_Storage_Device &fd );
 		
+	private:
 		Ui::Main_Window ui;
 		Ui::Advanced_Options ui_ao;
 		Ui::KVM_Options ui_kvm;

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -2103,7 +2103,147 @@
                  </property>
                 </widget>
                </item>
-              </layout>
+              
+                <item row="1" column="0" colspan="3">
+                 <widget class="QWidget" name="Widget_DeviceTree_Main" native="true">
+                  <layout class="QVBoxLayout" name="verticalLayout_DeviceTree_Main">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>4</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>4</number>
+                   </property>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_DeviceTree_Main">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="Label_DeviceTree_Main">
+                       <property name="text">
+                        <string>DeviceTree (.dtb / .im4p):</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="Edit_DeviceTree_Path">
+                       <property name="toolTip">
+                        <string>DeviceTree payload for Apple Silicon / iOS QEMU boot (-dtb)</string>
+                       </property>
+                       <property name="placeholderText">
+                        <string>/path/to/DeviceTree.n104ap.im4p or .dtb</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QToolButton" name="TB_DeviceTree_SetPath">
+                       <property name="text">
+                        <string>...</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../resources/icons.qrc">
+                         <normaloff>:/open-file.png</normaloff>:/open-file.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_App_Kernel_Main">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>4</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="Label_App_Kernel_Main">
+                       <property name="text">
+                        <string>Kernel (.research / .elf):</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="Edit_App_Kernel_Path">
+                       <property name="toolTip">
+                        <string>Kernel payload / kernelcache for Apple Silicon / iOS boot (-kernel)</string>
+                       </property>
+                       <property name="placeholderText">
+                        <string>/path/to/kernelcache.research.iphone12b</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QToolButton" name="TB_App_Kernel_SetPath">
+                       <property name="text">
+                        <string>...</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../resources/icons.qrc">
+                         <normaloff>:/open-file.png</normaloff>:/open-file.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_App_Kernel_Args_Main">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>4</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="Label_App_Kernel_Args_Main">
+                       <property name="text">
+                        <string>Boot Arguments (-append):</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="Edit_App_Kernel_Args">
+                       <property name="toolTip">
+                        <string>Arguments passed to the guest kernel command line (-append)</string>
+                       </property>
+                       <property name="placeholderText">
+                        <string>-v debug=0x14e kextlog=0xffff serial=3</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+</layout>
              </widget>
             </item>
            </layout>

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -588,6 +588,7 @@ bool System_Info::Update_VM_Computers_List()
 	QEMU_Video_Cards_v0_10_0 << Device_Map( QObject::tr("StdVGA (VESA 2.0)"), "std" );
 	QEMU_Video_Cards_v0_10_0 << Device_Map( QObject::tr("Cirrus CLGD 5446"), "cirrus" );
 	QEMU_Video_Cards_v0_10_0 << Device_Map( QObject::tr("VMWare Video Card"), "vmware" );
+	QEMU_Video_Cards_v0_10_0 << Device_Map( QObject::tr("Reims vGPU (3D Acceleration)"), "reims-vgpu-pci" );
 	QEMU_Video_Cards_v0_10_0 << Device_Map( QObject::tr("None Video Card"), "none" );
 	
 	QList<Device_Map> CPU_x86_v0_10_0 = CPU_x86;
@@ -1357,9 +1358,11 @@ Video_Arch_Family Get_Video_Arch_Family( const QString &computer_type )
 	const QString bin = computer_type.toLower();
 
 	if( bin.contains( "aarch64" ) || bin.contains( "qemu-system-arm" ) ||
-	    bin.contains( "riscv" ) || bin.contains( "loongarch" ) )
+	    bin.contains( "riscv" ) || bin.contains( "loongarch" ) ||
+	    bin.contains( "applesoc" ) )
 		return VAF_VIRT;
-	if( bin.contains( "x86_64" ) || bin.contains( "i386" ) || bin == "qemu-system-x86" )
+	if( bin.contains( "x86_64" ) || bin.contains( "i386" ) || bin == "qemu-system-x86" ||
+	    bin.contains( "reimsvgpu" ) )
 		return VAF_X86;
 	if( bin.contains( "sparc" ) )
 		return VAF_SPARC;
@@ -1405,10 +1408,10 @@ bool Is_Video_Card_Allowed( Video_Arch_Family fam, const QString &raw_name )
 		case VAF_X86:
 			return name == "std" || name == "cirrus" || name == "vmware" ||
 			       name == "qxl" || name == "virtio" || name == "virtio-vga-gl" ||
-			       name == "xenfb" || name == "none";
+			       name == "reims-vgpu-pci" || name == "xenfb" || name == "none";
 		case VAF_VIRT:
 			return name == "virtio-gpu-pci" || name == "virtio-gpu-gl-pci" ||
-			       name == "ramfb" || name == "none";
+			       name == "reims-vgpu-pci" || name == "ramfb" || name == "std" || name == "cirrus" || name == "none";
 		case VAF_SPARC:
 			return name == "cg3" || name == "tcx" || name == "std" || name == "none";
 		case VAF_PPC:
@@ -1446,10 +1449,10 @@ QList<Device_Map> Default_Video_List_For_Family( Video_Arch_Family fam )
 	auto add = [&]( const QString &caption, const QString &qemu_name ) {
 		list << Device_Map( caption, qemu_name );
 	};
-
 	switch( fam )
 	{
 		case VAF_X86:
+			add( QObject::tr("Reims vGPU (3D Acceleration)"), "reims-vgpu-pci" );
 			add( QObject::tr("Cirrus CLGD 5446"), "cirrus" );
 			add( QObject::tr("StdVGA (VESA 2.0)"), "std" );
 			add( QObject::tr("VMWare Video Card"), "vmware" );
@@ -1458,9 +1461,12 @@ QList<Device_Map> Default_Video_List_For_Family( Video_Arch_Family fam )
 			add( QObject::tr("VirtIO VGA (GL / OpenGL)"), "virtio-vga-gl" );
 			break;
 		case VAF_VIRT:
+			add( QObject::tr("Reims vGPU (3D Acceleration)"), "reims-vgpu-pci" );
 			add( QObject::tr("VirtIO GPU (PCI)"), "virtio-gpu-pci" );
 			add( QObject::tr("VirtIO GPU GL (PCI)"), "virtio-gpu-gl-pci" );
 			add( QObject::tr("ramfb (simple framebuffer)"), "ramfb" );
+			add( QObject::tr("Standard VGA"), "std" );
+			add( QObject::tr("Cirrus CLGD 5446"), "cirrus" );
 			break;
 		case VAF_SPARC:
 			add( QObject::tr("CG3 Framebuffer"), "cg3" );
@@ -1670,6 +1676,11 @@ void System_Info::Filter_Video_Card_List( Available_Devices &dev )
 	const Video_Arch_Family fam = Get_Video_Arch_Family( dev.System.QEMU_Name );
 	QList<Device_Map> filtered;
 
+	if( dev.Video_Card_List.isEmpty() )
+	{
+		dev.Video_Card_List = Default_Video_List_For_Family( fam );
+	}
+
 	for( int i = 0; i < dev.Video_Card_List.count(); ++i )
 	{
 		const QString qemu_name = Normalize_Video_Alias( dev.Video_Card_List[i].QEMU_Name );
@@ -1686,11 +1697,12 @@ void System_Info::Filter_Video_Card_List( Available_Devices &dev )
 
 	if( fam == VAF_VIRT )
 	{
-		QList<Device_Map> virt_list;
-		if( List_Has_Video( filtered, "virtio-gpu-pci" ) )
-			virt_list = filtered;
-		else
+		// Expose all detected display options, ensuring standard ones like std, cirrus, and none are kept
+		QList<Device_Map> virt_list = filtered;
+		if( ! List_Has_Video( virt_list, "virtio-gpu-pci" ) )
+		{
 			virt_list = Default_Video_List_For_Family( VAF_VIRT );
+		}
 
 		filtered.clear();
 		for( int i = 0; i < virt_list.count(); ++i )
@@ -2394,9 +2406,8 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 			else continue;
 		}
 		
-		// String empty?
-		if( ! (qemu_dev_name.isEmpty() ||
-			   qemu_dev_name.indexOf(QRegExp("/^\\S+$/"), 0) != -1) )
+		// Add parsed CPU device
+		if( ! qemu_dev_name.isEmpty() )
 		{
 			bool cpu_found = false;
 			for( int ix = 0; ix < default_device.CPU_List.count(); ix++ )
@@ -2405,14 +2416,13 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 				{
 					tmp_dev.CPU_List << default_device.CPU_List[ ix ];
 					cpu_found = true;
+					break;
 				}
 			}
 			
-			// No this device name in default list
-			if( cpu_found == false )
+			if( ! cpu_found )
 				tmp_dev.CPU_List << Device_Map( qemu_dev_name, qemu_dev_name );
 		}
-		else continue;
 	}
 	while( ! tmp.isNull() );
 	
@@ -2445,8 +2455,10 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 			QStringList rx_list = tmp_rx.capturedTexts();
 			if( rx_list.count() > 2 )
 			{
-				dev_map.Caption = rx_list[ 2 ];
-				dev_map.QEMU_Name = rx_list[ 1 ];
+				const QString id = rx_list[1];
+				const QString desc = rx_list[2].trimmed();
+				dev_map.Caption = desc.isEmpty() ? id : QString( "%1 — %2" ).arg( id, desc );
+				dev_map.QEMU_Name = id;
 			}
 			else
 			{
@@ -2457,7 +2469,7 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 			}
 		}
 		
-		if( ! (dev_map.QEMU_Name.isEmpty() || dev_map.QEMU_Name.indexOf(QRegExp("/^\\S+$/"), 0) != -1) )
+		if( ! dev_map.QEMU_Name.isEmpty() )
 		{
 			bool machine_found = false;
 			for( int ix = 0; ix < default_device.Machine_List.count(); ix++ )
@@ -2466,11 +2478,11 @@ Available_Devices System_Info::Get_Emulator_Info( const QString &path, bool *ok,
 				{
 					tmp_dev.Machine_List << default_device.Machine_List[ ix ];
 					machine_found = true;
+					break;
 				}
 			}
 			
-			// No this device name in default list
-			if( machine_found == false ) tmp_dev.Machine_List << dev_map;
+			if( ! machine_found ) tmp_dev.Machine_List << dev_map;
 		}
 		else continue;
 	}

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -61,8 +61,10 @@
 #include "QMP_Client.h"
 #include "Utils.h"
 #include "WSL_Launch.h"
+#include "WSL_Wizard_Window.h"
 #include "Emulator_Control_Window.h"
 #include "System_Info.h"
+#include "QEMU_Probe_Catalog.h"
 #include "VNC_Password_Window.h"
 
 using namespace TinyXML2QDomWrapper;
@@ -225,6 +227,8 @@ Virtual_Machine::Virtual_Machine( const Virtual_Machine &vm )
 	this->Linux_Boot = vm.Get_Use_Linux_Boot();
 	this->bzImage_Path = vm.Get_bzImage_Path();
 	this->Initrd_Path = vm.Get_Initrd_Path();
+	this->DeviceTree_Path = vm.Get_DeviceTree_Path();
+	this->App_Kernel_Path = vm.Get_App_Kernel_Path();
 	this->Kernel_ComLine = vm.Get_Kernel_ComLine();
 	
 	this->Additional_Args = vm.Get_Additional_Args();
@@ -675,6 +679,8 @@ bool Virtual_Machine::operator==( const Virtual_Machine &vm ) const
 		this->Linux_Boot == vm.Get_Use_Linux_Boot() &&
 		this->bzImage_Path == vm.Get_bzImage_Path() &&
 		this->Initrd_Path == vm.Get_Initrd_Path() &&
+		this->DeviceTree_Path == vm.Get_DeviceTree_Path() &&
+		this->App_Kernel_Path == vm.Get_App_Kernel_Path() &&
 		this->Kernel_ComLine == vm.Get_Kernel_ComLine() &&
 		this->Additional_Args == vm.Get_Additional_Args() &&
 		this->Only_User_Args == vm.Get_Only_User_Args() &&
@@ -975,6 +981,8 @@ Virtual_Machine &Virtual_Machine::operator=( const Virtual_Machine &vm )
 	Linux_Boot = vm.Get_Use_Linux_Boot();
 	bzImage_Path = vm.Get_bzImage_Path();
 	Initrd_Path = vm.Get_Initrd_Path();
+	DeviceTree_Path = vm.Get_DeviceTree_Path();
+	App_Kernel_Path = vm.Get_App_Kernel_Path();
 	Kernel_ComLine = vm.Get_Kernel_ComLine();
 
 	Additional_Args = vm.Get_Additional_Args();
@@ -3153,6 +3161,18 @@ bool Virtual_Machine::Create_VM_File( const QString &file_name, bool template_mo
 	VM_Element.appendChild( Dom_Element );
 	Dom_Text = New_Dom_Document.createTextNode( Initrd_Path );
 	Dom_Element.appendChild( Dom_Text );
+
+	// DeviceTree Path
+	Dom_Element = New_Dom_Document.createElement( "DeviceTree_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( DeviceTree_Path );
+	Dom_Element.appendChild( Dom_Text );
+
+	// App_Kernel_Path
+	Dom_Element = New_Dom_Document.createElement( "App_Kernel_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( App_Kernel_Path );
+	Dom_Element.appendChild( Dom_Text );
 	
 	// Kernel Command Line Arguments
 	Dom_Element = New_Dom_Document.createElement( "Kernel_ComLine" );
@@ -4272,7 +4292,7 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 				if( ! remapped )
 				{
 					const QFileInfo icon_fi( Icon_Path );
-					// Absolute paths (esp. Windows C:/...) must not be prefixed ‚Äî
+					// Absolute paths (esp. Windows C:/...) must not be prefixed ù
 					// old code did data_folder + absolute and blanked the list icon.
 					if( ! icon_fi.isAbsolute() )
 					{
@@ -5230,6 +5250,12 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 			// Initrd Path
 			Initrd_Path = Child_Element.firstChildElement( "Initrd_Path" ).text();
 			
+			// DeviceTree Path
+			DeviceTree_Path = Child_Element.firstChildElement( "DeviceTree_Path" ).text();
+
+			// App_Kernel_Path
+			App_Kernel_Path = Child_Element.firstChildElement( "App_Kernel_Path" ).text();
+			
 			// Kernel Command Line Arguments
 			Kernel_ComLine = Child_Element.firstChildElement( "Kernel_ComLine" ).text();
 			
@@ -5634,7 +5660,7 @@ VM_Native_Storage_Device Virtual_Machine::Load_VM_Native_Storage_Device( const Q
 	else
 	{
 		AQWarning( "VM_Native_Storage_Device Virtual_Machine::Load_VM_Native_Storage_Device( const QDomElement &Second_Element ) const",
-		           QStringLiteral( "Unknown Media \"%1\" ‚Äî treating as Disk" ).arg( media_str ) );
+		           QStringLiteral( "Unknown Media \"%1\" ù treating as Disk" ).arg( media_str ) );
 		tmp_device.Set_Media( VM::DM_Disk );
 	}
 	
@@ -6065,7 +6091,7 @@ static quint16 Allocate_Embedded_Monitor_Port( int embedded_display_port, quint1
 {
 	int preferred = Get_Emulator_Monitor_Base_Port()
 	                + ( embedded_display_port >= 0 ? embedded_display_port : 0 );
-	// Old installs defaulted to 26000, which Hyper-V often reserves ‚Üí QEMU aborts.
+	// Old installs defaulted to 26000, which Hyper-V often reserves ? QEMU aborts.
 	if( preferred < 1024 || Port_Looks_HyperV_Reserved( preferred ) )
 		preferred = 36000;
 
@@ -6081,7 +6107,7 @@ static quint16 Allocate_Embedded_Monitor_Port( int embedded_display_port, quint1
 		{
 			return candidate;
 		}
-		candidate = Find_Free_TCP_Port( 0 ); // OS ephemeral ‚Äî avoids reserved ranges
+		candidate = Find_Free_TCP_Port( 0 ); // OS ephemeral ù avoids reserved ranges
 	}
 
 	candidate = Find_Free_TCP_Port( 0 );
@@ -6161,7 +6187,7 @@ static bool Media_Is_Bootable_Now( const Virtual_Machine &vm, VM::Boot_Device ty
 				if( d.Get_Enabled() && ! p.isEmpty() && QFile::exists( p ) )
 					return true;
 			}
-			// Native / Device Manager extra storage (virtio, NVMe, ‚Ä¶)
+			// Native / Device Manager extra storage (virtio, NVMe, ù)
 			const QList<VM_Native_Storage_Device> &extra = vm.Get_Storage_Devices_List();
 			for( int i = 0; i < extra.count(); ++i )
 			{
@@ -6254,7 +6280,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 {
 	// Existing XP/.aqemu files may still have cirrus + SMP=2; force proven defaults.
 	Ensure_Windows_XP_Family_Defaults();
-	// OS/2 Warp: VirtIO/ACPI ‚Üí LVM.DLL Error 9; force IDE + TCG defaults.
+	// OS/2 Warp: VirtIO/ACPI ? LVM.DLL Error 9; force IDE + TCG defaults.
 	Ensure_OS2_Family_Defaults();
 	// ReactOS: wiki QEMU profile (IDE / std / AC97 / e1000).
 	Ensure_ReactOS_Defaults();
@@ -6493,7 +6519,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// CPU Model
 	// TCG aarch64 / Win11 ARM: -cpu max,pauth-impdef=on (PAuth without full crypto cost).
 	// KVM on ARM hosts: -cpu host. Bare -cpu max without pauth-impdef is too slow under TCG.
-	// Win95/98 (Force_TCG): period CPU ‚Äî modern "max"/"host" hangs at splash under WHPX/TCG.
+	// Win95/98 (Force_TCG): period CPU ù modern "max"/"host" hangs at splash under WHPX/TCG.
 	{
 		QString cpu_arg;
 		if( ! CPU_Type.trimmed().isEmpty() )
@@ -6514,9 +6540,14 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			#endif
 		}
 
+		if( Computer_Type.contains( "applesoc", Qt::CaseInsensitive ) && cpu_arg.contains( "pauth-impdef" ) && ! CPU_Type.trimmed().isEmpty() && CPU_Type.trimmed() != "max" )
+		{
+			cpu_arg = CPU_Type.trimmed();
+		}
+
 		if( Force_TCG )
 		{
-			// pentium2 is x86-only ‚Äî never rewrite POWER/SPARC/etc CPUs.
+			// pentium2 is x86-only ù never rewrite POWER/SPARC/etc CPUs.
 			const bool is_x86_guest =
 				Computer_Type.contains( QLatin1String( "x86_64" ), Qt::CaseInsensitive ) ||
 				Computer_Type.contains( QLatin1String( "i386" ), Qt::CaseInsensitive );
@@ -6676,7 +6707,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// Effective machine type. aarch64/arm/riscv have no QEMU default ? must pass virt
 	// (matches win11-pi5-kiosk: -M virt,accel=kvm).
 	QString effective_machine = Machine_Type;
-	// qemu-system-ppc64 with an empty -M defaults to pseries (SLOF) ‚Äî fine for AIX,
+	// qemu-system-ppc64 with an empty -M defaults to pseries (SLOF) ù fine for AIX,
 	// catastrophic for classic Mac OS X if the user left Machine blank after a bad import.
 	// qemu-system-ppc defaults to g3beige; prefer mac99 (New World / OS X era).
 	if( effective_machine.isEmpty() &&
@@ -6750,18 +6781,33 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 
 	if( device_based_video )
 	{
-		if( effective_video == "none" || effective_video == "-nographic" )
+		if( effective_video == "reims-vgpu-pci" ||
+		    ( is_reims_vgpu && ( effective_video.isEmpty() ||
+		                         effective_video == "default" ||
+		                         effective_video == "virtio-gpu-pci" ||
+		                         effective_video == "virtio" ||
+		                         effective_video == "std" ) ) )
+		{
+			Args << "-vga" << "none";
+			if( ! Args.contains( QStringLiteral( "reims-vgpu-pci" ) ) )
+				Args << "-device" << "reims-vgpu-pci";
+		}
+		else if( effective_video == "none" || effective_video == "-nographic" )
+		{
 			Args << "-nographic";
+		}
 		else if( effective_video == "ramfb" )
 			Args << "-device" << "ramfb";
 		else if( effective_video == "virtio-gpu-gl-pci" )
 			Args << "-device" << "virtio-gpu-gl-pci";
 		else if( effective_video == "virtio-vga-gl" )
 			Args << "-device" << "virtio-vga-gl";
-		else if( effective_video == "virtio-gpu-pci" ||
-		         effective_video == "virtio" ||
-		         ( ( effective_video.isEmpty() || effective_video == "default" ) &&
-		           ( System_Info::Uses_Device_Based_Video( Computer_Type ) || is_reims_vgpu ) ) )
+		else if( ( effective_video == "virtio-gpu-pci" ||
+		           effective_video == "virtio" ||
+		           ( ( effective_video.isEmpty() || effective_video == "default" ) &&
+		             ( System_Info::Uses_Device_Based_Video( Computer_Type ) ) ) ) &&
+		         !is_reims_vgpu &&
+		         effective_video != "none" )
 		{
 			// VirtIO-GPU with EDID. Do NOT auto-add ramfb here (BVM normal/boot mode):
 			// combining ramfb + virtio-gpu causes "Display output is not active" reboot loops.
@@ -6797,9 +6843,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 
 			Args << "-device" << virtio;
 		}
-		else
+		else if( !is_reims_vgpu && effective_video != "none" )
 		{
-			// Arbitrary display device from -device help / probe catalog (ati-vga, sm501, ‚Ä¶)
+			// Arbitrary display device from -device help / probe catalog (ati-vga, sm501, ù)
 			Args << "-device" << effective_video;
 		}
 	}
@@ -6818,7 +6864,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-vga" << "none";
 		else if( Intel_MacOS_Profile && GPU_Passthrough && ! GPU_PCI_Address.trimmed().isEmpty() )
 		{
-			// Real AMD dGPU via VFIO ‚Äî no emulated VGA.
+			// Real AMD dGPU via VFIO ù no emulated VGA.
 			Args << "-vga" << "none";
 		}
 		else if( Intel_MacOS_Profile &&
@@ -6864,8 +6910,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	bool legacy_force_tcg = Force_TCG && ! is_virt_arch;
 	const bool is_x86_guest =
 		Computer_Type.contains( QLatin1String( "x86_64" ), Qt::CaseInsensitive ) ||
+		Computer_Type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
 		Computer_Type.contains( QLatin1String( "i386" ), Qt::CaseInsensitive );
-	// UI "TCG" / Force_TCG / cross-arch must win. Never upgrade TCG‚ÜíKVM/WHPX silently,
+	// UI "TCG" / Force_TCG / cross-arch must win. Never upgrade TCG?KVM/WHPX silently,
 	// and never force KVM just because Launch_Via_WSL is set (PPC/ARM on x86 WSL).
 	const bool want_native_accel =
 		( Machine_Accelerator == VM::KVM ) && ! legacy_force_tcg && is_x86_guest;
@@ -6883,11 +6930,11 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	else if( is_virt_arch )
 		use_separate_tcg_accel = true;
 	else if( legacy_force_tcg )
-		// Win95/98: WHPX hangs at splash. XP: WHPX disables SMM ‚Üí black text mode.
+		// Win95/98: WHPX hangs at splash. XP: WHPX disables SMM ? black text mode.
 		use_separate_tcg_accel = true;
 	else if( ! is_x86_guest || Machine_Accelerator == VM::TCG )
 		// WHPX/HAX only accelerate x86. Also: selecting TCG in the UI must mean TCG
-		// (do not silently map it to whpx:hax:tcg ‚Äî that is what "KVM" means on Windows).
+		// (do not silently map it to whpx:hax:tcg ù that is what "KVM" means on Windows).
 		use_separate_tcg_accel = true;
 	else if( want_native_accel )
 		// Prefer Hyper-V WHPX (or HAX) for x86; fall back to TCG. Pure TCG makes
@@ -6927,8 +6974,8 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	Args << props.join(",");
 
 	// TCG: multi-thread + larger TB cache (Gemini/Linaro tips). tb-size is an -accel prop, not -tb-size.
-	// Legacy Win9x (Force_TCG): thread=single ‚Äî multi-thread TCG also breaks splash‚Üídesktop.
-	// PowerPC (and other non-MTTCG guests) warn/break with thread=multi ‚Äî use single.
+	// Legacy Win9x (Force_TCG): thread=single ù multi-thread TCG also breaks splash?desktop.
+	// PowerPC (and other non-MTTCG guests) warn/break with thread=multi ù use single.
 	if( use_separate_tcg_accel )
 	{
 		const bool no_mttcg =
@@ -7013,7 +7060,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-no-fd-bootchk";
 	}
 	
-	// No ACPI ‚Äî only pass -no-acpi if target explicitly advertises -no-acpi and guest ACPI is disabled.
+	// No ACPI ù only pass -no-acpi if target explicitly advertises -no-acpi and guest ACPI is disabled.
 	const QString qemu_target_name = Current_Emulator_Devices.System.QEMU_Name.trimmed().toLower();
 	const bool target_supports_no_acpi_flag = Current_Emulator_Devices.PSO_No_ACPI &&
 	                                         ! qemu_target_name.contains( QLatin1String( "reimsvgpu" ) ) &&
@@ -7089,7 +7136,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 							QString("Image \"%1\" doesn't exists!").arg(FD0.Get_File_Name()) );
 			}
 		}
-		// virt/pseries/etc: classic floppy not supported ‚Äî skip
+		// virt/pseries/etc: classic floppy not supported ù skip
 	}
 	else if( ! no_pc_fdd_ide && embedded_session )
 	{
@@ -7162,7 +7209,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			attach_cdrom = false;
 	}
 
-	// Intel macOS Recovery/installer ISO is attached separately ‚Äî do not also take IDE index 2.
+	// Intel macOS Recovery/installer ISO is attached separately ù do not also take IDE index 2.
 	if( mac_recovery_active && attach_cdrom )
 	{
 		const QString cd = AQ_Normalize_File_Path( CD_ROM.Get_File_Name() );
@@ -7214,7 +7261,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		else if( is_next_cube )
 		{
 			// NeXT Cube has onboard ESP SCSI (block_default_type=IF_SCSI).
-			// Do NOT invent virtio-scsi-pci ‚Äî that device does not exist on m68k.
+			// Do NOT invent virtio-scsi-pci ù that device does not exist on m68k.
 			// Keep CD off SCSI ID 0: NeXT `bsd` / default sd boots unit 0 (the HD).
 			if( QFile::exists( CD_ROM.Get_File_Name() ) || Build_QEMU_Args_for_Tab_Info )
 			{
@@ -7229,7 +7276,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 		else if( no_pc_fdd_ide && ! is_virt_arch )
 		{
-			// pSeries / PowerNV: no IDE ‚Äî present CD on virtio-scsi when a real ISO is set.
+			// pSeries / PowerNV: no IDE ù present CD on virtio-scsi when a real ISO is set.
 			if( QFile::exists( CD_ROM.Get_File_Name() ) || Build_QEMU_Args_for_Tab_Info )
 			{
 				has_virt_scsi = true;
@@ -7276,7 +7323,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	}
 	
 	// OpenCore first (Intel macOS). Prefer AHCI on q35 so OpenCore scans the volume;
-	// LongQT-style .iso ‚Üí patch BOOT.img with OpenPartitionDxe (missing from upstream),
+	// LongQT-style .iso ? patch BOOT.img with OpenPartitionDxe (missing from upstream),
 	// then attach as disk; true disk/qcow OpenCore images attach as-is.
 	bool mac_oc_has_partition_dxe = false;
 	{
@@ -7375,7 +7422,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	}
 
 	// Recovery / installer on same AHCI as OpenCore (OSX-KVM style).
-	// MIST/Pyenb "*.iso" = APM+HFS disk images ‚Äî must be ide-hd, not ide-cd.
+	// MIST/Pyenb "*.iso" = APM+HFS disk images ù must be ide-hd, not ide-cd.
 	// With OpenPartitionDxe present, attach the whole APM disk (no offset) so the
 	// kernel can re-find the same volume UUID after ExitBootServices.
 	// Fallback: raw HFS offset when PartitionDxe prep failed.
@@ -7449,7 +7496,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
         else if( HDA.Get_Native_Mode() )
         {
             VM_Native_Storage_Device native_hda = HDA.Get_Native_Device();
-			// aarch64/arm/riscv virt: never emit AHCI/IDE ‚Äî UEFI cannot boot the
+			// aarch64/arm/riscv virt: never emit AHCI/IDE ù UEFI cannot boot the
 			// guest disk and falls through to the USB installer ("USB HARDDRIVE").
 			if( is_virt_arch )
 			{
@@ -7703,9 +7750,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	//      (further) problems ...
 	Args << StorageArgs;
 
-	// Boot Device ‚Äî PC BIOS only. aarch64/arm/riscv UEFI uses bootindex on devices.
+	// Boot Device ù PC BIOS only. aarch64/arm/riscv UEFI uses bootindex on devices.
 	//
-	// Windows + our bundled QEMU 11.0.2: ANY `-boot ‚Ä¶` argument triggers
+	// Windows + our bundled QEMU 11.0.2: ANY `-boot ù` argument triggers
 	// STATUS_ACCESS_VIOLATION / HEAP_CORRUPTION (0xC0000005 / 0xC0000374) with
 	// empty stderr. System QEMU is fine; this is a Windows softmmu build bug.
 	// Skip `-boot` on Windows so VMs can actually start; SeaBIOS still boots
@@ -7722,7 +7769,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-boot" << bootStr;
 		else
 			AQWarning( "QStringList Virtual_Machine::Build_QEMU_Args()",
-					   "No bootable media in order list ‚Äî omitting -boot" );
+					   "No bootable media in order list ù omitting -boot" );
 #endif
 	}
 	
@@ -7819,7 +7866,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 						break;
 				}
 				
-				// Create String ‚Äî never emit deprecated vlan= on modern QEMU (tobimensch#44/#58)
+				// Create String ù never emit deprecated vlan= on modern QEMU (tobimensch#44/#58)
 				if( Network_Cards_Nativ[nc].Use_VLAN() && u_vlan &&
 				    Current_Emulator.Get_Version() == VM::Obsolete &&
 				    Network_Cards_Nativ[nc].Get_VLAN() > 0 )
@@ -7992,7 +8039,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				if( Network_Cards_Nativ[nc].Use_VHostFd() && u_vhostfd && Current_Emulator_Devices.PSO_Net_vhostfd )
 					nic_str += ",vhostfd=" + QString::number( Network_Cards_Nativ[nc].Get_VHostFd() );
 				
-				// Add to Args ‚Äî modern -netdev+device when enabled (qemu-doc ¬ß Network)
+				// Add to Args ù modern -netdev+device when enabled (qemu-doc ù Network)
 				const VM::Network_Mode_Nativ ntype = Network_Cards_Nativ[nc].Get_Network_Type();
 				const bool can_modern =
 					Modern_Netdev &&
@@ -8003,7 +8050,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				{
 					const QString nid = QStringLiteral( "aqnet%1" ).arg( nc );
 					QString nd = nic_str;
-					// nic_str is like "user,..." or "tap,..." without type prefix issues ‚Äî already has type
+					// nic_str is like "user,..." or "tap,..." without type prefix issues ù already has type
 					const int comma = nd.indexOf( QLatin1Char( ',' ) );
 					QString ntype_s = comma > 0 ? nd.left( comma ) : nd;
 					QString rest = comma > 0 ? nd.mid( comma + 1 ) : QString();
@@ -8057,7 +8104,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 					( effective_machine == "virt" || is_virt_arch ) )
 					model = "virtio-net-pci";
 				// LongQT / modern Intel macOS: VirtIO NIC (e1000-82545em often has no
-				// link in Sonoma/Monterey Recovery ‚Üí "internet connection required").
+				// link in Sonoma/Monterey Recovery ? "internet connection required").
 				if( Intel_MacOS_Profile )
 					model = QStringLiteral( "virtio-net-pci" );
 
@@ -8219,7 +8266,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			}
 		}
 		
-		// Network Tab. Redirections ‚Äî merge into one -net user (tobimensch#59)
+		// Network Tab. Redirections ù merge into one -net user (tobimensch#59)
 		if( Use_Redirections )
 		{
 			QStringList hostfwds;
@@ -8232,7 +8279,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 					redir_str += "udp:";
 				else
 					redir_str += "tcp:"; // qemu default is TCP
-				// host IP empty ‚Üí omit (tobimensch#54 ... placeholder)
+				// host IP empty ? omit (tobimensch#54 ... placeholder)
 				redir_str += ":" + QString::number( Get_Network_Redirection(rx).Get_Host_Port() ) + "-";
 				const QString guest_ip = Get_Network_Redirection(rx).Get_Guest_IP().trimmed();
 				if( ! guest_ip.isEmpty() && guest_ip != QLatin1String( "..." ) )
@@ -8261,7 +8308,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 	
-	// TFTP Prefix ‚Äî merge into existing user netdev when possible (tobimensch#19)
+	// TFTP Prefix ù merge into existing user netdev when possible (tobimensch#19)
 	if( ! TFTP_Prefix.isEmpty() )
 	{
 		const QString tftp_part = Build_QEMU_Args_for_Script_Mode
@@ -8303,7 +8350,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-net" << ( "user," + smb_part );
 	}
 	
-	// Ports Tabs ‚Äî allocate a TCP serial for the session console without mutating saved config
+	// Ports Tabs ù allocate a TCP serial for the session console without mutating saved config
 	Serial_Console_Port = 0;
 	QList<VM_Port> serial_for_args = Serial_Ports;
 	{
@@ -8447,7 +8494,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 					cdev = QStringLiteral( "braille,id=" ) + cid;
 					break;
 				case VM::PR_mon:
-					// Mux monitor onto this chardev after create ‚Äî fall back to legacy
+					// Mux monitor onto this chardev after create ù fall back to legacy
 					cdev.clear();
 					break;
 				default:
@@ -8631,7 +8678,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			if( Build_QEMU_Args_for_Tab_Info == false ) System_Info::Update_Host_USB();
 			QList<VM_USB> all_usb = System_Info::Get_All_Host_USB();
 
-			// Auto-attach Xbox / USB gamepads when enabled (local list ‚Äî do not mutate USB_Ports)
+			// Auto-attach Xbox / USB gamepads when enabled (local list ù do not mutate USB_Ports)
 			QList<VM_USB> ports = USB_Ports;
 			if( Pass_Through_Gamepads )
 			{
@@ -8756,7 +8803,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 							
 							usbControllerID = "ehci.0";
 						}
-						else // USB 1.1 ‚Äî modern QEMU uses usb-bus.0 (tobimensch#76/#111)
+						else // USB 1.1 ù modern QEMU uses usb-bus.0 (tobimensch#76/#111)
 						{
 							usbControllerID = "usb-bus.0";
 						}
@@ -8785,7 +8832,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 						if( ! use_vid_pid && no_bus_path )
 						{
 							AQWarning( "QStringList Virtual_Machine::Build_QEMU_Args()",
-								QStringLiteral( "Skipping USB device %1 ‚Äî no bus/port or VID:PID" )
+								QStringLiteral( "Skipping USB device %1 ù no bus/port or VID:PID" )
 									.arg( current_USB_Device.Get_Product_Name().isEmpty()
 										? current_USB_Device.Get_ID_Line()
 										: current_USB_Device.Get_Product_Name() ) );
@@ -8842,7 +8889,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 	
-	// Emulated USB gamepad (QEMU usb-gamepad ‚Äî maps host joystick when supported)
+	// Emulated USB gamepad (QEMU usb-gamepad ù maps host joystick when supported)
 	if( Emulate_USB_Gamepad )
 	{
 		if( ! Args.contains( QStringLiteral( "-usb" ) ) )
@@ -8866,6 +8913,38 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				Args << "-initrd" << Initrd_Path;
 		}
 		
+		if( ! DeviceTree_Path.isEmpty() )
+		{
+			if( Build_QEMU_Args_for_Script_Mode )
+				Args << "-dtb" << "\"" + DeviceTree_Path + "\"";
+			else
+				Args << "-dtb" << DeviceTree_Path;
+		}
+		
+		if( ! Kernel_ComLine.isEmpty() )
+		{
+			if( Build_QEMU_Args_for_Script_Mode )
+				Args << "-append" << "\"" + Kernel_ComLine + "\"";
+			else
+				Args << "-append" << Kernel_ComLine;
+		}
+	}
+	else
+	{
+		if( ! App_Kernel_Path.isEmpty() )
+		{
+			if( Build_QEMU_Args_for_Script_Mode )
+				Args << "-kernel" << "\"" + App_Kernel_Path + "\"";
+			else
+				Args << "-kernel" << App_Kernel_Path;
+		}
+		if( ! DeviceTree_Path.isEmpty() )
+		{
+			if( Build_QEMU_Args_for_Script_Mode )
+				Args << "-dtb" << "\"" + DeviceTree_Path + "\"";
+			else
+				Args << "-dtb" << DeviceTree_Path;
+		}
 		if( ! Kernel_ComLine.isEmpty() )
 		{
 			if( Build_QEMU_Args_for_Script_Mode )
@@ -8971,7 +9050,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 
-	// Apple SMC (Intel macOS) ‚Äî only emit OSK if the user supplied one (never invent a key)
+	// Apple SMC (Intel macOS) ù only emit OSK if the user supplied one (never invent a key)
 	if( Intel_MacOS_Profile && Use_Apple_SMC_Flag && ! Apple_SMC_OSK.trimmed().isEmpty() )
 	{
 		QString osk = Apple_SMC_OSK;
@@ -8982,7 +9061,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	if( Intel_MacOS_Profile )
 		Args << "-smbios" << "type=2";
 
-	// AMD GPU VFIO passthrough (Metal) ‚Äî native Linux only; gated at Start_vm()
+	// AMD GPU VFIO passthrough (Metal) ù native Linux only; gated at Start_vm()
 	if( Intel_MacOS_Profile && GPU_Passthrough && ! GPU_PCI_Address.trimmed().isEmpty() )
 	{
 		QString gpu_dev = QStringLiteral( "vfio-pci,host=%1" ).arg( GPU_PCI_Address.trimmed() );
@@ -9271,7 +9350,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	}
 	else if( embedded_session )
 	{
-		// Headless: no QEMU SDL/GTK chrome ‚Äî AQEMU owns the window
+		// Headless: no QEMU SDL/GTK chrome ù AQEMU owns the window
 		Args << "-display" << "none";
 
 #ifdef Q_OS_WIN32
@@ -9301,7 +9380,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Embedded_Spice_Port = 0;
 		}
 
-		// VNC for LibVNC client ‚Äî bind a free TCP port (not a fixed display index)
+		// VNC for LibVNC client ù bind a free TCP port (not a fixed display index)
 		if( Embedded_VNC_Port <= 0 )
 		{
 			const int first_vnc = Settings.value( "First_VNC_Port", "5910" ).toString().toInt();
@@ -9333,9 +9412,14 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		if( disp == QLatin1String( "none" ) || disp == QLatin1String( "curses" ) ||
 		    disp == QLatin1String( "sdl" ) || disp == QLatin1String( "gtk" ) ||
 		    disp == QLatin1String( "egl-headless" ) || disp == QLatin1String( "spice-app" ) )
-			Args << "-display" << disp;
+		{
+			if( disp == QLatin1String( "sdl" ) )
+				Args << "-display" << "sdl,show-cursor=on,gl=on";
+			else
+				Args << "-display" << disp;
+		}
 		else
-			Args << "-display" << QStringLiteral( "sdl" );
+			Args << "-display" << QStringLiteral( "sdl,show-cursor=on,gl=on" );
 	}
 	else if( SPICE.Use_SPICE() )
 	{
@@ -9676,7 +9760,7 @@ QStringList Virtual_Machine::Build_Native_Device_Args( VM_Native_Storage_Device 
 				break;
 
 			case VM::DI_NVMe:
-				// SteamOS installer expects /dev/nvme0n1 ‚Äî needs -device nvme + serial
+				// SteamOS installer expects /dev/nvme0n1 ù needs -device nvme + serial
 				opt << "if=none,id=" + vsname;
 				break;
 
@@ -10007,14 +10091,19 @@ bool Virtual_Machine::Start_impl()
 	}
 
 	#ifdef Q_OS_WIN32
-	// Prefer WSL/KVM for Intel macOS when enabled globally or on this VM
+	// Prefer WSL/KVM for Intel macOS when enabled globally or on this VM.
+	// Reims vGPU always requires Linux qemu-system-reims3d (Windows PE has no reims-vgpu-pci).
 	{
 		QSettings s;
 		const bool global_wsl = s.value( QStringLiteral( "WSL_Launch/Enabled" ), false ).toBool();
+		const bool is_reims =
+			Computer_Type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
+		if( is_reims )
+			Launch_Via_WSL = true;
 		if( Launch_Via_WSL || ( Intel_MacOS_Profile && global_wsl ) )
 		{
 			const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
-			// Fresh probe on start ‚Äî a prior cold-start timeout must not stick.
+			// Fresh probe on start ù a prior cold-start timeout must not stick.
 			WSL_Clear_Probe_Cache();
 			if( WSL_Is_Available( true ) )
 			{
@@ -10023,8 +10112,18 @@ bool Virtual_Machine::Start_impl()
 				if( ! WSL_Ensure_KVM_Access( distro ) )
 				{
 					AQWarning( "Virtual_Machine::Start_impl()",
-						"WSL /dev/kvm still not writable after automatic fix ‚Äî using TCG" );
+						"WSL /dev/kvm still not writable after automatic fix ù using TCG" );
 				}
+			}
+			else if( is_reims )
+			{
+				AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+					tr( "Reims vGPU requires WSL with the Linux binary "
+					    "/usr/local/bin/qemu-system-reims3d.\n\n"
+					    "The Windows qemu-system-reimsvgpu.exe build does not expose "
+					    "reims-vgpu-pci and cannot accelerate Metal/Vulkan." ), false );
+				Start_Snapshot_Tag = "";
+				return false;
 			}
 			else if( Launch_Via_WSL )
 			{
@@ -10042,7 +10141,7 @@ bool Virtual_Machine::Start_impl()
 	if( QEMU_Process && QEMU_Process->state() != QProcess::NotRunning )
 	{
 		AQWarning( "bool Virtual_Machine::Start_impl()",
-		           "Previous QEMU process still running ‚Äî terminating it before restart" );
+		           "Previous QEMU process still running ù terminating it before restart" );
 		QEMU_Process->kill();
 		if( ! QEMU_Process->waitForFinished( 5000 ) )
 		{
@@ -10209,6 +10308,7 @@ bool Virtual_Machine::Start_impl()
         // Get bin path
         QMap<QString, QString> bin_list = Current_Emulator.Get_Binary_Files();
         QString find_name = Current_Emulator_Devices.System.QEMU_Name;
+        if( find_name.isEmpty() ) find_name = Computer_Type;
         QString bin_path = "";
 
         for( QMap<QString, QString>::const_iterator iter = bin_list.constBegin(); iter != bin_list.constEnd(); iter++ )
@@ -10319,18 +10419,79 @@ bool Virtual_Machine::Start_impl()
 		if( Launch_Via_WSL )
 		{
 			QSettings s;
-			const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+			QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+			QString wslUser = s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
+			if( wslUser.trimmed().isEmpty() )
+			{
+				WSL_Wizard_Window wizard;
+				if( wizard.exec() != QDialog::Accepted )
+				{
+					AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+					                 tr( "WSL configuration is required to launch this VM." ), false );
+					Start_Snapshot_Tag = "";
+					return false;
+				}
+				distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+			}
+
 			QString linux_qemu = s.value( QStringLiteral( "WSL_Launch/Qemu_Binary" ),
 			                              QStringLiteral( "qemu-system-x86_64" ) ).toString();
-			if( linux_qemu.trimmed().isEmpty() )
-				linux_qemu = QStringLiteral( "qemu-system-x86_64" );
 			// Prefer matching guest arch binary name when possible
 			if( Computer_Type.contains( QLatin1String( "ppc" ), Qt::CaseInsensitive ) )
 				linux_qemu = QStringLiteral( "qemu-system-ppc" );
 			else if( Computer_Type.contains( QLatin1String( "aarch64" ), Qt::CaseInsensitive ) )
 				linux_qemu = QStringLiteral( "qemu-system-aarch64" );
+			else if( Computer_Type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) )
+			{
+				// Always use the Linux Reims ELF. The Windows qemu-system-reimsvgpu.exe
+				// is a mislabeled x86_64 build without reims-vgpu-pci / metal2vulkan.
+				linux_qemu = QStringLiteral( "/usr/local/bin/qemu-system-reims3d" );
+
+				// Optional: sync a host-side Linux ELF into WSL (never a Windows .exe).
+				QString host_linux_bin = QDir( QCoreApplication::applicationDirPath() )
+				                             .filePath( QStringLiteral( "qemu-system-reims3d" ) );
+				if( ! QFile::exists( host_linux_bin ) )
+					host_linux_bin = AQ_Get_Bundled_QEMU_Dir() + QStringLiteral( "/qemu-system-reims3d" );
+
+				if( QFile::exists( host_linux_bin ) &&
+				    ! host_linux_bin.endsWith( QLatin1String( ".exe" ), Qt::CaseInsensitive ) )
+				{
+					const QString wsl_src = Windows_Path_To_WSL( host_linux_bin );
+					AQDebug( "bool Virtual_Machine::Start()",
+					         QString( "Syncing host Linux Reims3D into WSL: %1 -> /usr/local/bin/qemu-system-reims3d" )
+					             .arg( host_linux_bin ) );
+
+					QStringList sync_args;
+					if( ! distro.trimmed().isEmpty() )
+						sync_args << QStringLiteral( "-d" ) << distro.trimmed();
+					// Prefer root so we avoid storing a sudo password in settings.
+					sync_args << QStringLiteral( "-u" ) << QStringLiteral( "root" );
+					sync_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" );
+					sync_args << QString(
+						"mkdir -p /usr/local/bin && "
+						"cp -f \"%1\" /usr/local/bin/qemu-system-reims3d && "
+						"chmod +x /usr/local/bin/qemu-system-reims3d && "
+						"mkdir -p /usr/share/qemu && "
+						"if [ -d /usr/share/seabios ] && [ ! -f /usr/share/qemu/vgabios-stdvga.bin ]; then "
+						"  ln -sf /usr/share/seabios/vgabios-stdvga.bin /usr/share/qemu/vgabios-stdvga.bin; "
+						"fi && "
+						"if [ -d /usr/share/seabios ] && [ ! -f /usr/share/qemu/kvmvapic.bin ]; then "
+						"  ln -sf /usr/share/seabios/kvmvapic.bin /usr/share/qemu/kvmvapic.bin; "
+						"fi" ).arg( wsl_src );
+
+					QProcess sync_proc;
+					sync_proc.start( QStringLiteral( "wsl.exe" ), sync_args );
+					sync_proc.waitForFinished( 15000 );
+				}
+			}
 
 			QStringList qemu_args = this->Build_QEMU_Args();
+			if( Computer_Type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) )
+			{
+				// Ensure the Linux Reims device is present (do not skip when other -device args exist).
+				if( ! qemu_args.contains( QStringLiteral( "reims-vgpu-pci" ) ) )
+					qemu_args << QStringLiteral( "-device" ) << QStringLiteral( "reims-vgpu-pci" );
+			}
 			// Ensure script-mode quoting cannot leak into argv launch
 			Build_QEMU_Args_for_Script_Mode = false;
 			QStringList wsl_args = Build_WSL_Launch_Args( distro, linux_qemu, qemu_args );
@@ -10584,7 +10745,7 @@ void Virtual_Machine::Kill_Orphan_QEMU_Using_Disks()
 	}
 
 	// Launch-via-WSL: Linux qemu-system often survives after wsl.exe is killed.
-	// Match on file basenames (paths differ: D:\‚Ä¶ vs /mnt/d/‚Ä¶).
+	// Match on file basenames (paths differ: D:\ù vs /mnt/d/ù).
 	if( ! Launch_Via_WSL )
 		return;
 
@@ -10599,7 +10760,7 @@ void Virtual_Machine::Kill_Orphan_QEMU_Using_Disks()
 	}
 	if( ! basenames.isEmpty() && WSL_Is_Available( false ) )
 	{
-		// Fixed-string match only (grep -F) ‚Äî never regex wildcards (PR #1 / Qodo)
+		// Fixed-string match only (grep -F) ù never regex wildcards (PR #1 / Qodo)
 		QString hit_checks;
 		for( const QString &b : basenames )
 		{
@@ -11016,11 +11177,13 @@ void Virtual_Machine::Update_Current_Emulator_Devices()
 	}
 	
 	// Predefined fallback if devices list does not contain this computer type
-	if( Current_Emulator_Devices.System.QEMU_Name.isEmpty() )
+	if( Current_Emulator_Devices.System.QEMU_Name.isEmpty() && ! Computer_Type.isEmpty() )
 	{
-		Current_Emulator_Devices = System_Info::Emulator_QEMU_2_0[ Computer_Type ];
+		Current_Emulator_Devices.System.QEMU_Name = Computer_Type;
 	}
-	
+	System_Info::Normalize_Virt_Arch_Devices( Current_Emulator_Devices );
+	QEMU_Probe_Catalog::Merge_Into( Current_Emulator_Devices );
+
 	// Loading Info Complete?
 	if( Current_Emulator_Devices.System.QEMU_Name.isEmpty() )
 	{
@@ -11312,7 +11475,7 @@ void Virtual_Machine::Ensure_Windows_XP_Family_Defaults()
 	Use_Check_FDD_Boot_Sector( false );
 
 	// WHPX (and HVF/NVMM) disable SMM. QEMU 9.1+ then hides VGA text RAM
-	// (0xa0000) ‚Üí XP setup blacks out after "inspecting hardware" over VNC/SPICE
+	// (0xa0000) ? XP setup blacks out after "inspecting hardware" over VNC/SPICE
 	// (gitlab.com/qemu-project/qemu/-/issues/2608). Pure TCG keeps SMM/text mode.
 	Use_Force_TCG( true );
 	Set_Machine_Accelerator( VM::TCG );
@@ -11326,7 +11489,7 @@ void Virtual_Machine::Ensure_Windows_XP_Family_Defaults()
 		Set_Mouse_USB_Version( 1 );
 	}
 
-	// XP setup has no VirtIO drivers ‚Äî disk must be IDE or setup sees "no hard disks".
+	// XP setup has no VirtIO drivers ù disk must be IDE or setup sees "no hard disks".
 	if( HDA.Get_Enabled() )
 	{
 		VM_Native_Storage_Device native = HDA.Get_Native_Device();
@@ -11418,7 +11581,7 @@ void Virtual_Machine::Ensure_ReactOS_Defaults()
 	if( Memory_Size < 1024 )
 		Set_Memory_Size( 1024 );
 
-	// Single AC97 only ‚Äî HDA / multiple cards can prevent boot (Installing ReactOS wiki).
+	// Single AC97 only ù HDA / multiple cards can prevent boot (Installing ReactOS wiki).
 	VM::Sound_Cards audio;
 	audio.Audio_AC97 = true;
 	Set_Audio_Cards( audio );
@@ -12249,6 +12412,26 @@ const QString &Virtual_Machine::Get_Initrd_Path() const
 void Virtual_Machine::Set_Initrd_Path( const QString &path )
 {
 	Initrd_Path = path;
+}
+
+const QString &Virtual_Machine::Get_DeviceTree_Path() const
+{
+	return DeviceTree_Path;
+}
+
+void Virtual_Machine::Set_DeviceTree_Path( const QString &path )
+{
+	DeviceTree_Path = path;
+}
+
+const QString &Virtual_Machine::Get_App_Kernel_Path() const
+{
+	return App_Kernel_Path;
+}
+
+void Virtual_Machine::Set_App_Kernel_Path( const QString &path )
+{
+	App_Kernel_Path = path;
 }
 
 const QString &Virtual_Machine::Get_Kernel_ComLine() const

--- a/src/VM.h
+++ b/src/VM.h
@@ -366,6 +366,12 @@ class Virtual_Machine: public QObject
 		
 		const QString &Get_Initrd_Path() const;
 		void Set_Initrd_Path( const QString &path );
+
+		const QString &Get_DeviceTree_Path() const;
+		void Set_DeviceTree_Path( const QString &path );
+
+		const QString &Get_App_Kernel_Path() const;
+		void Set_App_Kernel_Path( const QString &path );
 		
 		const QString &Get_Kernel_ComLine() const;
 		void Set_Kernel_ComLine( const QString &cl );
@@ -857,6 +863,8 @@ class Virtual_Machine: public QObject
 		bool Linux_Boot;
 		QString bzImage_Path;
 		QString Initrd_Path;
+		QString DeviceTree_Path;
+		QString App_Kernel_Path;
 		QString Kernel_ComLine;
 		
 		QString Additional_Args; // user arguments

--- a/src/VM_Devices.cpp
+++ b/src/VM_Devices.cpp
@@ -3668,7 +3668,7 @@ QString VM_Net_Card::Generate_MAC() const
 		else if( model == "pcnet" )
 		{
 			int rm = Get_Random( 0,1 );
-			if( rm >= 0 ) nmac.prepend( amd_mac[rm] );
+			if( rm >= 0 && rm < amd_mac.count() ) nmac.prepend( amd_mac[rm] );
 		}
 		else if( model == "rtl8139" )
 		{
@@ -3677,17 +3677,17 @@ QString VM_Net_Card::Generate_MAC() const
 		else if( model == "smc91c111" )
 		{
 			int rm = Get_Random( 0,4 );
-			if( rm >= 0 ) nmac.prepend( smc_mac[rm] );
+			if( rm >= 0 && rm < smc_mac.count() ) nmac.prepend( smc_mac[rm] );
 		}
 		else if( model == "mcf_fec" )
 		{
 			int rm = Get_Random( 0,4 );
-			if( rm >= 0 ) nmac.prepend( motorola_mac[rm] );
+			if( rm >= 0 && rm < motorola_mac.count() ) nmac.prepend( motorola_mac[rm] );
 		}
 		else if( model == "lance" )
 		{
 			int rm = Get_Random( 0,4 );
-			if( rm >= 0 ) nmac.prepend( sun_mac[rm] );
+			if( rm >= 0 && rm < sun_mac.count() ) nmac.prepend( sun_mac[rm] );
 		}
 		else if( model == "fseth" )
 		{

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -5129,7 +5129,8 @@ void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )
 	}
 	else
 	{
-		New_VM->Set_Video_Card( QStringLiteral( "virtio-gpu-pci" ) ); // Reims vGPU acceleration
+		New_VM->Set_Video_Card( QStringLiteral( "reims-vgpu-pci" ) ); // Linux Reims / AppleParavirtGPU
+		New_VM->Use_Launch_Via_WSL( true ); // Windows PE lacks reims-vgpu-pci — require WSL ELF
 	}
 	New_VM->Set_Machine_Type( QStringLiteral( "q35" ) );
 	New_VM->Set_CPU_Type( QStringLiteral( "Skylake-Client-v4" ) );
@@ -5158,10 +5159,10 @@ void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )
 	New_VM->Set_Mac_Recovery_Image_Path( QDir::toNativeSeparators( AQ_Normalize_File_Path( Edit_Intel_Mac_Recovery->text() ) ) );
 	New_VM->Set_Apple_SMC_OSK( Edit_Intel_Mac_OSK->text() );
 	New_VM->Use_Apple_SMC( ! Edit_Intel_Mac_OSK->text().trimmed().isEmpty() );
-	New_VM->Use_Launch_Via_WSL( CH_Intel_Mac_Prefer_WSL->isChecked() );
+	New_VM->Use_Launch_Via_WSL( is_reims || CH_Intel_Mac_Prefer_WSL->isChecked() );
 
 #ifdef Q_OS_WIN32
-	if( CH_Intel_Mac_Prefer_WSL->isChecked() )
+	if( is_reims || CH_Intel_Mac_Prefer_WSL->isChecked() )
 	{
 		Settings.setValue( QStringLiteral( "WSL_Launch/Enabled" ), true );
 	}

--- a/src/WSL_Launch.cpp
+++ b/src/WSL_Launch.cpp
@@ -13,6 +13,7 @@
 #include <QMutex>
 #include <QMutexLocker>
 #include <QTextCodec>
+#include <QSettings>
 
 #ifdef Q_OS_WIN32
 
@@ -92,6 +93,7 @@ bool Run_WSL( const QStringList &args, int timeout_ms, QString *stdout_text = nu
 
 } // namespace
 
+/** Clear cached WSL/KVM probe results (e.g. after Settings Probe). */
 void WSL_Clear_Probe_Cache()
 {
 	QMutexLocker lock( &g_wsl_cache_mutex );
@@ -99,6 +101,45 @@ void WSL_Clear_Probe_Cache()
 	g_wsl_kvm_valid = false;
 	g_wsl_avail_ms = 0;
 	g_wsl_kvm_ms = 0;
+}
+
+QStringList WSL_Get_Installed_Distros()
+{
+	QStringList distros;
+	QString out;
+	// wsl.exe -l -q lists installed distros line-by-line
+	if( Run_WSL( QStringList() << QStringLiteral( "-l" ) << QStringLiteral( "-q" ), 5000, &out ) )
+	{
+		const QStringList lines = out.split( QRegularExpression( QStringLiteral( "[\\r\\n]+" ) ), QString::SkipEmptyParts );
+		for( const QString &line : lines )
+		{
+			const QString t = line.trimmed();
+			if( ! t.isEmpty() && ! distros.contains( t ) )
+				distros << t;
+		}
+	}
+	return distros;
+}
+
+QString WSL_Get_Distro_Default_User( const QString &distro )
+{
+	QString user;
+	QStringList who = Distro_Args( distro );
+	who << QStringLiteral( "--" ) << QStringLiteral( "whoami" );
+	if( Run_WSL( who, 5000, &user ) && ! user.trimmed().isEmpty() )
+	{
+		user = user.trimmed();
+		// Defensive: only return safe username characters
+		for( const QChar &ch : user )
+		{
+			if( ! ( ch.isLetterOrNumber() || ch == QLatin1Char( '_' ) || ch == QLatin1Char( '-' ) ) )
+			{
+				return QStringLiteral( "root" );
+			}
+		}
+		return user;
+	}
+	return QStringLiteral( "root" );
 }
 
 bool WSL_Is_Available( bool force_refresh )
@@ -166,36 +207,55 @@ bool WSL_Ensure_KVM_Access( const QString &distro )
 	if( ! WSL_Is_Available( false ) )
 		return false;
 
+	QSettings s;
+	const QString wslUser = s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
+	const QString wslPassword = s.value( QStringLiteral( "WSL_Launch/Password" ), QString() ).toString();
+
 	// macOS guests (and many OSX-KVM recipes) need ignore_msrs=1 or the
 	// kernel hangs after OpenCore with "still waiting for root device".
 	{
-		QStringList root_msrs;
+		QStringList msr_args;
 		if( ! d.isEmpty() )
-			root_msrs << QStringLiteral( "-d" ) << d;
-		root_msrs << QStringLiteral( "-u" ) << QStringLiteral( "root" ) << QStringLiteral( "--" )
-		          << QStringLiteral( "bash" ) << QStringLiteral( "-lc" )
-		          << QStringLiteral(
-				"if [ -w /sys/module/kvm/parameters/ignore_msrs ]; then "
-				"echo 1 > /sys/module/kvm/parameters/ignore_msrs; fi; "
-				"mkdir -p /etc/modprobe.d 2>/dev/null || true; "
-				"printf 'options kvm ignore_msrs=Y report_ignored_msrs=0\\n' "
-				"> /etc/modprobe.d/aqemu-kvm-macos.conf 2>/dev/null || true; "
-				"exit 0" );
-		Run_WSL( root_msrs, kWslTimeoutMs );
+			msr_args << QStringLiteral( "-d" ) << d;
+		if( ! wslUser.trimmed().isEmpty() )
+			msr_args << QStringLiteral( "-u" ) << wslUser.trimmed();
+		msr_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" );
+
+		QString cmdStr;
+		if( ! wslPassword.isEmpty() )
+		{
+			cmdStr = QString( "echo \"%1\" | sudo -S sh -c \""
+			                 "if [ -w /sys/module/kvm/parameters/ignore_msrs ]; then "
+			                 "echo 1 > /sys/module/kvm/parameters/ignore_msrs; fi; "
+			                 "mkdir -p /etc/modprobe.d 2>/dev/null || true; "
+			                 "printf 'options kvm ignore_msrs=Y report_ignored_msrs=0\\\\n' "
+			                 "> /etc/modprobe.d/aqemu-kvm-macos.conf 2>/dev/null || true;\"" ).arg( wslPassword );
+		}
+		else
+		{
+			cmdStr = QStringLiteral( "sudo sh -c \""
+			                        "if [ -w /sys/module/kvm/parameters/ignore_msrs ]; then "
+			                        "echo 1 > /sys/module/kvm/parameters/ignore_msrs; fi; "
+			                        "mkdir -p /etc/modprobe.d 2>/dev/null || true; "
+			                        "printf 'options kvm ignore_msrs=Y report_ignored_msrs=0\\n' "
+			                        "> /etc/modprobe.d/aqemu-kvm-macos.conf 2>/dev/null || true;\"" );
+		}
+		msr_args << cmdStr;
+		Run_WSL( msr_args, kWslTimeoutMs );
 	}
 
 	if( WSL_Has_KVM( d, true ) )
 		return true;
 
-	// Resolve the default (non-root) username for this distro
-	QString user;
+	// Resolve the username
+	QString user = wslUser.trimmed();
+	if( user.isEmpty() )
 	{
 		QStringList who = Distro_Args( d );
 		who << QStringLiteral( "--" ) << QStringLiteral( "whoami" );
 		if( ! Run_WSL( who, kWslTimeoutMs, &user ) || user.trimmed().isEmpty() )
-			user = QStringLiteral( "root" ); // shouldn't happen; chmod still helps
+			user = QStringLiteral( "root" );
 		user = user.trimmed();
-		// Defensive: only allow safe username chars
 		for( const QChar &ch : user )
 		{
 			if( ! ( ch.isLetterOrNumber() || ch == QLatin1Char( '_' ) || ch == QLatin1Char( '-' ) ) )
@@ -206,12 +266,13 @@ bool WSL_Ensure_KVM_Access( const QString &distro )
 		}
 	}
 
-	// WSL root is typically passwordless from Windows — fix group + immediate access.
-	QStringList root_args;
+	// Fix KVM permissions using user settings
+	QStringList kvm_args;
 	if( ! d.isEmpty() )
-		root_args << QStringLiteral( "-d" ) << d;
-	root_args << QStringLiteral( "-u" ) << QStringLiteral( "root" ) << QStringLiteral( "--" )
-	          << QStringLiteral( "bash" ) << QStringLiteral( "-lc" );
+		kvm_args << QStringLiteral( "-d" ) << d;
+	if( ! wslUser.trimmed().isEmpty() )
+		kvm_args << QStringLiteral( "-u" ) << wslUser.trimmed();
+	kvm_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" );
 
 	QString script = QStringLiteral(
 		"getent group kvm >/dev/null 2>&1 || groupadd -r kvm 2>/dev/null || true; "
@@ -219,16 +280,25 @@ bool WSL_Ensure_KVM_Access( const QString &distro )
 	if( ! user.isEmpty() && user != QLatin1String( "root" ) )
 	{
 		script += QStringLiteral( "usermod -aG kvm '%1' 2>/dev/null || true; " ).arg( user );
-		// Persist across WSL restarts when possible (udev/rules or module load)
 		script += QStringLiteral(
 			"mkdir -p /etc/udev/rules.d 2>/dev/null || true; "
 			"printf 'KERNEL==\"kvm\", GROUP=\"kvm\", MODE=\"0660\"\\n' "
 			"> /etc/udev/rules.d/99-aqemu-kvm.rules 2>/dev/null || true; " );
 	}
 	script += QStringLiteral( "exit 0" );
-	root_args << script;
 
-	Run_WSL( root_args, kWslTimeoutMs );
+	QString finalCmd;
+	if( ! wslPassword.isEmpty() )
+	{
+		finalCmd = QString( "echo \"%1\" | sudo -S sh -c \"%2\"" ).arg( wslPassword, script );
+	}
+	else
+	{
+		finalCmd = QString( "sudo sh -c \"%1\"" ).arg( script );
+	}
+	kvm_args << finalCmd;
+
+	Run_WSL( kvm_args, kWslTimeoutMs );
 
 	WSL_Clear_Probe_Cache();
 	return WSL_Has_KVM( d, true );
@@ -335,6 +405,7 @@ QStringList Rewrite_Args_For_WSL( const QStringList &win_args )
 		      a == QLatin1String( "-fdb" ) || a == QLatin1String( "-kernel" ) ||
 		      a == QLatin1String( "-initrd" ) || a == QLatin1String( "-bios" ) ||
 		      a == QLatin1String( "-pflash" ) || a == QLatin1String( "-dtb" ) ||
+		      a == QLatin1String( "-L" ) ||
 		      a == QLatin1String( "-append" ) ) &&
 		    i + 1 < win_args.size() )
 		{
@@ -390,7 +461,8 @@ QStringList Build_WSL_Launch_Args( const QString &distro,
 	              ? QStringLiteral( "qemu-system-x86_64" )
 	              : linux_qemu_binary );
 
-	QStringList rewritten = Rewrite_Args_For_WSL( qemu_args );
+	const bool runs_windows_exe = linux_qemu_binary.endsWith( QLatin1String( ".exe" ), Qt::CaseInsensitive );
+	QStringList rewritten = runs_windows_exe ? qemu_args : Rewrite_Args_For_WSL( qemu_args );
 	for( int i = 0; i < rewritten.size(); ++i )
 	{
 		QString &a = rewritten[i];

--- a/src/WSL_Launch.cpp
+++ b/src/WSL_Launch.cpp
@@ -74,6 +74,27 @@ QStringList Distro_Args( const QString &distro )
 	return args;
 }
 
+/** Username safe for shell interpolation (letters, digits, _ and - only). */
+QString Sanitize_WSL_Username( const QString &raw )
+{
+	const QString user = raw.trimmed();
+	if( user.isEmpty() )
+		return QString();
+	for( const QChar &ch : user )
+	{
+		if( ! ( ch.isLetterOrNumber() || ch == QLatin1Char( '_' ) || ch == QLatin1Char( '-' ) ) )
+			return QString();
+	}
+	return user;
+}
+
+QString Configured_WSL_Username()
+{
+	QSettings s;
+	return Sanitize_WSL_Username(
+		s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString() );
+}
+
 bool Run_WSL( const QStringList &args, int timeout_ms, QString *stdout_text = nullptr )
 {
 	QProcess p;
@@ -174,8 +195,11 @@ bool WSL_Has_KVM( const QString &distro, bool force_refresh )
 			return g_wsl_kvm;
 	}
 
-	// Require read+write — `test -e` alone is not enough (Permission denied on open).
+	// Probe as the configured launch user so results match Build_WSL_Launch_Args.
 	QStringList args = Distro_Args( d );
+	const QString wslUser = Configured_WSL_Username();
+	if( ! wslUser.isEmpty() )
+		args << QStringLiteral( "-u" ) << wslUser;
 	args << QStringLiteral( "--" ) << QStringLiteral( "test" )
 	     << QStringLiteral( "-r" ) << QStringLiteral( "/dev/kvm" )
 	     << QStringLiteral( "-a" )
@@ -207,72 +231,49 @@ bool WSL_Ensure_KVM_Access( const QString &distro )
 	if( ! WSL_Is_Available( false ) )
 		return false;
 
-	QSettings s;
-	const QString wslUser = s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
-	const QString wslPassword = s.value( QStringLiteral( "WSL_Launch/Password" ), QString() ).toString();
+	// Drop any legacy stored password — never pass secrets via wsl argv.
+	{
+		QSettings s;
+		s.remove( QStringLiteral( "WSL_Launch/Password" ) );
+	}
+
+	const QString wslUser = Configured_WSL_Username();
+
+	// Privileged setup always runs as root via `wsl -u root` (no sudo / no password).
+	auto root_args = [&]( const QString &script ) -> QStringList
+	{
+		QStringList args = Distro_Args( d );
+		args << QStringLiteral( "-u" ) << QStringLiteral( "root" )
+		     << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" )
+		     << script;
+		return args;
+	};
 
 	// macOS guests (and many OSX-KVM recipes) need ignore_msrs=1 or the
 	// kernel hangs after OpenCore with "still waiting for root device".
-	{
-		QStringList msr_args;
-		if( ! d.isEmpty() )
-			msr_args << QStringLiteral( "-d" ) << d;
-		if( ! wslUser.trimmed().isEmpty() )
-			msr_args << QStringLiteral( "-u" ) << wslUser.trimmed();
-		msr_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" );
-
-		QString cmdStr;
-		if( ! wslPassword.isEmpty() )
-		{
-			cmdStr = QString( "echo \"%1\" | sudo -S sh -c \""
-			                 "if [ -w /sys/module/kvm/parameters/ignore_msrs ]; then "
-			                 "echo 1 > /sys/module/kvm/parameters/ignore_msrs; fi; "
-			                 "mkdir -p /etc/modprobe.d 2>/dev/null || true; "
-			                 "printf 'options kvm ignore_msrs=Y report_ignored_msrs=0\\\\n' "
-			                 "> /etc/modprobe.d/aqemu-kvm-macos.conf 2>/dev/null || true;\"" ).arg( wslPassword );
-		}
-		else
-		{
-			cmdStr = QStringLiteral( "sudo sh -c \""
-			                        "if [ -w /sys/module/kvm/parameters/ignore_msrs ]; then "
-			                        "echo 1 > /sys/module/kvm/parameters/ignore_msrs; fi; "
-			                        "mkdir -p /etc/modprobe.d 2>/dev/null || true; "
-			                        "printf 'options kvm ignore_msrs=Y report_ignored_msrs=0\\n' "
-			                        "> /etc/modprobe.d/aqemu-kvm-macos.conf 2>/dev/null || true;\"" );
-		}
-		msr_args << cmdStr;
-		Run_WSL( msr_args, kWslTimeoutMs );
-	}
+	Run_WSL( root_args( QStringLiteral(
+		"if [ -w /sys/module/kvm/parameters/ignore_msrs ]; then "
+		"echo 1 > /sys/module/kvm/parameters/ignore_msrs; fi; "
+		"mkdir -p /etc/modprobe.d 2>/dev/null || true; "
+		"printf 'options kvm ignore_msrs=Y report_ignored_msrs=0\\n' "
+		"> /etc/modprobe.d/aqemu-kvm-macos.conf 2>/dev/null || true; "
+		"exit 0" ) ), kWslTimeoutMs );
 
 	if( WSL_Has_KVM( d, true ) )
 		return true;
 
-	// Resolve the username
-	QString user = wslUser.trimmed();
+	// Resolve the username to add to the kvm group
+	QString user = wslUser;
 	if( user.isEmpty() )
 	{
 		QStringList who = Distro_Args( d );
 		who << QStringLiteral( "--" ) << QStringLiteral( "whoami" );
-		if( ! Run_WSL( who, kWslTimeoutMs, &user ) || user.trimmed().isEmpty() )
+		QString whoami;
+		if( Run_WSL( who, kWslTimeoutMs, &whoami ) )
+			user = Sanitize_WSL_Username( whoami );
+		if( user.isEmpty() )
 			user = QStringLiteral( "root" );
-		user = user.trimmed();
-		for( const QChar &ch : user )
-		{
-			if( ! ( ch.isLetterOrNumber() || ch == QLatin1Char( '_' ) || ch == QLatin1Char( '-' ) ) )
-			{
-				user.clear();
-				break;
-			}
-		}
 	}
-
-	// Fix KVM permissions using user settings
-	QStringList kvm_args;
-	if( ! d.isEmpty() )
-		kvm_args << QStringLiteral( "-d" ) << d;
-	if( ! wslUser.trimmed().isEmpty() )
-		kvm_args << QStringLiteral( "-u" ) << wslUser.trimmed();
-	kvm_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" );
 
 	QString script = QStringLiteral(
 		"getent group kvm >/dev/null 2>&1 || groupadd -r kvm 2>/dev/null || true; "
@@ -287,18 +288,7 @@ bool WSL_Ensure_KVM_Access( const QString &distro )
 	}
 	script += QStringLiteral( "exit 0" );
 
-	QString finalCmd;
-	if( ! wslPassword.isEmpty() )
-	{
-		finalCmd = QString( "echo \"%1\" | sudo -S sh -c \"%2\"" ).arg( wslPassword, script );
-	}
-	else
-	{
-		finalCmd = QString( "sudo sh -c \"%1\"" ).arg( script );
-	}
-	kvm_args << finalCmd;
-
-	Run_WSL( kvm_args, kWslTimeoutMs );
+	Run_WSL( root_args( script ), kWslTimeoutMs );
 
 	WSL_Clear_Probe_Cache();
 	return WSL_Has_KVM( d, true );
@@ -453,6 +443,11 @@ QStringList Build_WSL_Launch_Args( const QString &distro,
 	QStringList args;
 	if( ! distro.trimmed().isEmpty() )
 		args << QStringLiteral( "-d" ) << distro.trimmed();
+	// Run QEMU as the configured WSL user so KVM group membership matches
+	// WSL_Ensure_KVM_Access / WSL_Has_KVM probes.
+	const QString wslUser = Configured_WSL_Username();
+	if( ! wslUser.isEmpty() )
+		args << QStringLiteral( "-u" ) << wslUser;
 	// -e/--exec: run without the default Linux shell. Using `wsl -- cmd …`
 	// goes through bash -c, which breaks OSK strings containing '(c)' and
 	// paths with spaces.

--- a/src/WSL_Launch.h
+++ b/src/WSL_Launch.h
@@ -20,6 +20,12 @@ bool WSL_Ensure_KVM_Access( const QString &distro = QString() );
 /** Clear cached WSL/KVM probe results (e.g. after Settings Probe). */
 void WSL_Clear_Probe_Cache();
 
+/** Retrieve a list of all installed WSL distributions. */
+QStringList WSL_Get_Installed_Distros();
+
+/** Get the default non-root username for a given WSL distro. */
+QString WSL_Get_Distro_Default_User( const QString &distro );
+
 QString Windows_Path_To_WSL( const QString &windows_path );
 /** Rewrite file=/firmware paths in a QEMU arg list for Linux inside WSL. */
 QStringList Rewrite_Args_For_WSL( const QStringList &win_args );

--- a/src/WSL_Launch.h
+++ b/src/WSL_Launch.h
@@ -29,7 +29,7 @@ QString WSL_Get_Distro_Default_User( const QString &distro );
 QString Windows_Path_To_WSL( const QString &windows_path );
 /** Rewrite file=/firmware paths in a QEMU arg list for Linux inside WSL. */
 QStringList Rewrite_Args_For_WSL( const QStringList &win_args );
-/** Build wsl.exe argv: optional -d distro, --, linux_qemu, rewritten qemu args. */
+/** Build wsl.exe argv: optional -d distro, optional -u user, -e, linux_qemu, rewritten qemu args. */
 QStringList Build_WSL_Launch_Args( const QString &distro,
                                    const QString &linux_qemu_binary,
                                    const QStringList &qemu_args );

--- a/src/WSL_Wizard_Window.cpp
+++ b/src/WSL_Wizard_Window.cpp
@@ -36,10 +36,10 @@ WSL_Wizard_Window::WSL_Wizard_Window( QWidget *parent )
 	Edit_User->setText( Settings.value( "WSL_Launch/Username", "" ).toString() );
 	form->addRow( tr("WSL Username:"), Edit_User );
 
-	Edit_Password = new QLineEdit();
-	Edit_Password->setEchoMode( QLineEdit::Password );
-	Edit_Password->setPlaceholderText( tr( "Optional — prefer wsl -u root for admin tasks" ) );
-	form->addRow( tr("WSL Password (optional):"), Edit_Password );
+	QLabel *hint = new QLabel( tr( "Admin tasks (KVM group) use wsl -u root — no password needed." ) );
+	hint->setWordWrap( true );
+	hint->setStyleSheet( QStringLiteral( "color: gray;" ) );
+	form->addRow( QString(), hint );
 
 	mainLay->addLayout( form );
 
@@ -66,11 +66,6 @@ QString WSL_Wizard_Window::Get_Username() const
 	return Edit_User->text().trimmed();
 }
 
-QString WSL_Wizard_Window::Get_Password() const
-{
-	return Edit_Password->text();
-}
-
 void WSL_Wizard_Window::on_CB_Distro_currentIndexChanged( int index )
 {
 	Q_UNUSED( index );
@@ -90,7 +85,7 @@ void WSL_Wizard_Window::on_Btn_Ok_clicked()
 	}
 	Settings.setValue( "WSL_Launch/Distro", Get_Distro() );
 	Settings.setValue( "WSL_Launch/Username", Get_Username() );
-	// Do not persist the WSL password — optional sudo prompts can use root via wsl -u root.
+	// Never persist WSL passwords; privileged ops use wsl -u root.
 	Settings.remove( "WSL_Launch/Password" );
 	accept();
 }

--- a/src/WSL_Wizard_Window.cpp
+++ b/src/WSL_Wizard_Window.cpp
@@ -1,0 +1,101 @@
+#include "WSL_Wizard_Window.h"
+#include "WSL_Launch.h"
+#include "Utils.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QLabel>
+
+WSL_Wizard_Window::WSL_Wizard_Window( QWidget *parent )
+	: QDialog( parent )
+{
+	setWindowTitle( tr("WSL First-Run Setup") );
+	setMinimumWidth( 400 );
+
+	QVBoxLayout *mainLay = new QVBoxLayout( this );
+
+	QLabel *intro = new QLabel( tr("AQEMU needs your WSL configuration to start VMs. Please configure your distro details below:") );
+	intro->setWordWrap( true );
+	mainLay->addWidget( intro );
+
+	QFormLayout *form = new QFormLayout();
+
+	CB_Distro = new QComboBox();
+	CB_Distro->setEditable( true );
+	CB_Distro->addItem( "" );
+	CB_Distro->addItems( WSL_Get_Installed_Distros() );
+	const QString savedDistro = Settings.value( "WSL_Launch/Distro", "" ).toString();
+	CB_Distro->setCurrentText( savedDistro );
+	form->addRow( tr("WSL Distro:"), CB_Distro );
+
+	Edit_User = new QLineEdit();
+	Edit_User->setText( Settings.value( "WSL_Launch/Username", "" ).toString() );
+	form->addRow( tr("WSL Username:"), Edit_User );
+
+	Edit_Password = new QLineEdit();
+	Edit_Password->setEchoMode( QLineEdit::Password );
+	Edit_Password->setPlaceholderText( tr( "Optional — prefer wsl -u root for admin tasks" ) );
+	form->addRow( tr("WSL Password (optional):"), Edit_Password );
+
+	mainLay->addLayout( form );
+
+	QHBoxLayout *btnLay = new QHBoxLayout();
+	QPushButton *btnOk = new QPushButton( tr("OK") );
+	QPushButton *btnCancel = new QPushButton( tr("Cancel") );
+	btnLay->addStretch();
+	btnLay->addWidget( btnOk );
+	btnLay->addWidget( btnCancel );
+	mainLay->addLayout( btnLay );
+
+	connect( CB_Distro, SIGNAL(currentIndexChanged(int)), this, SLOT(on_CB_Distro_currentIndexChanged(int)) );
+	connect( btnOk, SIGNAL(clicked()), this, SLOT(on_Btn_Ok_clicked()) );
+	connect( btnCancel, SIGNAL(clicked()), this, SLOT(on_Btn_Cancel_clicked()) );
+}
+
+QString WSL_Wizard_Window::Get_Distro() const
+{
+	return CB_Distro->currentText().trimmed();
+}
+
+QString WSL_Wizard_Window::Get_Username() const
+{
+	return Edit_User->text().trimmed();
+}
+
+QString WSL_Wizard_Window::Get_Password() const
+{
+	return Edit_Password->text();
+}
+
+void WSL_Wizard_Window::on_CB_Distro_currentIndexChanged( int index )
+{
+	Q_UNUSED( index );
+	const QString distro = CB_Distro->currentText().trimmed();
+	if( ! distro.isEmpty() && Edit_User->text().isEmpty() )
+	{
+		Edit_User->setText( WSL_Get_Distro_Default_User( distro ) );
+	}
+}
+
+void WSL_Wizard_Window::on_Btn_Ok_clicked()
+{
+	if( Edit_User->text().trimmed().isEmpty() )
+	{
+		AQGraphic_Warning( tr("Warning"), tr("WSL Username is required!") );
+		return;
+	}
+	Settings.setValue( "WSL_Launch/Distro", Get_Distro() );
+	Settings.setValue( "WSL_Launch/Username", Get_Username() );
+	// Do not persist the WSL password — optional sudo prompts can use root via wsl -u root.
+	Settings.remove( "WSL_Launch/Password" );
+	accept();
+}
+
+void WSL_Wizard_Window::on_Btn_Cancel_clicked()
+{
+	reject();
+}

--- a/src/WSL_Wizard_Window.h
+++ b/src/WSL_Wizard_Window.h
@@ -16,7 +16,6 @@ class WSL_Wizard_Window : public QDialog
 		WSL_Wizard_Window( QWidget *parent = 0 );
 		QString Get_Distro() const;
 		QString Get_Username() const;
-		QString Get_Password() const;
 
 	private slots:
 		void on_CB_Distro_currentIndexChanged( int index );
@@ -26,7 +25,6 @@ class WSL_Wizard_Window : public QDialog
 	private:
 		QComboBox *CB_Distro;
 		QLineEdit *Edit_User;
-		QLineEdit *Edit_Password;
 		QSettings Settings;
 };
 

--- a/src/WSL_Wizard_Window.h
+++ b/src/WSL_Wizard_Window.h
@@ -1,0 +1,33 @@
+#ifndef WSL_WIZARD_WINDOW_H
+#define WSL_WIZARD_WINDOW_H
+
+#include <QDialog>
+#include <QSettings>
+
+class QComboBox;
+class QLineEdit;
+class QLabel;
+
+class WSL_Wizard_Window : public QDialog
+{
+	Q_OBJECT
+
+	public:
+		WSL_Wizard_Window( QWidget *parent = 0 );
+		QString Get_Distro() const;
+		QString Get_Username() const;
+		QString Get_Password() const;
+
+	private slots:
+		void on_CB_Distro_currentIndexChanged( int index );
+		void on_Btn_Ok_clicked();
+		void on_Btn_Cancel_clicked();
+
+	private:
+		QComboBox *CB_Distro;
+		QLineEdit *Edit_User;
+		QLineEdit *Edit_Password;
+		QSettings Settings;
+};
+
+#endif

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -1,0 +1,322 @@
+#include "iOS_Firmware_Tool_Window.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QApplication>
+#include <QClipboard>
+#include <QDir>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include "AQ_UI_Style.h"
+#include "Utils.h"
+
+iOS_Firmware_Tool_Window::iOS_Firmware_Tool_Window( QWidget *parent )
+	: QDialog( parent )
+	, Process( new QProcess( this ) )
+{
+	setWindowTitle( tr( "iOS Firmware Unpacker & pyimg4 Processor" ) );
+	resize( AQ_Px( 780, this ), AQ_Px( 560, this ) );
+	PyIMG4_Exe = Find_PyIMG4_Executable();
+
+	connect( Process, &QProcess::readyReadStandardOutput, this, &iOS_Firmware_Tool_Window::On_Process_Output );
+	connect( Process, &QProcess::readyReadStandardError, this, &iOS_Firmware_Tool_Window::On_Process_Output );
+	connect( Process, QOverload<int, QProcess::ExitStatus>::of( &QProcess::finished ),
+	         this, &iOS_Firmware_Tool_Window::On_Process_Finished );
+
+	Setup_Ui();
+}
+
+QString iOS_Firmware_Tool_Window::Find_PyIMG4_Executable() const
+{
+	const QString app_dir = QCoreApplication::applicationDirPath();
+	const QStringList candidates = {
+		app_dir + "/pyimg4.exe",
+		app_dir + "/tools/pyimg4.exe",
+		"C:/msys64/ucrt64/bin/pyimg4.exe",
+		"C:/msys64/ucrt64/bin/pyimg4",
+		QStandardPaths::findExecutable( "pyimg4" )
+	};
+
+	for( const QString &path : candidates )
+	{
+		if( ! path.isEmpty() && QFile::exists( path ) )
+			return QDir::toNativeSeparators( path );
+	}
+	return QStringLiteral( "pyimg4" );
+}
+
+void iOS_Firmware_Tool_Window::Setup_Ui()
+{
+	QVBoxLayout *main_lay = new QVBoxLayout( this );
+
+	// Top Banner / Intro
+	QLabel *title = new QLabel( tr( "<b>Apple iOS Firmware Unpacker & pyimg4 Processor</b>" ) );
+	title->setStyleSheet( QStringLiteral( "font-size: 14px; color: #1a5fb4;" ) );
+	main_lay->addWidget( title );
+
+	QLabel *subtitle = new QLabel( tr( "Automates IPSW extraction and Image4 payload processing (SEP, iBSS, iBEC) for QEMU Apple SoC emulation." ) );
+	subtitle->setWordWrap( true );
+	main_lay->addWidget( subtitle );
+
+	Stack_Pages = new QStackedWidget( this );
+
+	// Page 1: IPSW Unpack & Extract
+	QWidget *page1 = new QWidget();
+	QVBoxLayout *p1_lay = new QVBoxLayout( page1 );
+	QGroupBox *gb_ipsw = new QGroupBox( tr( "Step 1: Unpack IPSW Archive" ) );
+	QGridLayout *grid1 = new QGridLayout( gb_ipsw );
+
+	grid1->addWidget( new QLabel( tr( "IPSW File:" ) ), 0, 0 );
+	Edit_IPSW_Path = new QLineEdit();
+	Edit_IPSW_Path->setPlaceholderText( tr( "Select downloaded iOS IPSW file (e.g., iPhone12,1_14.0_Restore.ipsw)..." ) );
+	grid1->addWidget( Edit_IPSW_Path, 0, 1 );
+	Btn_Browse_IPSW = new QPushButton( tr( "Browse..." ) );
+	connect( Btn_Browse_IPSW, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_IPSW_File );
+	grid1->addWidget( Btn_Browse_IPSW, 0, 2 );
+
+	grid1->addWidget( new QLabel( tr( "Extraction Output Directory:" ) ), 1, 0 );
+	Edit_Output_Dir = new QLineEdit();
+	Edit_Output_Dir->setText( QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/firmware_extracted" ) );
+	grid1->addWidget( Edit_Output_Dir, 1, 1 );
+	Btn_Browse_OutDir = new QPushButton( tr( "Browse..." ) );
+	connect( Btn_Browse_OutDir, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_Output_Dir );
+	grid1->addWidget( Btn_Browse_OutDir, 1, 2 );
+
+	Btn_Start_Unpack = new QPushButton( tr( "Unpack IPSW Payload" ) );
+	Btn_Start_Unpack->setStyleSheet( QStringLiteral( "font-weight: bold; background-color: #3584e4; color: white; padding: 6px;" ) );
+	connect( Btn_Start_Unpack, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Run_IPSW_Extraction );
+	grid1->addWidget( Btn_Start_Unpack, 2, 1, 1, 2 );
+
+	p1_lay->addWidget( gb_ipsw );
+
+	// Page 2: IM4P Payload Operation
+	QGroupBox *gb_im4p = new QGroupBox( tr( "Step 2: Process IM4P Payload (pyimg4)" ) );
+	QGridLayout *grid2 = new QGridLayout( gb_im4p );
+
+	grid2->addWidget( new QLabel( tr( "IM4P Payload File:" ) ), 0, 0 );
+	Edit_IM4P_Path = new QLineEdit();
+	Edit_IM4P_Path->setPlaceholderText( tr( "Select IM4P file (e.g. sep-firmware.im4p or iBEC.im4p)..." ) );
+	grid2->addWidget( Edit_IM4P_Path, 0, 1 );
+	Btn_Browse_IM4P = new QPushButton( tr( "Browse..." ) );
+	connect( Btn_Browse_IM4P, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_IM4P_File );
+	grid2->addWidget( Btn_Browse_IM4P, 0, 2 );
+
+	grid2->addWidget( new QLabel( tr( "Operation:" ) ), 1, 0 );
+	CB_IM4P_Action = new QComboBox();
+	CB_IM4P_Action->addItem( tr( "Extract Raw Payload (pyimg4 im4p extract)" ), "extract_raw" );
+	CB_IM4P_Action->addItem( tr( "Decrypt Payload with Key (pyimg4 im4p extract --key --iv)" ), "decrypt" );
+	CB_IM4P_Action->addItem( tr( "View Payload Stats (pyimg4 im4p stats)" ), "stats" );
+	grid2->addWidget( CB_IM4P_Action, 1, 1, 1, 2 );
+
+	grid2->addWidget( new QLabel( tr( "AES IV (Hex, optional):" ) ), 2, 0 );
+	Edit_AES_IV = new QLineEdit();
+	grid2->addWidget( Edit_AES_IV, 2, 1, 1, 2 );
+
+	grid2->addWidget( new QLabel( tr( "AES Key (Hex, optional):" ) ), 3, 0 );
+	Edit_AES_Key = new QLineEdit();
+	grid2->addWidget( Edit_AES_Key, 3, 1, 1, 2 );
+
+	Btn_Start_IM4P = new QPushButton( tr( "Execute pyimg4 Action" ) );
+	connect( Btn_Start_IM4P, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Run_IM4P_Operation );
+	grid2->addWidget( Btn_Start_IM4P, 4, 1, 1, 2 );
+
+	p1_lay->addWidget( gb_im4p );
+	Stack_Pages->addWidget( page1 );
+
+	main_lay->addWidget( Stack_Pages, 1 );
+
+	// Output Console Log
+	QGroupBox *gb_log = new QGroupBox( tr( "Execution Output Log" ) );
+	QVBoxLayout *log_lay = new QVBoxLayout( gb_log );
+	Text_Console_Log = new QTextEdit();
+	Text_Console_Log->setReadOnly( true );
+	Text_Console_Log->setStyleSheet( QStringLiteral( "font-family: Consolas, monospace; font-size: 11px; background-color: #1e1e1e; color: #d4d4d4;" ) );
+	log_lay->addWidget( Text_Console_Log );
+	main_lay->addWidget( gb_log, 1 );
+
+	// Output File Paths summary card
+	QGroupBox *gb_paths = new QGroupBox( tr( "Extracted Output File Locations" ) );
+	QHBoxLayout *paths_lay = new QHBoxLayout( gb_paths );
+	Text_Result_Paths = new QTextEdit();
+	Text_Result_Paths->setReadOnly( true );
+	Text_Result_Paths->setMaximumHeight( AQ_Px( 70, this ) );
+	paths_lay->addWidget( Text_Result_Paths, 1 );
+
+	Btn_Copy_Paths = new QPushButton( tr( "Copy Locations" ) );
+	Btn_Copy_Paths->setIcon( QIcon( QStringLiteral( ":/edit-copy.png" ) ) );
+	connect( Btn_Copy_Paths, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Copy_Output_Paths );
+	paths_lay->addWidget( Btn_Copy_Paths );
+
+	main_lay->addWidget( gb_paths );
+
+	QHBoxLayout *btn_lay = new QHBoxLayout();
+	btn_lay->addStretch( 1 );
+	QPushButton *btn_close = new QPushButton( tr( "Close" ) );
+	connect( btn_close, &QPushButton::clicked, this, &QDialog::accept );
+	btn_lay->addWidget( btn_close );
+	main_lay->addLayout( btn_lay );
+}
+
+void iOS_Firmware_Tool_Window::Browse_IPSW_File()
+{
+	const QString file = QFileDialog::getOpenFileName(
+		this, tr( "Select Apple iOS IPSW File" ),
+		Edit_IPSW_Path->text(),
+		tr( "Apple IPSW Firmware (*.ipsw *.zip);;All Files (*.*)" ) );
+	if( ! file.isEmpty() )
+		Edit_IPSW_Path->setText( QDir::toNativeSeparators( file ) );
+}
+
+void iOS_Firmware_Tool_Window::Browse_Output_Dir()
+{
+	const QString dir = QFileDialog::getExistingDirectory(
+		this, tr( "Select Target Extraction Folder" ), Edit_Output_Dir->text() );
+	if( ! dir.isEmpty() )
+		Edit_Output_Dir->setText( QDir::toNativeSeparators( dir ) );
+}
+
+void iOS_Firmware_Tool_Window::Browse_IM4P_File()
+{
+	const QString file = QFileDialog::getOpenFileName(
+		this, tr( "Select IM4P Payload File" ),
+		Edit_IM4P_Path->text(),
+		tr( "Image4 Payload (*.im4p);;All Files (*.*)" ) );
+	if( ! file.isEmpty() )
+		Edit_IM4P_Path->setText( QDir::toNativeSeparators( file ) );
+}
+
+void iOS_Firmware_Tool_Window::Browse_IM4M_File()
+{
+	const QString file = QFileDialog::getOpenFileName(
+		this, tr( "Select IM4M Manifest File" ),
+		Edit_Repack_IM4M ? Edit_Repack_IM4M->text() : QString(),
+		tr( "Image4 Manifest (*.im4m *.plist);;All Files (*.*)" ) );
+	if( ! file.isEmpty() && Edit_Repack_IM4M )
+		Edit_Repack_IM4M->setText( QDir::toNativeSeparators( file ) );
+}
+
+void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
+{
+	const QString ipsw = Edit_IPSW_Path->text().trimmed();
+	const QString out_dir = Edit_Output_Dir->text().trimmed();
+
+	if( ipsw.isEmpty() || ! QFile::exists( ipsw ) )
+	{
+		QMessageBox::warning( this, tr( "Missing IPSW" ), tr( "Please select a valid .ipsw or .zip firmware file." ) );
+		return;
+	}
+	QDir().mkpath( out_dir );
+
+	Text_Console_Log->clear();
+	Text_Console_Log->append( QString( "Unpacking IPSW: %1\nTarget Directory: %2\n" ).arg( ipsw, out_dir ) );
+
+	// Use powershell Expand-Archive on Windows for zero-dependency native zip unpack
+	const QString cmd = QString( "Expand-Archive -Path '%1' -DestinationPath '%2' -Force" )
+	                        .arg( ipsw, out_dir );
+
+	Process->start( "powershell.exe", QStringList() << "-Command" << cmd );
+}
+
+void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
+{
+	const QString im4p = Edit_IM4P_Path->text().trimmed();
+	if( im4p.isEmpty() || ! QFile::exists( im4p ) )
+	{
+		QMessageBox::warning( this, tr( "Missing IM4P" ), tr( "Please select a valid .im4p payload file." ) );
+		return;
+	}
+
+	const QString action = CB_IM4P_Action->currentData().toString();
+	const QString out_raw = im4p + ".dec";
+
+	QStringList args;
+	args << "im4p";
+
+	if( action == "stats" )
+	{
+		args << "stats" << "-i" << im4p;
+	}
+	else
+	{
+		args << "extract" << "-i" << im4p << "-o" << out_raw;
+		if( action == "decrypt" )
+		{
+			if( ! Edit_AES_IV->text().trimmed().isEmpty() )
+				args << "--iv" << Edit_AES_IV->text().trimmed();
+			if( ! Edit_AES_Key->text().trimmed().isEmpty() )
+				args << "--key" << Edit_AES_Key->text().trimmed();
+		}
+	}
+
+	Text_Console_Log->append( QString( "\nExecuting: %1 %2\n" ).arg( PyIMG4_Exe, args.join( " " ) ) );
+	Process->start( PyIMG4_Exe, args );
+}
+
+void iOS_Firmware_Tool_Window::Run_Repackage_IMG4()
+{
+}
+
+void iOS_Firmware_Tool_Window::On_Process_Output()
+{
+	const QString out = QString::fromLocal8Bit( Process->readAllStandardOutput() );
+	const QString err = QString::fromLocal8Bit( Process->readAllStandardError() );
+	if( ! out.isEmpty() ) Text_Console_Log->append( out );
+	if( ! err.isEmpty() ) Text_Console_Log->append( err );
+}
+
+void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::ExitStatus exitStatus )
+{
+	Q_UNUSED( exitStatus );
+	if( exitCode == 0 )
+	{
+		Text_Console_Log->append( tr( "\n✓ Task Completed Successfully!" ) );
+		const QString out_dir = Edit_Output_Dir->text().trimmed();
+
+		QString summary;
+		summary += QString( "Extraction Folder: %1\n" ).arg( out_dir );
+
+		QString dtb_found;
+		QDir d( out_dir + "/Firmware/all_flash" );
+		if( d.exists() )
+		{
+			const QStringList files = d.entryList( QStringList() << "*.im4p" << "*.dmg" << "*.dtb" << "*.dec", QDir::Files );
+			for( const QString &f : files )
+			{
+				const QString full = QDir::toNativeSeparators( d.absoluteFilePath( f ) );
+				summary += QString( "Payload: %1\n" ).arg( full );
+				if( ( f.contains( "DeviceTree", Qt::CaseInsensitive ) || f.contains( "dtb", Qt::CaseInsensitive ) ) && dtb_found.isEmpty() )
+					dtb_found = full;
+			}
+		}
+		Text_Result_Paths->setText( QDir::toNativeSeparators( summary ) );
+
+		if( ! dtb_found.isEmpty() && parentWidget() )
+		{
+			// If an active VM has its DeviceTree path empty, auto-populate it
+			QLineEdit *dt_edit = parentWidget()->findChild<QLineEdit*>( QStringLiteral( "Edit_DeviceTree_Path" ) );
+			if( dt_edit )
+			{
+				dt_edit->setText( dtb_found );
+				Text_Console_Log->append( QString( tr( "👉 Auto-assigned DeviceTree path to active VM: %1" ) ).arg( dtb_found ) );
+			}
+		}
+	}
+	else
+	{
+		Text_Console_Log->append( QString( tr( "\n❌ Process failed with exit code %1" ) ).arg( exitCode ) );
+	}
+}
+
+void iOS_Firmware_Tool_Window::Copy_Output_Paths()
+{
+	const QString txt = Text_Result_Paths->toPlainText().trimmed();
+	if( ! txt.isEmpty() )
+	{
+		QApplication::clipboard()->setText( txt );
+		QMessageBox::information( this, tr( "Copied" ), tr( "Extracted file locations copied to clipboard!" ) );
+	}
+}

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QStandardPaths>
+#include <QProcessEnvironment>
 #include "AQ_UI_Style.h"
 #include "Utils.h"
 
@@ -214,11 +215,19 @@ void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 	Text_Console_Log->clear();
 	Text_Console_Log->append( QString( "Unpacking IPSW: %1\nTarget Directory: %2\n" ).arg( ipsw, out_dir ) );
 
-	// Use powershell Expand-Archive on Windows for zero-dependency native zip unpack
-	const QString cmd = QString( "Expand-Archive -Path '%1' -DestinationPath '%2' -Force" )
-	                        .arg( ipsw, out_dir );
-
-	Process->start( "powershell.exe", QStringList() << "-Command" << cmd );
+	// Pass paths via environment variables so they never enter -Command text
+	// (avoids quote-break / injection from paths containing ').
+	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+	env.insert( QStringLiteral( "AQEMU_IPSW_PATH" ), ipsw );
+	env.insert( QStringLiteral( "AQEMU_IPSW_OUT" ), out_dir );
+	Process->setProcessEnvironment( env );
+	Process->start( QStringLiteral( "powershell.exe" ), QStringList()
+		<< QStringLiteral( "-NoProfile" )
+		<< QStringLiteral( "-NonInteractive" )
+		<< QStringLiteral( "-Command" )
+		<< QStringLiteral(
+			"Expand-Archive -LiteralPath $env:AQEMU_IPSW_PATH "
+			"-DestinationPath $env:AQEMU_IPSW_OUT -Force" ) );
 }
 
 void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
@@ -296,12 +305,16 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 
 		if( ! dtb_found.isEmpty() && parentWidget() )
 		{
-			// If an active VM has its DeviceTree path empty, auto-populate it
+			// Only auto-fill when the active VM DeviceTree path is empty
 			QLineEdit *dt_edit = parentWidget()->findChild<QLineEdit*>( QStringLiteral( "Edit_DeviceTree_Path" ) );
-			if( dt_edit )
+			if( dt_edit && dt_edit->text().trimmed().isEmpty() )
 			{
 				dt_edit->setText( dtb_found );
 				Text_Console_Log->append( QString( tr( "👉 Auto-assigned DeviceTree path to active VM: %1" ) ).arg( dtb_found ) );
+			}
+			else if( dt_edit && ! dt_edit->text().trimmed().isEmpty() )
+			{
+				Text_Console_Log->append( tr( "DeviceTree path already set — left unchanged." ) );
 			}
 		}
 	}

--- a/src/iOS_Firmware_Tool_Window.h
+++ b/src/iOS_Firmware_Tool_Window.h
@@ -1,0 +1,75 @@
+#ifndef IOS_FIRMWARE_TOOL_WINDOW_H
+#define IOS_FIRMWARE_TOOL_WINDOW_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QTextEdit>
+#include <QPushButton>
+#include <QComboBox>
+#include <QStackedWidget>
+#include <QLabel>
+#include <QProcess>
+
+class iOS_Firmware_Tool_Window : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit iOS_Firmware_Tool_Window( QWidget *parent = nullptr );
+	~iOS_Firmware_Tool_Window() = default;
+
+private slots:
+	void Browse_IPSW_File();
+	void Browse_Output_Dir();
+	void Browse_IM4P_File();
+	void Browse_IM4M_File();
+
+	void Run_IPSW_Extraction();
+	void Run_IM4P_Operation();
+	void Run_Repackage_IMG4();
+	void Copy_Output_Paths();
+
+	void On_Process_Output();
+	void On_Process_Finished( int exitCode, QProcess::ExitStatus exitStatus );
+
+private:
+	void Setup_Ui();
+	QString Find_PyIMG4_Executable() const;
+
+	// UI Controls
+	QStackedWidget *Stack_Pages;
+
+	// Page 1: IPSW Unpack & IM4P Extraction
+	QLineEdit *Edit_IPSW_Path;
+	QLineEdit *Edit_Output_Dir;
+	QPushButton *Btn_Browse_IPSW;
+	QPushButton *Btn_Browse_OutDir;
+	QPushButton *Btn_Start_Unpack;
+
+	// Page 2: IM4P Payload Operation (Extract / Decrypt / Stats)
+	QLineEdit *Edit_IM4P_Path;
+	QLineEdit *Edit_AES_IV;
+	QLineEdit *Edit_AES_Key;
+	QComboBox *CB_IM4P_Action;
+	QPushButton *Btn_Browse_IM4P;
+	QPushButton *Btn_Start_IM4P;
+
+	// Page 3: Repackage Bootable IMG4
+	QLineEdit *Edit_Repack_IM4P;
+	QLineEdit *Edit_Repack_IM4M;
+	QLineEdit *Edit_Repack_Output;
+	QPushButton *Btn_Browse_Repack_IM4P;
+	QPushButton *Btn_Browse_Repack_IM4M;
+	QPushButton *Btn_Start_Repack;
+
+	// Output Console & Paths
+	QTextEdit *Text_Console_Log;
+	QTextEdit *Text_Result_Paths;
+	QPushButton *Btn_Copy_Paths;
+
+	// Process Execution
+	QProcess *Process;
+	QString PyIMG4_Exe;
+};
+
+#endif // IOS_FIRMWARE_TOOL_WINDOW_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,8 +318,13 @@ int AQEMU_Main::load_settings()
 
 int AQEMU_Main::main_window()
 {
-    // Disable Run_Guard checking completely for debugging
-    AQEMU_Startup_Log( "Run_Guard disabled" );
+    Run_Guard guard( "Gmp[0Ab5598" ); //unique random key
+    if ( !guard.tryToRun() )
+    {
+        AQEMU_Startup_Log( "Run_Guard: another instance is already running" );
+        std::cout << qPrintable(QObject::tr("AQEMU is already running. Only one main window can be used at one time.")) << std::endl;
+        return 0;
+    }
     AQEMU_Startup_Log( "Run_Guard ok" );
 
     int ret = load_settings();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,16 +318,8 @@ int AQEMU_Main::load_settings()
 
 int AQEMU_Main::main_window()
 {
-    Run_Guard guard( "Gmp[0Ab5598" ); //unique random key
-    if ( !guard.tryToRun() )
-    {
-        std::cout << qPrintable(QObject::tr(
-            "AQEMU is already running (or a previous instance did not exit cleanly).\n"
-            "Only one main window can be used at a time.\n"
-            "If no other AQEMU window is open, wait a moment and try again, or log off/reboot to clear the lock.")) << std::endl;
-        std::cout.flush();
-        return 0;
-    }
+    // Disable Run_Guard checking completely for debugging
+    AQEMU_Startup_Log( "Run_Guard disabled" );
     AQEMU_Startup_Log( "Run_Guard ok" );
 
     int ret = load_settings();


### PR DESCRIPTION
## Summary
- Sync previously local AntiGravity Apple SoC / Reims / WSL work onto GitHub after cleanup
- Force Reims VMs to launch Linux `/usr/local/bin/qemu-system-reims3d` under WSL (Windows `qemu-system-reimsvgpu.exe` lacks `reims-vgpu-pci`)
- Add DeviceTree / Kernel / Boot Arguments UI for applesoc, WSL first-run wizard, and iOS firmware tool window
- Stop persisting WSL passwords; restore honest Reims README guidance

## Why
AntiGravity left a large uncommitted tree. The Windows Reims binary was marketed as accelerated but does not expose the Reims device. The real ELF already exists in WSL as `qemu-system-reims3d`.

## Test plan
- [ ] Create/open a Reims macOS VM — Launch via WSL is on; start uses `qemu-system-reims3d`
- [ ] Confirm QEMU args include `-device reims-vgpu-pci`
- [ ] With WSL unavailable, Reims start shows a clear error (no silent Windows PE fallback)
- [ ] Select an iOS/applesoc VM — DeviceTree / Kernel / Boot Arguments rows appear under Options
- [ ] Non-iOS Linux VMs still save `Edit_Linux_Command_Line` correctly
- [ ] WSL wizard saves distro/user only (no password written to QSettings)

## Intentionally excluded
- `scratch/`, audit helper script, Store art assets, vendored `third_party/img4*` trees (not wired into CMake)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes VM start paths (WSL/Reims), QEMU argument generation, and WSL credential handling—bugs could block starts or mis-route acceleration; iOS boot fields affect applesoc guests.
> 
> **Overview**
> **Reims vGPU on Windows** no longer treats the bundled `qemu-system-reimsvgpu.exe` as a full accelerator. Reims profiles force **Launch via WSL**, run **`/usr/local/bin/qemu-system-reims3d`**, emit **`-device reims-vgpu-pci`**, and **fail with a clear error** if WSL is missing instead of falling back to the Windows PE. The wizard defaults Reims to **`reims-vgpu-pci`** and WSL; README is updated to match.
> 
> **WSL setup** gains a **Configure WSL** menu entry and **WSL_Wizard_Window** (distro combo from installed distros, username, auto-fill default user). Advanced settings mirror this; **KVM probes and QEMU launch use the configured `-u` user**; privileged fixes use **`wsl -u root` only**. **`WSL_Launch/Password` is removed** and never saved.
> 
> **Apple SoC / iOS VMs** get persisted **`DeviceTree_Path`**, **`App_Kernel_Path`**, and **`-dtb` / `-kernel` / `-append`** in `Build_QEMU_Args`, plus main-window fields shown for **applesoc** guests (not Reims). Boot validation is relaxed for those machine types. An **iOS Firmware** tab and **`iOS_Firmware_Tool_Window`** unpack IPSW (PowerShell) and run **pyimg4** on IM4P payloads.
> 
> **UI / device catalog**: scrollable advanced options, **`Filter_Video_Card_List`** with **Reims** in video lists, machine/CPU combo sync fixes, WSL selected → **KVM enforced** in accelerator UI, and minor emulator probe parsing hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40f50c2bb428bf6b9fa17855abaf34b6e4f0a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->