### PR TITLE
fix: clean up AntiGravity Apple/Reims leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ AQEMU integrates **steelbrain's `qemu-reims-vgpu`** so Intel macOS guests can us
 ### Important (Windows hosts)
 - Real Reims acceleration requires the **Linux** binary **`qemu-system-reims3d`** under **WSL** (with KVM + a working Vulkan/GL stack).
 - The Windows `qemu-system-reimsvgpu.exe` helper is **not** a complete Reims build: it does **not** expose `reims-vgpu-pci`. AQEMU therefore **forces Launch via WSL** for Reims VMs and runs `/usr/local/bin/qemu-system-reims3d`.
-- Place or build `qemu-system-reims3d` inside your WSL distro (already installed at `/usr/local/bin/qemu-system-reims3d` on this development machine).
+- Build or install `qemu-system-reims3d` inside your WSL distro (typically `/usr/local/bin/qemu-system-reims3d`).
 
 ### How Reims accelerates macOS graphics
 - **Zero guest kext mods**: macOS already includes **`AppleParavirtGPU.kext`**. The Reims QEMU device presents the MMIO/IRQ shims that driver expects (`-device reims-vgpu-pci`).
@@ -290,25 +290,23 @@ Apple Silicon macOS guests on Snapdragon Windows hosts — not this release’s 
 
 ---
 
-## 🍏 Apple Silicon (iOS & macOS ARM64) Emulation on Windows
+## Apple Silicon (iOS & macOS ARM64) — experimental
 
-AQEMU now bundles **`qemu-system-applesoc.exe`**, a specialized QEMU binary compiled with **ChefKiss Inferno**, **Apple Secure Enclave (SEP) crypto primitives** (`nettle`/`gmp`), **User NAT networking** (`slirp`), and **LZFSE compressed kernel cache decoding** (`liblzfse`).
+AQEMU can drive a **`qemu-system-applesoc`** binary (ChefKiss Inferno builds) when present next to AQEMU or in your QEMU directory. This is **TCG on x86 Windows** — slow, incomplete, and not a shipping Store promise for “run iPhone on PC.”
 
-AQEMU is the **first hypervisor frontend on Windows** to offer a native UI for probing and configuring Apple Silicon SoC targets (`t8030` A13 Bionic & `s8000` Apple A9)!
+Supported machine presets in the UI today: **`t8030`** (A13) and **`s8000`**. Do not expect M1/`t8101` unless your applesoc binary actually lists it in `-machine help`.
 
-### 🚀 How to Run iOS / macOS Apple Silicon in AQEMU
+### How to try it
 
-1. **Select iOS or macOS Apple Silicon in the New VM Wizard**:
-   - Navigate to **New VM Wizard → Apple → `iOS (ARM64)`** or **`macOS Apple Silicon (ARM64)`**.
-   - AQEMU automatically selects **`qemu-system-applesoc`** and sets the machine target to **`t8030` (Apple A13 Bionic - iPhone 11)** with 4 vCPUs, 4GB RAM, and VirtIO networking.
-2. **Extract Kernel Cache & Device Tree (`-kernel` and `-dtb`)**:
-   - Obtain a legitimate iOS IPSW for iPhone 11 or target Apple device.
-   - Extract the `kernelcache` and target hardware `.dtb` device tree blob.
-   - Pass `-kernel /path/to/kernelcache` and `-dtb /path/to/device.dtb` in AQEMU's **VM Configuration → Advanced QEMU Options → Additional Command Line Arguments**.
-3. **Mount APFS Disk Image (`-drive`)**:
-   - Provide an APFS-formatted iOS/macOS system image attached via NVMe (`-device nvme-mmu`).
-4. **Launch & Monitor via Embedded SPICE / Serial Console**:
-   - Hit **Play**! AQEMU launches `qemu-system-applesoc.exe` in headless SPICE/serial mode, giving you direct control over the booted Apple Silicon environment on your x86_64 Windows PC.
+1. **New VM Wizard → Apple → `iOS (ARM64)` or `macOS Apple Silicon (ARM64)`**  
+   AQEMU selects `qemu-system-applesoc` and defaults toward `t8030`, 4 vCPUs, ≥4 GB RAM.
+2. **Kernel + DeviceTree**  
+   Put paths in the VM’s **DeviceTree / Kernel / Boot Arguments** fields (Other page) — not Additional Args.  
+   Use **File → iOS Firmware Tool** to unpack an IPSW; IM4P extract/decrypt needs an external **`pyimg4`** on PATH (AQEMU does not vendor it).
+3. **Start**  
+   Boot validation requires an existing kernelcache and an extracted DeviceTree (`.dtb` / `.dec`, not raw `.im4p`).
+
+AQEMU does **not** ship IPSW files, kernels, DeviceTrees, or Apple OS images.
 
 ---
 

--- a/qemu_probe_full_v3/applesoc.json
+++ b/qemu_probe_full_v3/applesoc.json
@@ -1,5 +1,5 @@
 {
-  "binary": "C:\\Users\\chron\\CURSOR-PROJECTS\\aqemu\\build_win\\qemu-system-applesoc.exe",
+  "binary": "qemu-system-applesoc.exe",
   "architecture": "applesoc",
   "probed_at": "2026-07-31T07:49:22.960945",
   "fallback_machine": "t8030",

--- a/qemu_probe_full_v3/applesoc.md
+++ b/qemu_probe_full_v3/applesoc.md
@@ -1,11 +1,11 @@
 # QEMU Complete Architecture capability map: `applesoc`
 
 - **Architecture Target:** `applesoc`
-- **Binary Executable:** `C:\Users\chron\CURSOR-PROJECTS\aqemu\build_win\qemu-system-applesoc.exe`
+- **Binary Executable:** `qemu-system-applesoc.exe` (local Windows probe path redacted)
 - **Probed At:** 2026-07-31T07:49:22.960945
 - **Fallback Machine Used for Context:** `t8030`
 
-> **INSTRUCTIONS FOR CURSOR AI:** This document contains the verified whitelist of supported flags, boards, CPUs, devices, storage drivers, audio backends, and display renderers for `qemu-system-{arch}`. Use this data as the absolute ground truth to construct and validate VM configuration parameters.
+> **INSTRUCTIONS FOR CURSOR AI:** Prefer live `-machine help` from the applesoc binary you ship. AQEMU UI currently presets `t8030` / `s8000` only.
 
 ## 1. Supported Machines (`-machine help`)
 

--- a/qemu_probe_full_v3/reimsvgpu.json
+++ b/qemu_probe_full_v3/reimsvgpu.json
@@ -1,5 +1,5 @@
 {
-  "binary": "C:\\Users\\chron\\CURSOR-PROJECTS\\aqemu\\build_win\\qemu-system-reimsvgpu.exe",
+  "binary": "qemu-system-reimsvgpu.exe",
   "architecture": "reimsvgpu",
   "probed_at": "2026-07-31T08:33:05.000335",
   "fallback_machine": "none",
@@ -835,5 +835,6 @@
     "display": "Available display backend types:\nnone\ngtk\nsdl\negl-headless\ncurses\nspice-app\ndbus\n\nSome display backends support suboptions, which can be set with\n   -display backend,option=value,option=value...\nFor a short list of the suboptions for each display, see the top-level -help output; more detail is in the documentation.\n",
     "audio": "Available audio drivers:\nnone\ndbus\ndsound\nsdl\nspice\nwav\n",
     "objects": "List of user creatable objects:\n  acpi-generic-initiator\n  acpi-generic-port\n  authz-list\n  authz-list-file\n  authz-simple\n  can-bus\n  colo-compare\n  cryptodev-backend\n  cryptodev-backend-builtin\n  dbus-display\n  dbus-vmstate\n  filter-buffer\n  filter-dump\n  filter-mirror\n  filter-redirector\n  filter-replay\n  filter-rewriter\n  input-barrier\n  iothread\n  main-loop\n  memory-backend-ram\n  monitor-hmp\n  monitor-qmp\n  qtest\n  rng-builtin\n  rng-egd\n  secret\n  throttle-group\n  tls-cipher-suites\n  tls-creds-anon\n  tls-creds-psk\n  tls-creds-x509\n"
-  }
+  },
+  "note": "Windows PE probe only; production uses WSL qemu-system-reims3d"
 }

--- a/qemu_probe_full_v3/reimsvgpu.md
+++ b/qemu_probe_full_v3/reimsvgpu.md
@@ -1,11 +1,14 @@
 # QEMU Complete Architecture capability map: `reimsvgpu`
 
-- **Architecture Target:** `reimsvgpu`
-- **Binary Executable:** `C:\Users\chron\CURSOR-PROJECTS\aqemu\build_win\qemu-system-reimsvgpu.exe`
+- **Architecture Target:** `reimsvgpu` (AQEMU label)
+- **Binary Executable:** `qemu-system-reimsvgpu.exe` (local Windows probe — **incomplete**; no `reims-vgpu-pci`)
+- **Real acceleration path:** Linux `qemu-system-reims3d` under WSL (not this PE)
 - **Probed At:** 2026-07-31T08:33:05.000335
 - **Fallback Machine Used for Context:** `none`
 
-> **INSTRUCTIONS FOR CURSOR AI:** This document contains the verified whitelist of supported flags, boards, CPUs, devices, storage drivers, audio backends, and display renderers for `qemu-system-{arch}`. Use this data as the absolute ground truth to construct and validate VM configuration parameters.
+> **NOTE:** Treat this Windows PE probe as non-authoritative for Reims graphics. Production launches must use WSL `qemu-system-reims3d`.
+
+> **INSTRUCTIONS FOR CURSOR AI:** This document contains a probe snapshot. Prefer live `-device help` / `-machine help` from the binary you ship; do not assume `reims-vgpu-pci` exists on the Windows helper.
 
 ## 1. Supported Machines (`-machine help`)
 

--- a/resources/wizard_trees.json
+++ b/resources/wizard_trees.json
@@ -688,7 +688,7 @@
       "hdd_gb": 32.0,
       "nic": "virtio-net-pci",
       "sound": "none",
-      "tip": "Defaulting to Apple A13 Bionic (t8030 - iPhone 11). Emulation of Apple Silicon iOS runs via ChefKiss Inferno."
+      "tip": "Experimental: qemu-system-applesoc (Inferno) machine t8030. Supply kernelcache + DeviceTree via the VM DeviceTree fields. TCG on x86 hosts."
     },
     "macOS Apple Silicon (ARM64)": {
       "target": "applesoc",
@@ -697,7 +697,7 @@
       "hdd_gb": 64.0,
       "nic": "virtio-net-pci",
       "sound": "none",
-      "tip": "Defaulting to Apple A13 Bionic (t8030) machine architecture via ChefKiss Inferno emulator."
+      "tip": "Experimental Apple Silicon path via qemu-system-applesoc (t8030). Not Intel OpenCore. Kernel/DeviceTree required."
     },
     "macOS x86_64 vGPU (Reims)": {
       "target": "reimsvgpu",
@@ -706,16 +706,7 @@
       "hdd_gb": 64.0,
       "nic": "virtio-net-pci",
       "sound": "hda",
-      "tip": "Virtual GPU accelerated Intel macOS via steelbrain Reims vGPU engine (qemu-system-reimsvgpu)."
-    },
-    "Windows 11 vGPU (Reims)": {
-      "target": "reimsvgpu",
-      "machine": "q35",
-      "ram_mb": 8192,
-      "hdd_gb": 64.0,
-      "nic": "virtio-net-pci",
-      "sound": "hda",
-      "tip": "Virtual GPU accelerated Windows 11 using Reims vGPU QEMU target (qemu-system-reimsvgpu)."
+      "tip": "Intel macOS + Reims: forces WSL launch of Linux qemu-system-reims3d with -device reims-vgpu-pci. Windows qemu-system-reimsvgpu.exe is incomplete."
     },
     "Pegasos II": {
       "target": "ppc",

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -651,13 +651,21 @@ void Advanced_Settings_Window::done(int r)
 #ifdef Q_OS_WIN32
 	    if( CH_WSL_Launch_Enabled )
 	    {
+		    const QString wsl_user = Edit_WSL_User ? Edit_WSL_User->text().trimmed() : QString();
+		    if( ! wsl_user.isEmpty() && ! WSL_Is_Valid_Username( wsl_user ) )
+		    {
+			    AQGraphic_Warning( tr( "WSL" ),
+				    tr( "WSL username may only contain letters, digits, underscore, and hyphen." ) );
+			    return;
+		    }
 		    Settings.setValue( "WSL_Launch/Enabled", CH_WSL_Launch_Enabled->isChecked() );
 		    Settings.setValue( "WSL_Launch/Distro", CB_WSL_Distro ? CB_WSL_Distro->currentText().trimmed() : QString() );
-		    Settings.setValue( "WSL_Launch/Username", Edit_WSL_User ? Edit_WSL_User->text().trimmed() : QString() );
+		    Settings.setValue( "WSL_Launch/Username", WSL_Sanitize_Username( wsl_user ) );
 		    // Never persist WSL sudo passwords to disk.
 		    Settings.remove( "WSL_Launch/Password" );
 		    Settings.setValue( "WSL_Launch/Qemu_Binary",
 			    Edit_WSL_Qemu_Binary ? Edit_WSL_Qemu_Binary->text().trimmed() : QStringLiteral( "qemu-system-x86_64" ) );
+		    WSL_Clear_Probe_Cache();
 	    }
 #endif
 	    // Execute Before Start QEMU

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -184,16 +184,24 @@ Main_Window::Main_Window( QWidget *parent )
 		} );
 		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actRemote );
 	}
-	// File → Configure WSL (Distro selection, username, password)
+	// File → Configure WSL (distro + username)
 	{
 		QAction *actWsl = new QAction( QIcon( ":/configure.png" ),
 			tr( "Configure &WSL…" ), this );
-		actWsl->setStatusTip( tr( "Set WSL default distribution, username, and password credentials" ) );
+		actWsl->setStatusTip( tr( "Set WSL default distribution and username for KVM launches" ) );
 		connect( actWsl, &QAction::triggered, this, [this]() {
 			WSL_Wizard_Window wizard( this );
 			wizard.exec();
 		} );
 		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actWsl );
+	}
+	// File → iOS Firmware Tool
+	{
+		QAction *actIosFw = new QAction( QIcon( QStringLiteral( ":/default_mac.png" ) ),
+			tr( "iOS &Firmware Tool…" ), this );
+		actIosFw->setStatusTip( tr( "Unpack IPSW archives and process IM4P payloads with pyimg4" ) );
+		connect( actIosFw, &QAction::triggered, this, &Main_Window::slot_iOS_Firmware_Tool_triggered );
+		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actIosFw );
 	}
 	if( ui.actionCopy )
 		ui.actionCopy->setText( tr( "Clone &VM…" ) );
@@ -357,20 +365,6 @@ Main_Window::Main_Window( QWidget *parent )
 
 	ui.TabWidget_Media->insertTab( 0, Dev_Manager, QIcon(":/hdd.png"), tr("Device Manager") );
     ui.TabWidget_Media->setCurrentWidget(Dev_Manager);
-
-	// Add explicit iOS Firmware tab into TabWidget_Media BEFORE Settings_Widget converts it
-	QWidget *tab_ios_fw = new QWidget();
-	QVBoxLayout *lay_fw = new QVBoxLayout( tab_ios_fw );
-	lay_fw->setContentsMargins( 20, 20, 20, 20 );
-	QLabel *lbl_fw = new QLabel( tr( "<h3>Apple iOS Firmware Unpacker & pyimg4 Tool</h3><p>Extract and decrypt IPSW archives, DeviceTree, kernelcache, and SEP payloads natively on Windows.</p>" ), tab_ios_fw );
-	lbl_fw->setWordWrap( true );
-	QPushButton *btn_open_fw = new QPushButton( QIcon( QStringLiteral( ":/default_mac.png" ) ), tr( "Launch iOS Firmware Unpacker Tool" ), tab_ios_fw );
-	btn_open_fw->setFixedHeight( 36 );
-	connect( btn_open_fw, &QPushButton::clicked, this, &Main_Window::slot_iOS_Firmware_Tool_triggered );
-	lay_fw->addWidget( lbl_fw );
-	lay_fw->addWidget( btn_open_fw );
-	lay_fw->addStretch();
-	ui.TabWidget_Media->addTab( tab_ios_fw, QIcon( QStringLiteral( ":/default_mac.png" ) ), tr( "iOS Firmware" ) );
 
     Media_Settings_Widget = new Settings_Widget( ui.TabWidget_Media, QBoxLayout::LeftToRight, true );
     Media_Settings_Widget->setIconSize( AQ_Nav_Icon_Size( this ) );
@@ -1956,8 +1950,9 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Use_USB_Hub( old_vm->Use_USB_Hub() );
 	tmp_vm->Set_Win11_Lifecycle_Mode( old_vm->Get_Win11_Lifecycle_Mode() );
 	// Honor the checkbox — do not OR with old_vm (that made Intel Mac / WSL sticky forever).
-	const bool is_reims_vm = old_vm && ( old_vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
-	                                      old_vm->Get_Machine_Name().contains( QLatin1String( "Reims" ), Qt::CaseInsensitive ) );
+	// Reims computer type still implies Intel macOS OpenCore profile (not display-name heuristics).
+	const bool is_reims_vm = old_vm &&
+		old_vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
 	tmp_vm->Use_Intel_MacOS_Profile( ui_ao.CH_Intel_MacOS_Profile->isChecked() || is_reims_vm );
 	{
 		// Prefer main VM-page Intel macOS fields when that section is shown; else Advanced Options;
@@ -2783,10 +2778,17 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	ui_ao.Edit_UEFI_CODE_File->setText( tmp_vm->Get_UEFI_CODE_File() );
 	ui_ao.Edit_UEFI_VARS_File->setText( tmp_vm->Get_UEFI_VARS_File() );
 	ui_ao.CH_Launch_Via_WSL->setChecked( tmp_vm->Use_Launch_Via_WSL() );
-	ui_ao.GB_Intel_MacOS->setVisible( tmp_vm->Use_Intel_MacOS_Profile() ||
-		tmp_vm->Get_Machine_Name().contains( "macOS", Qt::CaseInsensitive ) ||
-		tmp_vm->Get_Machine_Name().contains( "Mac OS X", Qt::CaseInsensitive ) ||
-		tmp_vm->Get_Machine_Name().contains( "Darwin", Qt::CaseInsensitive ) );
+	{
+		const bool is_apple_soc =
+			tmp_vm->Get_Computer_Type().contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+			tmp_vm->Get_Machine_Name().contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
+			tmp_vm->Get_Machine_Name().contains( QLatin1String( "iOS" ), Qt::CaseInsensitive );
+		ui_ao.GB_Intel_MacOS->setVisible( ! is_apple_soc && (
+			tmp_vm->Use_Intel_MacOS_Profile() ||
+			tmp_vm->Get_Machine_Name().contains( "macOS", Qt::CaseInsensitive ) ||
+			tmp_vm->Get_Machine_Name().contains( "Mac OS X", Qt::CaseInsensitive ) ||
+			tmp_vm->Get_Machine_Name().contains( "Darwin", Qt::CaseInsensitive ) ) );
+	}
 
 	ui.Edit_Intel_Mac_OpenCore_Main->setText( tmp_vm->Get_OpenCore_Boot_Path() );
 	ui.Edit_Intel_Mac_Recovery_Main->setText( tmp_vm->Get_Mac_Recovery_Image_Path() );
@@ -4382,11 +4384,38 @@ bool Main_Window::Boot_Is_Correct( Virtual_Machine *tmp_vm )
 		return false;
 	}
 
-	// Always allow applesoc / iOS VM boot configs to pass validation checks
+	// Apple SoC / iOS: require a kernel and DeviceTree (do not skip all boot checks).
 	if( tmp_vm->Get_Computer_Type().contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
 	    tmp_vm->Get_Machine_Type().contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
 	    tmp_vm->Get_Machine_Type().contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) )
 	{
+		const QString kernel = ! tmp_vm->Get_App_Kernel_Path().trimmed().isEmpty()
+			? tmp_vm->Get_App_Kernel_Path().trimmed()
+			: ( tmp_vm->Get_Use_Linux_Boot() ? tmp_vm->Get_bzImage_Path().trimmed() : QString() );
+		const QString dtb = tmp_vm->Get_DeviceTree_Path().trimmed();
+
+		if( kernel.isEmpty() || ! QFile::exists( kernel ) )
+		{
+			AQGraphic_Warning( tr( "Error!" ),
+				tr( "Apple SoC / iOS VMs need a valid kernelcache path "
+				    "(DeviceTree / Kernel section)." ) );
+			return false;
+		}
+		if( dtb.isEmpty() || ! QFile::exists( dtb ) )
+		{
+			AQGraphic_Warning( tr( "Error!" ),
+				tr( "Apple SoC / iOS VMs need a valid DeviceTree path "
+				    "(.dtb or extracted payload)." ) );
+			return false;
+		}
+		if( dtb.endsWith( QLatin1String( ".im4p" ), Qt::CaseInsensitive ) )
+		{
+			AQGraphic_Warning( tr( "Error!" ),
+				tr( "DeviceTree is still an .im4p payload. Extract/decrypt it to a "
+				    "raw .dtb (or .dec) with the iOS Firmware Tool before starting." ) );
+			return false;
+		}
+		// Disk image is optional at first boot (kernel+dtb only), but warn if missing.
 		return true;
 	}
 
@@ -6135,6 +6164,16 @@ void Main_Window::sync_arch_CPU_Type_changed( int index )
 void Main_Window::slot_iOS_Firmware_Tool_triggered()
 {
 	iOS_Firmware_Tool_Window dlg( this );
+	connect( &dlg, &iOS_Firmware_Tool_Window::DeviceTree_Path_Suggested,
+	         this, [this]( const QString &path ) {
+		if( path.isEmpty() )
+			return;
+		if( ui.Edit_DeviceTree_Path->text().trimmed().isEmpty() )
+		{
+			ui.Edit_DeviceTree_Path->setText( path );
+			VM_Changed();
+		}
+	} );
 	dlg.exec();
 }
 
@@ -6220,12 +6259,14 @@ void Main_Window::Enforce_Accel_Honesty()
 	}
 
 	bool forced_tcg = false;
+	bool accel_index_changed = false;
 	if( is_wsl )
 	{
 		ui.CB_Machine_Accelerator->setEnabled( false );
 		if( kvm_index >= 0 && ui.CB_Machine_Accelerator->currentIndex() != kvm_index )
 		{
 			ui.CB_Machine_Accelerator->setCurrentIndex( kvm_index );
+			accel_index_changed = true;
 		}
 		ui.CB_Machine_Accelerator->setToolTip(
 			tr( "WSL execution selected: native KVM acceleration is enforced inside the WSL VM." ) );
@@ -6254,8 +6295,8 @@ void Main_Window::Enforce_Accel_Honesty()
 	ui.CB_Machine_Accelerator->blockSignals( false );
 	Update_Accelerator_Options();
 
-	// If we had to override a impossible KVM/XEN pick, mark dirty so Apply saves TCG.
-	if( forced_tcg )
+	// Persist forced accel (WSL→KVM or cross-arch→TCG) so Apply/Cancel don't lose it.
+	if( forced_tcg || accel_index_changed )
 		VM_Changed();
 }
 
@@ -6871,10 +6912,13 @@ void Main_Window::Update_Win11_Lifecycle_Ui()
 void Main_Window::Update_Intel_MacOS_Settings_Ui()
 {
 	Virtual_Machine *vm = Get_Current_VM();
-	const bool is_reims = vm && (
-		vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
-		vm->Get_Machine_Name().contains( QLatin1String( "Reims" ), Qt::CaseInsensitive ) );
-	const bool show = vm && ( vm->Use_Intel_MacOS_Profile() || is_reims );
+	const bool is_apple_soc = vm && (
+		vm->Get_Computer_Type().contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+		vm->Get_Machine_Name().contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
+		vm->Get_Machine_Name().contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) );
+	const bool is_reims = vm &&
+		vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
+	const bool show = vm && ! is_apple_soc && ( vm->Use_Intel_MacOS_Profile() || is_reims );
 
 	ui.label_intel_macos->setVisible( show );
 	ui.GB_Intel_MacOS_Settings->setVisible( show );
@@ -6906,8 +6950,7 @@ void Main_Window::Update_DeviceTree_Visibility()
 	                      m_name.contains( QLatin1String( "iPad" ), Qt::CaseInsensitive ) ||
 	                      c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
 	                      m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
-	                      m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) ||
-	                      m_type.contains( QLatin1String( "t8101" ), Qt::CaseInsensitive ) ) &&
+	                      m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) ) &&
 	                    ! c_type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
 
 	ui.Widget_DeviceTree_Main->setVisible( is_ios );

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -1912,19 +1912,11 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Set_Initrd_Path( ui.Edit_Linux_Initrd_Path->text() );
 	tmp_vm->Set_DeviceTree_Path( ui.Edit_DeviceTree_Path->text() );
 	tmp_vm->Set_App_Kernel_Path( ui.Edit_App_Kernel_Path->text() );
-	// iOS/applesoc uses Edit_App_Kernel_Args; classic Linux boot uses Edit_Linux_Command_Line.
-	// Key off computer type / iOS paths — not widget visibility (can be false for non-VM reasons).
-	{
-		const QString computer = tmp_vm->Get_Computer_Type();
-		const bool use_app_kernel_args =
-			computer.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
-			! ui.Edit_DeviceTree_Path->text().trimmed().isEmpty() ||
-			! ui.Edit_App_Kernel_Path->text().trimmed().isEmpty();
-		if( use_app_kernel_args )
-			tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
-		else
-			tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
-	}
+	// Must match Update_DeviceTree_Visibility / Uses_Apple_SoC_Boot_UI — not path emptiness.
+	if( Uses_Apple_SoC_Boot_UI( tmp_vm ) )
+		tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
+	else
+		tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
 
 	// Optional Images
 	// ROM File
@@ -6941,19 +6933,26 @@ void Main_Window::Update_DeviceTree_Visibility()
 		return;
 	}
 
+	ui.Widget_DeviceTree_Main->setVisible( Uses_Apple_SoC_Boot_UI( vm ) );
+}
+
+bool Main_Window::Uses_Apple_SoC_Boot_UI( const Virtual_Machine *vm ) const
+{
+	if( ! vm )
+		return false;
+
 	const QString m_name = vm->Get_Machine_Name();
 	const QString c_type = vm->Get_Computer_Type();
 	const QString m_type = vm->Get_Machine_Type();
 
-	const bool is_ios = ( m_name.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) ||
-	                      m_name.contains( QLatin1String( "iPhone" ), Qt::CaseInsensitive ) ||
-	                      m_name.contains( QLatin1String( "iPad" ), Qt::CaseInsensitive ) ||
-	                      c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
-	                      m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
-	                      m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) ) &&
-	                    ! c_type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
-
-	ui.Widget_DeviceTree_Main->setVisible( is_ios );
+	return ( m_name.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) ||
+	         m_name.contains( QLatin1String( "iPhone" ), Qt::CaseInsensitive ) ||
+	         m_name.contains( QLatin1String( "iPad" ), Qt::CaseInsensitive ) ||
+	         m_name.contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
+	         c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+	         m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
+	         m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) ) &&
+	       ! c_type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
 }
 
 void Main_Window::Update_Intel_Mac_GPU_Passthrough_Ui()

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -171,6 +171,7 @@ class Main_Window: public QMainWindow
 		void Update_Win11_Lifecycle_Ui();
 		void Update_Intel_MacOS_Settings_Ui();
 		void Update_DeviceTree_Visibility();
+		bool Uses_Apple_SoC_Boot_UI( const Virtual_Machine *vm ) const;
 		void Update_Intel_Mac_GPU_Passthrough_Ui();
 		void Apply_Intel_Mac_GPU_Passthrough_Ui_From_Cache();
 		void Start_Host_GPU_Scan();

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -668,7 +668,6 @@ bool System_Info::Update_VM_Computers_List()
 	ad.CPU_List += CPU_ARM;
 	ad.Machine_List << Device_Map( QObject::tr("Apple A13 Bionic (t8030)"), "t8030" );
 	ad.Machine_List << Device_Map( QObject::tr("Apple S8000 (s8000)"), "s8000" );
-	ad.Machine_List << Device_Map( QObject::tr("Apple M1 (t8101)"), "t8101" );
 	ad.Network_Card_List += Network_Card_ARM;
 	ad.Video_Card_List += QEMU_Video_Cards_v0_10_0;
 	ad.Audio_Card_List = VM::Sound_Cards();
@@ -677,7 +676,7 @@ bool System_Info::Update_VM_Computers_List()
 	System_Info::Emulator_QEMU_2_0[ "qemu-system-applesoc" ] = ad;
 	
 	ad = Available_Devices();
-	ad.System = Device_Map( "x86_64 vGPU Accelerated", "qemu-system-reimsvgpu" );
+	ad.System = Device_Map( "x86_64 Reims (WSL / reims3d)", "qemu-system-reimsvgpu" );
 	ad.CPU_List += CPU_x86_64_v0_10_0;
 	ad.Machine_List += Machine_x86;
 	ad.Network_Card_List += Network_Card_v0_10_0;
@@ -690,7 +689,7 @@ bool System_Info::Update_VM_Computers_List()
 	ad.PSO_No_FB_Boot_Check = true;
 	ad.PSO_Win2K_Hack = true;
 	ad.PSO_RTC_TD_Hack = true;
-	ad.PSO_Kernel_KQEMU = true;
+	ad.PSO_Kernel_KQEMU = false;
 	ad.PSO_No_ACPI = true;
 	System_Info::Emulator_QEMU_2_0[ "qemu-system-reimsvgpu" ] = ad;
 	
@@ -1411,7 +1410,7 @@ bool Is_Video_Card_Allowed( Video_Arch_Family fam, const QString &raw_name )
 			       name == "reims-vgpu-pci" || name == "xenfb" || name == "none";
 		case VAF_VIRT:
 			return name == "virtio-gpu-pci" || name == "virtio-gpu-gl-pci" ||
-			       name == "reims-vgpu-pci" || name == "ramfb" || name == "std" || name == "cirrus" || name == "none";
+			       name == "ramfb" || name == "std" || name == "cirrus" || name == "none";
 		case VAF_SPARC:
 			return name == "cg3" || name == "tcx" || name == "std" || name == "none";
 		case VAF_PPC:
@@ -1461,7 +1460,6 @@ QList<Device_Map> Default_Video_List_For_Family( Video_Arch_Family fam )
 			add( QObject::tr("VirtIO VGA (GL / OpenGL)"), "virtio-vga-gl" );
 			break;
 		case VAF_VIRT:
-			add( QObject::tr("Reims vGPU (3D Acceleration)"), "reims-vgpu-pci" );
 			add( QObject::tr("VirtIO GPU (PCI)"), "virtio-gpu-pci" );
 			add( QObject::tr("VirtIO GPU GL (PCI)"), "virtio-gpu-gl-pci" );
 			add( QObject::tr("ramfb (simple framebuffer)"), "ramfb" );

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -636,7 +636,8 @@ QString AQ_Get_Bundled_QEMU_Dir()
 		const QString marker2 = d + QDir::separator() + QStringLiteral( "qemu-system-i386" ) + suf;
 		const QString marker3 = d + QDir::separator() + QStringLiteral( "qemu-system-aarch64" ) + suf;
 		const QString marker4 = d + QDir::separator() + QStringLiteral( "qemu-system-applesoc" ) + suf;
-		const QString marker5 = d + QDir::separator() + QStringLiteral( "qemu-system-reimsvgpu" ) + suf;
+		// Prefer real Linux Reims ELF as a bundle marker; Windows reimsvgpu.exe alone is incomplete.
+		const QString marker5 = d + QDir::separator() + QStringLiteral( "qemu-system-reims3d" );
 		if( QFile::exists( marker ) || QFile::exists( marker2 ) || QFile::exists( marker3 ) ||
 		    QFile::exists( marker4 ) || QFile::exists( marker5 ) )
 		{
@@ -1946,6 +1947,11 @@ QString AQ_Normalize_CPU_Architecture( const QString &raw )
 	const QString a = raw.trimmed().toLower();
 	if( a.isEmpty() )
 		return QString();
+	// Custom AQEMU targets (normalize before qemu-system- strip / generic match)
+	if( a.contains( QLatin1String( "reimsvgpu" ) ) || a.contains( QLatin1String( "reims3d" ) ) )
+		return QStringLiteral( "x86_64" );
+	if( a.contains( QLatin1String( "applesoc" ) ) )
+		return QStringLiteral( "aarch64" );
 	if( a == QLatin1String( "x86_64" ) || a == QLatin1String( "amd64" ) ||
 	    a == QLatin1String( "x64" ) || a.contains( QLatin1String( "x86_64" ) ) )
 		return QStringLiteral( "x86_64" );

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -10481,7 +10481,34 @@ bool Virtual_Machine::Start_impl()
 
 					QProcess sync_proc;
 					sync_proc.start( QStringLiteral( "wsl.exe" ), sync_args );
-					sync_proc.waitForFinished( 15000 );
+					if( ! sync_proc.waitForFinished( 15000 ) || sync_proc.exitCode() != 0 )
+					{
+						AQWarning( "bool Virtual_Machine::Start()",
+						           QString( "Failed to sync qemu-system-reims3d into WSL (exit %1): %2" )
+						               .arg( sync_proc.exitCode() )
+						               .arg( QString::fromLocal8Bit( sync_proc.readAllStandardError() ) ) );
+					}
+				}
+
+				// Require the Linux Reims binary inside WSL before launch.
+				{
+					QStringList test_args;
+					if( ! distro.trimmed().isEmpty() )
+						test_args << QStringLiteral( "-d" ) << distro.trimmed();
+					test_args << QStringLiteral( "-e" ) << QStringLiteral( "test" )
+					          << QStringLiteral( "-x" ) << linux_qemu;
+					QProcess test_proc;
+					test_proc.start( QStringLiteral( "wsl.exe" ), test_args );
+					if( ! test_proc.waitForFinished( 10000 ) || test_proc.exitCode() != 0 )
+					{
+						AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+							tr( "Linux Reims binary not found or not executable in WSL:\n%1\n\n"
+							    "Build or install qemu-system-reims3d inside your WSL distro "
+							    "(typically /usr/local/bin/qemu-system-reims3d)." )
+								.arg( linux_qemu ), false );
+						Start_Snapshot_Tag = "";
+						return false;
+					}
 				}
 			}
 

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -10457,36 +10457,71 @@ bool Virtual_Machine::Start_impl()
 				    ! host_linux_bin.endsWith( QLatin1String( ".exe" ), Qt::CaseInsensitive ) )
 				{
 					const QString wsl_src = Windows_Path_To_WSL( host_linux_bin );
-					AQDebug( "bool Virtual_Machine::Start()",
-					         QString( "Syncing host Linux Reims3D into WSL: %1 -> /usr/local/bin/qemu-system-reims3d" )
-					             .arg( host_linux_bin ) );
-
-					QStringList sync_args;
-					if( ! distro.trimmed().isEmpty() )
-						sync_args << QStringLiteral( "-d" ) << distro.trimmed();
-					// Prefer root so we avoid storing a sudo password in settings.
-					sync_args << QStringLiteral( "-u" ) << QStringLiteral( "root" );
-					sync_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" ) << QStringLiteral( "-c" );
-					sync_args << QString(
-						"mkdir -p /usr/local/bin && "
-						"cp -f \"%1\" /usr/local/bin/qemu-system-reims3d && "
-						"chmod +x /usr/local/bin/qemu-system-reims3d && "
-						"mkdir -p /usr/share/qemu && "
-						"if [ -d /usr/share/seabios ] && [ ! -f /usr/share/qemu/vgabios-stdvga.bin ]; then "
-						"  ln -sf /usr/share/seabios/vgabios-stdvga.bin /usr/share/qemu/vgabios-stdvga.bin; "
-						"fi && "
-						"if [ -d /usr/share/seabios ] && [ ! -f /usr/share/qemu/kvmvapic.bin ]; then "
-						"  ln -sf /usr/share/seabios/kvmvapic.bin /usr/share/qemu/kvmvapic.bin; "
-						"fi" ).arg( wsl_src );
-
-					QProcess sync_proc;
-					sync_proc.start( QStringLiteral( "wsl.exe" ), sync_args );
-					if( ! sync_proc.waitForFinished( 15000 ) || sync_proc.exitCode() != 0 )
+					// Reject paths that could break shell/argv assumptions (defense in depth).
+					const bool path_ok = wsl_src.startsWith( QLatin1String( "/mnt/" ) ) &&
+						! wsl_src.contains( QLatin1Char( '"' ) ) &&
+						! wsl_src.contains( QLatin1Char( '\'' ) ) &&
+						! wsl_src.contains( QLatin1Char( '`' ) ) &&
+						! wsl_src.contains( QLatin1Char( '$' ) ) &&
+						! wsl_src.contains( QLatin1Char( '\n' ) ) &&
+						! wsl_src.contains( QLatin1Char( '\\' ) );
+					if( ! path_ok )
 					{
 						AQWarning( "bool Virtual_Machine::Start()",
-						           QString( "Failed to sync qemu-system-reims3d into WSL (exit %1): %2" )
-						               .arg( sync_proc.exitCode() )
-						               .arg( QString::fromLocal8Bit( sync_proc.readAllStandardError() ) ) );
+						           QString( "Skipping Reims3D sync — unsafe WSL path: %1" ).arg( wsl_src ) );
+					}
+					else
+					{
+						AQDebug( "bool Virtual_Machine::Start()",
+						         QString( "Syncing host Linux Reims3D into WSL: %1 -> /usr/local/bin/qemu-system-reims3d" )
+						             .arg( host_linux_bin ) );
+
+						auto run_wsl_root = [&]( const QStringList &cmd ) -> bool
+						{
+							QStringList args;
+							if( ! distro.trimmed().isEmpty() )
+								args << QStringLiteral( "-d" ) << distro.trimmed();
+							args << QStringLiteral( "-u" ) << QStringLiteral( "root" )
+							     << QStringLiteral( "-e" );
+							args << cmd;
+							QProcess p;
+							p.start( QStringLiteral( "wsl.exe" ), args );
+							if( ! p.waitForFinished( 15000 ) )
+							{
+								p.kill();
+								p.waitForFinished( 1000 );
+								return false;
+							}
+							return p.exitStatus() == QProcess::NormalExit && p.exitCode() == 0;
+						};
+
+						// Never interpolate the path into sh -c — pass as argv to cp/chmod.
+						const bool copied = run_wsl_root( QStringList()
+							<< QStringLiteral( "cp" ) << QStringLiteral( "-f" )
+							<< wsl_src
+							<< QStringLiteral( "/usr/local/bin/qemu-system-reims3d" ) );
+						const bool chmodded = copied && run_wsl_root( QStringList()
+							<< QStringLiteral( "chmod" ) << QStringLiteral( "+x" )
+							<< QStringLiteral( "/usr/local/bin/qemu-system-reims3d" ) );
+						// Optional firmware symlinks — fixed script, no user-controlled path.
+						if( chmodded )
+						{
+							run_wsl_root( QStringList()
+								<< QStringLiteral( "sh" ) << QStringLiteral( "-c" )
+								<< QStringLiteral(
+									"mkdir -p /usr/local/bin /usr/share/qemu; "
+									"if [ -d /usr/share/seabios ] && [ ! -f /usr/share/qemu/vgabios-stdvga.bin ]; then "
+									"  ln -sf /usr/share/seabios/vgabios-stdvga.bin /usr/share/qemu/vgabios-stdvga.bin; "
+									"fi; "
+									"if [ -d /usr/share/seabios ] && [ ! -f /usr/share/qemu/kvmvapic.bin ]; then "
+									"  ln -sf /usr/share/seabios/kvmvapic.bin /usr/share/qemu/kvmvapic.bin; "
+									"fi" ) );
+						}
+						else
+						{
+							AQWarning( "bool Virtual_Machine::Start()",
+							           QStringLiteral( "Failed to sync qemu-system-reims3d into WSL via argv cp/chmod" ) );
+						}
 					}
 				}
 

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -2083,7 +2083,8 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 			if( New_VM->Get_Memory_Size() < 4096 )
 				New_VM->Set_Memory_Size( 8192 );
 			New_VM->Set_SMP_CPU_Count( 4 );
-			New_VM->Set_Video_Card( QStringLiteral( "virtio-gpu-pci" ) );
+			New_VM->Set_Video_Card( QStringLiteral( "reims-vgpu-pci" ) );
+			New_VM->Use_Launch_Via_WSL( true ); // Windows PE lacks reims-vgpu-pci
 		}
 
 		const bool chromeos_flex = ( os == QLatin1String( "Chrome OS Flex" ) );
@@ -3604,24 +3605,44 @@ void VM_Wizard_Window::Probe_WSL_For_Intel_Mac_Page()
 #endif
 }
 
+bool VM_Wizard_Window::Is_Apple_Silicon_Or_iOS_Template() const
+{
+	if( Selected_Target == QLatin1String( "applesoc" ) )
+		return true;
+	const QString n = Three_Path_Active ? Selected_OS_Name
+		: ( ui.RB_VM_Template->isChecked() ? ui.CB_OS_Type->currentText() : QString() );
+	return n.contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
+	       n.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) ||
+	       n.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive );
+}
+
 bool VM_Wizard_Window::Is_Intel_MacOS_Template() const
 {
+	// Never treat Apple Silicon / iOS as Intel macOS (OpenCore / x86_64 rewrite).
+	if( Is_Apple_Silicon_Or_iOS_Template() )
+		return false;
+
 	if( Three_Path_Active )
 	{
 		return Selected_Target == QLatin1String( "reimsvgpu" ) ||
-		       Selected_OS_Name.contains( "macOS", Qt::CaseInsensitive ) ||
+		       Selected_OS_Name.contains( "macOS x86_64", Qt::CaseInsensitive ) ||
 		       Selected_OS_Name.contains( "Reims", Qt::CaseInsensitive ) ||
 		       Selected_OS_Name.contains( "Mac OS X Intel" ) ||
-		       Selected_OS_Name.contains( "Darwin" );
+		       ( Selected_OS_Name.compare( QLatin1String( "macOS" ), Qt::CaseInsensitive ) == 0 ) ||
+		       ( Selected_OS_Name.compare( QLatin1String( "Darwin" ), Qt::CaseInsensitive ) == 0 );
 	}
 	if( ! ui.RB_VM_Template->isChecked() )
 		return false;
 	if( ui.CB_OS_Type->currentIndex() <= 0 )
 		return false;
 	const QString t = ui.CB_OS_Type->currentText();
+	if( t.contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
+	    t.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) )
+		return false;
 	return t.contains( "MacOS X x86", Qt::CaseInsensitive ) ||
 	       t.contains( "Reims", Qt::CaseInsensitive ) ||
-	       t.contains( "macOS", Qt::CaseInsensitive );
+	       t.contains( "macOS x86_64", Qt::CaseInsensitive ) ||
+	       ( t.compare( QLatin1String( "macOS" ), Qt::CaseInsensitive ) == 0 );
 }
 
 void VM_Wizard_Window::Intel_Mac_New_Disk_Toggled( bool on )
@@ -4922,13 +4943,29 @@ void VM_Wizard_Window::Update_Finish_Page_Guidance()
 			"<code>qemu-system-ppc</code> and re-run the First Start Wizard.</li>"
 			"</ul>" );
 	}
-	else if( Selected_OS_Name.contains( "macOS", Qt::CaseInsensitive ) ||
+	else if( Is_Apple_Silicon_Or_iOS_Template() )
+	{
+		help = tr( "<p><b>Apple Silicon / iOS (experimental)</b></p><ul>"
+			"<li>Uses <code>qemu-system-applesoc</code> (ChefKiss Inferno) with machines such as "
+			"<code>t8030</code> or <code>s8000</code>.</li>"
+			"<li>Supply a kernelcache and DeviceTree via the DeviceTree / Kernel fields on the VM "
+			"(not Additional Args).</li>"
+			"<li>AQEMU does not ship IPSW files, kernels, or DeviceTrees. Use "
+			"<b>File → iOS Firmware Tool</b> if you have <code>pyimg4</code> installed.</li>"
+			"<li>On x86 Windows hosts this is TCG-only and very slow.</li>"
+			"</ul>" );
+	}
+	else if( Selected_OS_Name.contains( "Reims", Qt::CaseInsensitive ) ||
+	         Selected_OS_Name.contains( "macOS x86_64", Qt::CaseInsensitive ) ||
 	         Selected_OS_Name.contains( "Mac OS X Intel" ) ||
-	         Selected_OS_Name.contains( "Darwin" ) )
+	         Selected_OS_Name.compare( QLatin1String( "macOS" ), Qt::CaseInsensitive ) == 0 ||
+	         Selected_OS_Name.compare( QLatin1String( "Darwin" ), Qt::CaseInsensitive ) == 0 )
 	{
 		help = tr( "<p><b>Intel macOS (experimental)</b></p><ul>"
 			"<li>You must supply OpenCore boot disk, OVMF firmware, OSK, and install/system disks.</li>"
 			"<li>AQEMU does not ship Apple OS files or a default OSK.</li>"
+			"<li>Reims vGPU needs Linux <code>qemu-system-reims3d</code> under WSL — the Windows "
+			"<code>qemu-system-reimsvgpu.exe</code> helper does not expose <code>reims-vgpu-pci</code>.</li>"
 			"<li>On Windows, WHPX is used unless you enable Launch via WSL/KVM.</li>"
 			"</ul>" );
 	}
@@ -5130,7 +5167,6 @@ void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )
 	else
 	{
 		New_VM->Set_Video_Card( QStringLiteral( "reims-vgpu-pci" ) ); // Linux Reims / AppleParavirtGPU
-		New_VM->Use_Launch_Via_WSL( true ); // Windows PE lacks reims-vgpu-pci — require WSL ELF
 	}
 	New_VM->Set_Machine_Type( QStringLiteral( "q35" ) );
 	New_VM->Set_CPU_Type( QStringLiteral( "Skylake-Client-v4" ) );

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -120,6 +120,7 @@ class VM_Wizard_Window: public QDialog
 		void Apply_Windows11_ARM_Profile( bool simulate );
 		void Apply_AArch64_Generic_Profile( bool simulate );
 		void Build_Windows11_ARM_Page();
+		bool Is_Apple_Silicon_Or_iOS_Template() const;
 		bool Is_Intel_MacOS_Template() const;
 		void Apply_Intel_MacOS_Profile( bool simulate );
 		void Build_Intel_MacOS_Page();

--- a/src/WSL_Launch.cpp
+++ b/src/WSL_Launch.cpp
@@ -27,6 +27,7 @@ qint64 g_wsl_avail_ms = 0;
 bool g_wsl_kvm_valid = false;
 bool g_wsl_kvm = false;
 QString g_wsl_kvm_distro;
+QString g_wsl_kvm_user;
 qint64 g_wsl_kvm_ms = 0;
 
 const qint64 kSuccessCacheTtlMs = 60 * 1000;
@@ -122,6 +123,17 @@ void WSL_Clear_Probe_Cache()
 	g_wsl_kvm_valid = false;
 	g_wsl_avail_ms = 0;
 	g_wsl_kvm_ms = 0;
+	g_wsl_kvm_user.clear();
+}
+
+QString WSL_Sanitize_Username( const QString &raw )
+{
+	return Sanitize_WSL_Username( raw );
+}
+
+bool WSL_Is_Valid_Username( const QString &raw )
+{
+	return ! Sanitize_WSL_Username( raw ).isEmpty();
 }
 
 QStringList WSL_Get_Installed_Distros()
@@ -188,16 +200,17 @@ bool WSL_Is_Available( bool force_refresh )
 bool WSL_Has_KVM( const QString &distro, bool force_refresh )
 {
 	const QString d = distro.trimmed();
+	const QString wslUser = Configured_WSL_Username();
 	{
 		QMutexLocker lock( &g_wsl_cache_mutex );
 		if( ! force_refresh && g_wsl_kvm_valid && g_wsl_kvm_distro == d &&
+		    g_wsl_kvm_user == wslUser &&
 		    Cache_Fresh( g_wsl_kvm_ms, g_wsl_kvm ) )
 			return g_wsl_kvm;
 	}
 
 	// Probe as the configured launch user so results match Build_WSL_Launch_Args.
 	QStringList args = Distro_Args( d );
-	const QString wslUser = Configured_WSL_Username();
 	if( ! wslUser.isEmpty() )
 		args << QStringLiteral( "-u" ) << wslUser;
 	args << QStringLiteral( "--" ) << QStringLiteral( "test" )
@@ -220,6 +233,7 @@ bool WSL_Has_KVM( const QString &distro, bool force_refresh )
 	g_wsl_kvm = ok;
 	g_wsl_kvm_valid = true;
 	g_wsl_kvm_distro = d;
+	g_wsl_kvm_user = wslUser;
 	g_wsl_kvm_ms = QDateTime::currentMSecsSinceEpoch();
 	return ok;
 }
@@ -562,6 +576,8 @@ void WSL_Clear_Probe_Cache() {}
 bool WSL_Is_Available( bool ) { return false; }
 bool WSL_Has_KVM( const QString &, bool ) { return false; }
 bool WSL_Ensure_KVM_Access( const QString & ) { return false; }
+QString WSL_Sanitize_Username( const QString & ) { return QString(); }
+bool WSL_Is_Valid_Username( const QString & ) { return false; }
 QString Windows_Path_To_WSL( const QString &windows_path ) { return windows_path; }
 QStringList Rewrite_Args_For_WSL( const QStringList &win_args ) { return win_args; }
 QStringList Build_WSL_Launch_Args( const QString &, const QString &, const QStringList &qemu_args )

--- a/src/WSL_Launch.h
+++ b/src/WSL_Launch.h
@@ -20,6 +20,10 @@ bool WSL_Ensure_KVM_Access( const QString &distro = QString() );
 /** Clear cached WSL/KVM probe results (e.g. after Settings Probe). */
 void WSL_Clear_Probe_Cache();
 
+/** Letters, digits, underscore, hyphen only — empty if invalid. */
+QString WSL_Sanitize_Username( const QString &raw );
+bool WSL_Is_Valid_Username( const QString &raw );
+
 /** Retrieve a list of all installed WSL distributions. */
 QStringList WSL_Get_Installed_Distros();
 

--- a/src/WSL_Wizard_Window.cpp
+++ b/src/WSL_Wizard_Window.cpp
@@ -83,10 +83,17 @@ void WSL_Wizard_Window::on_Btn_Ok_clicked()
 		AQGraphic_Warning( tr("Warning"), tr("WSL Username is required!") );
 		return;
 	}
+	if( ! WSL_Is_Valid_Username( Edit_User->text() ) )
+	{
+		AQGraphic_Warning( tr( "Warning" ),
+			tr( "WSL username may only contain letters, digits, underscore, and hyphen." ) );
+		return;
+	}
 	Settings.setValue( "WSL_Launch/Distro", Get_Distro() );
-	Settings.setValue( "WSL_Launch/Username", Get_Username() );
+	Settings.setValue( "WSL_Launch/Username", WSL_Sanitize_Username( Get_Username() ) );
 	// Never persist WSL passwords; privileged ops use wsl -u root.
 	Settings.remove( "WSL_Launch/Password" );
+	WSL_Clear_Probe_Cache();
 	accept();
 }
 

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -19,7 +19,7 @@ iOS_Firmware_Tool_Window::iOS_Firmware_Tool_Window( QWidget *parent )
 	: QDialog( parent )
 	, Process( new QProcess( this ) )
 {
-	setWindowTitle( tr( "iOS Firmware Unpacker & pyimg4 Processor" ) );
+	setWindowTitle( tr( "iOS Firmware Tool" ) );
 	resize( AQ_Px( 780, this ), AQ_Px( 560, this ) );
 	PyIMG4_Exe = Find_PyIMG4_Executable();
 
@@ -37,9 +37,8 @@ QString iOS_Firmware_Tool_Window::Find_PyIMG4_Executable() const
 	const QStringList candidates = {
 		app_dir + "/pyimg4.exe",
 		app_dir + "/tools/pyimg4.exe",
-		"C:/msys64/ucrt64/bin/pyimg4.exe",
-		"C:/msys64/ucrt64/bin/pyimg4",
-		QStandardPaths::findExecutable( "pyimg4" )
+		QStandardPaths::findExecutable( "pyimg4" ),
+		QStandardPaths::findExecutable( "pyimg4.exe" )
 	};
 
 	for( const QString &path : candidates )
@@ -47,33 +46,44 @@ QString iOS_Firmware_Tool_Window::Find_PyIMG4_Executable() const
 		if( ! path.isEmpty() && QFile::exists( path ) )
 			return QDir::toNativeSeparators( path );
 	}
-	return QStringLiteral( "pyimg4" );
+	return QString();
+}
+
+bool iOS_Firmware_Tool_Window::Ensure_PyIMG4_Available()
+{
+	if( PyIMG4_Exe.isEmpty() )
+		PyIMG4_Exe = Find_PyIMG4_Executable();
+	if( PyIMG4_Exe.isEmpty() || ! QFile::exists( PyIMG4_Exe ) )
+	{
+		QMessageBox::warning( this, tr( "pyimg4 not found" ),
+			tr( "pyimg4 was not found next to AQEMU or on PATH.\n\n"
+			    "Install pyimg4 and ensure it is available as `pyimg4` "
+			    "(or place pyimg4.exe beside aqemu.exe)." ) );
+		return false;
+	}
+	return true;
 }
 
 void iOS_Firmware_Tool_Window::Setup_Ui()
 {
 	QVBoxLayout *main_lay = new QVBoxLayout( this );
 
-	// Top Banner / Intro
-	QLabel *title = new QLabel( tr( "<b>Apple iOS Firmware Unpacker & pyimg4 Processor</b>" ) );
-	title->setStyleSheet( QStringLiteral( "font-size: 14px; color: #1a5fb4;" ) );
+	QLabel *title = new QLabel( tr( "<b>iOS Firmware Unpacker</b>" ) );
+	title->setStyleSheet( QStringLiteral( "font-size: 14px;" ) );
 	main_lay->addWidget( title );
 
-	QLabel *subtitle = new QLabel( tr( "Automates IPSW extraction and Image4 payload processing (SEP, iBSS, iBEC) for QEMU Apple SoC emulation." ) );
+	QLabel *subtitle = new QLabel( tr(
+		"Unpack IPSW archives and process Image4 payloads (DeviceTree, kernelcache, SEP) "
+		"for Apple SoC QEMU. Requires an external pyimg4 install for IM4P steps." ) );
 	subtitle->setWordWrap( true );
 	main_lay->addWidget( subtitle );
 
-	Stack_Pages = new QStackedWidget( this );
-
-	// Page 1: IPSW Unpack & Extract
-	QWidget *page1 = new QWidget();
-	QVBoxLayout *p1_lay = new QVBoxLayout( page1 );
 	QGroupBox *gb_ipsw = new QGroupBox( tr( "Step 1: Unpack IPSW Archive" ) );
 	QGridLayout *grid1 = new QGridLayout( gb_ipsw );
 
 	grid1->addWidget( new QLabel( tr( "IPSW File:" ) ), 0, 0 );
 	Edit_IPSW_Path = new QLineEdit();
-	Edit_IPSW_Path->setPlaceholderText( tr( "Select downloaded iOS IPSW file (e.g., iPhone12,1_14.0_Restore.ipsw)..." ) );
+	Edit_IPSW_Path->setPlaceholderText( tr( "Select an iOS IPSW or ZIP…" ) );
 	grid1->addWidget( Edit_IPSW_Path, 0, 1 );
 	Btn_Browse_IPSW = new QPushButton( tr( "Browse..." ) );
 	connect( Btn_Browse_IPSW, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_IPSW_File );
@@ -81,26 +91,24 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 
 	grid1->addWidget( new QLabel( tr( "Extraction Output Directory:" ) ), 1, 0 );
 	Edit_Output_Dir = new QLineEdit();
-	Edit_Output_Dir->setText( QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/firmware_extracted" ) );
+	Edit_Output_Dir->setText( QDir::toNativeSeparators(
+		QCoreApplication::applicationDirPath() + "/firmware_extracted" ) );
 	grid1->addWidget( Edit_Output_Dir, 1, 1 );
 	Btn_Browse_OutDir = new QPushButton( tr( "Browse..." ) );
 	connect( Btn_Browse_OutDir, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_Output_Dir );
 	grid1->addWidget( Btn_Browse_OutDir, 1, 2 );
 
-	Btn_Start_Unpack = new QPushButton( tr( "Unpack IPSW Payload" ) );
-	Btn_Start_Unpack->setStyleSheet( QStringLiteral( "font-weight: bold; background-color: #3584e4; color: white; padding: 6px;" ) );
+	Btn_Start_Unpack = new QPushButton( tr( "Unpack IPSW" ) );
 	connect( Btn_Start_Unpack, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Run_IPSW_Extraction );
 	grid1->addWidget( Btn_Start_Unpack, 2, 1, 1, 2 );
+	main_lay->addWidget( gb_ipsw );
 
-	p1_lay->addWidget( gb_ipsw );
-
-	// Page 2: IM4P Payload Operation
 	QGroupBox *gb_im4p = new QGroupBox( tr( "Step 2: Process IM4P Payload (pyimg4)" ) );
 	QGridLayout *grid2 = new QGridLayout( gb_im4p );
 
 	grid2->addWidget( new QLabel( tr( "IM4P Payload File:" ) ), 0, 0 );
 	Edit_IM4P_Path = new QLineEdit();
-	Edit_IM4P_Path->setPlaceholderText( tr( "Select IM4P file (e.g. sep-firmware.im4p or iBEC.im4p)..." ) );
+	Edit_IM4P_Path->setPlaceholderText( tr( "Select an .im4p file…" ) );
 	grid2->addWidget( Edit_IM4P_Path, 0, 1 );
 	Btn_Browse_IM4P = new QPushButton( tr( "Browse..." ) );
 	connect( Btn_Browse_IM4P, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_IM4P_File );
@@ -108,50 +116,43 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 
 	grid2->addWidget( new QLabel( tr( "Operation:" ) ), 1, 0 );
 	CB_IM4P_Action = new QComboBox();
-	CB_IM4P_Action->addItem( tr( "Extract Raw Payload (pyimg4 im4p extract)" ), "extract_raw" );
-	CB_IM4P_Action->addItem( tr( "Decrypt Payload with Key (pyimg4 im4p extract --key --iv)" ), "decrypt" );
-	CB_IM4P_Action->addItem( tr( "View Payload Stats (pyimg4 im4p stats)" ), "stats" );
+	CB_IM4P_Action->addItem( tr( "Extract raw payload" ), "extract_raw" );
+	CB_IM4P_Action->addItem( tr( "Decrypt payload (--key / --iv)" ), "decrypt" );
+	CB_IM4P_Action->addItem( tr( "Show payload info" ), "info" );
 	grid2->addWidget( CB_IM4P_Action, 1, 1, 1, 2 );
 
-	grid2->addWidget( new QLabel( tr( "AES IV (Hex, optional):" ) ), 2, 0 );
+	grid2->addWidget( new QLabel( tr( "AES IV (hex, optional):" ) ), 2, 0 );
 	Edit_AES_IV = new QLineEdit();
 	grid2->addWidget( Edit_AES_IV, 2, 1, 1, 2 );
 
-	grid2->addWidget( new QLabel( tr( "AES Key (Hex, optional):" ) ), 3, 0 );
+	grid2->addWidget( new QLabel( tr( "AES Key (hex, optional):" ) ), 3, 0 );
 	Edit_AES_Key = new QLineEdit();
 	grid2->addWidget( Edit_AES_Key, 3, 1, 1, 2 );
 
-	Btn_Start_IM4P = new QPushButton( tr( "Execute pyimg4 Action" ) );
+	Btn_Start_IM4P = new QPushButton( tr( "Run pyimg4" ) );
 	connect( Btn_Start_IM4P, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Run_IM4P_Operation );
 	grid2->addWidget( Btn_Start_IM4P, 4, 1, 1, 2 );
+	main_lay->addWidget( gb_im4p );
 
-	p1_lay->addWidget( gb_im4p );
-	Stack_Pages->addWidget( page1 );
-
-	main_lay->addWidget( Stack_Pages, 1 );
-
-	// Output Console Log
-	QGroupBox *gb_log = new QGroupBox( tr( "Execution Output Log" ) );
+	QGroupBox *gb_log = new QGroupBox( tr( "Output log" ) );
 	QVBoxLayout *log_lay = new QVBoxLayout( gb_log );
 	Text_Console_Log = new QTextEdit();
 	Text_Console_Log->setReadOnly( true );
-	Text_Console_Log->setStyleSheet( QStringLiteral( "font-family: Consolas, monospace; font-size: 11px; background-color: #1e1e1e; color: #d4d4d4;" ) );
+	Text_Console_Log->setStyleSheet(
+		QStringLiteral( "font-family: Consolas, monospace; font-size: 11px;" ) );
 	log_lay->addWidget( Text_Console_Log );
 	main_lay->addWidget( gb_log, 1 );
 
-	// Output File Paths summary card
-	QGroupBox *gb_paths = new QGroupBox( tr( "Extracted Output File Locations" ) );
+	QGroupBox *gb_paths = new QGroupBox( tr( "Extracted file locations" ) );
 	QHBoxLayout *paths_lay = new QHBoxLayout( gb_paths );
 	Text_Result_Paths = new QTextEdit();
 	Text_Result_Paths->setReadOnly( true );
 	Text_Result_Paths->setMaximumHeight( AQ_Px( 70, this ) );
 	paths_lay->addWidget( Text_Result_Paths, 1 );
 
-	Btn_Copy_Paths = new QPushButton( tr( "Copy Locations" ) );
-	Btn_Copy_Paths->setIcon( QIcon( QStringLiteral( ":/edit-copy.png" ) ) );
+	Btn_Copy_Paths = new QPushButton( tr( "Copy locations" ) );
 	connect( Btn_Copy_Paths, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Copy_Output_Paths );
 	paths_lay->addWidget( Btn_Copy_Paths );
-
 	main_lay->addWidget( gb_paths );
 
 	QHBoxLayout *btn_lay = new QHBoxLayout();
@@ -190,16 +191,6 @@ void iOS_Firmware_Tool_Window::Browse_IM4P_File()
 		Edit_IM4P_Path->setText( QDir::toNativeSeparators( file ) );
 }
 
-void iOS_Firmware_Tool_Window::Browse_IM4M_File()
-{
-	const QString file = QFileDialog::getOpenFileName(
-		this, tr( "Select IM4M Manifest File" ),
-		Edit_Repack_IM4M ? Edit_Repack_IM4M->text() : QString(),
-		tr( "Image4 Manifest (*.im4m *.plist);;All Files (*.*)" ) );
-	if( ! file.isEmpty() && Edit_Repack_IM4M )
-		Edit_Repack_IM4M->setText( QDir::toNativeSeparators( file ) );
-}
-
 void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 {
 	const QString ipsw = Edit_IPSW_Path->text().trimmed();
@@ -207,7 +198,8 @@ void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 
 	if( ipsw.isEmpty() || ! QFile::exists( ipsw ) )
 	{
-		QMessageBox::warning( this, tr( "Missing IPSW" ), tr( "Please select a valid .ipsw or .zip firmware file." ) );
+		QMessageBox::warning( this, tr( "Missing IPSW" ),
+			tr( "Please select a valid .ipsw or .zip firmware file." ) );
 		return;
 	}
 	QDir().mkpath( out_dir );
@@ -215,8 +207,7 @@ void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 	Text_Console_Log->clear();
 	Text_Console_Log->append( QString( "Unpacking IPSW: %1\nTarget Directory: %2\n" ).arg( ipsw, out_dir ) );
 
-	// Pass paths via environment variables so they never enter -Command text
-	// (avoids quote-break / injection from paths containing ').
+	// Pass paths via environment variables so they never enter -Command text.
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	env.insert( QStringLiteral( "AQEMU_IPSW_PATH" ), ipsw );
 	env.insert( QStringLiteral( "AQEMU_IPSW_OUT" ), out_dir );
@@ -232,10 +223,14 @@ void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 
 void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
 {
+	if( ! Ensure_PyIMG4_Available() )
+		return;
+
 	const QString im4p = Edit_IM4P_Path->text().trimmed();
 	if( im4p.isEmpty() || ! QFile::exists( im4p ) )
 	{
-		QMessageBox::warning( this, tr( "Missing IM4P" ), tr( "Please select a valid .im4p payload file." ) );
+		QMessageBox::warning( this, tr( "Missing IM4P" ),
+			tr( "Please select a valid .im4p payload file." ) );
 		return;
 	}
 
@@ -245,9 +240,9 @@ void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
 	QStringList args;
 	args << "im4p";
 
-	if( action == "stats" )
+	if( action == "info" )
 	{
-		args << "stats" << "-i" << im4p;
+		args << "info" << "-i" << im4p;
 	}
 	else
 	{
@@ -265,10 +260,6 @@ void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
 	Process->start( PyIMG4_Exe, args );
 }
 
-void iOS_Firmware_Tool_Window::Run_Repackage_IMG4()
-{
-}
-
 void iOS_Firmware_Tool_Window::On_Process_Output()
 {
 	const QString out = QString::fromLocal8Bit( Process->readAllStandardOutput() );
@@ -282,7 +273,7 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 	Q_UNUSED( exitStatus );
 	if( exitCode == 0 )
 	{
-		Text_Console_Log->append( tr( "\n✓ Task Completed Successfully!" ) );
+		Text_Console_Log->append( tr( "\nTask completed successfully." ) );
 		const QString out_dir = Edit_Output_Dir->text().trimmed();
 
 		QString summary;
@@ -292,35 +283,34 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 		QDir d( out_dir + "/Firmware/all_flash" );
 		if( d.exists() )
 		{
-			const QStringList files = d.entryList( QStringList() << "*.im4p" << "*.dmg" << "*.dtb" << "*.dec", QDir::Files );
+			// Prefer extracted DeviceTree (.dtb / .dec), never raw .im4p for -dtb.
+			const QStringList files = d.entryList(
+				QStringList() << "*.dtb" << "*.dec" << "*.im4p" << "*.dmg", QDir::Files );
 			for( const QString &f : files )
 			{
 				const QString full = QDir::toNativeSeparators( d.absoluteFilePath( f ) );
 				summary += QString( "Payload: %1\n" ).arg( full );
-				if( ( f.contains( "DeviceTree", Qt::CaseInsensitive ) || f.contains( "dtb", Qt::CaseInsensitive ) ) && dtb_found.isEmpty() )
+				const bool is_dt = f.contains( "DeviceTree", Qt::CaseInsensitive ) ||
+				                   f.contains( "dtb", Qt::CaseInsensitive );
+				const bool usable = f.endsWith( QLatin1String( ".dtb" ), Qt::CaseInsensitive ) ||
+				                    f.endsWith( QLatin1String( ".dec" ), Qt::CaseInsensitive );
+				if( is_dt && usable && dtb_found.isEmpty() )
 					dtb_found = full;
 			}
 		}
 		Text_Result_Paths->setText( QDir::toNativeSeparators( summary ) );
 
-		if( ! dtb_found.isEmpty() && parentWidget() )
+		if( ! dtb_found.isEmpty() )
 		{
-			// Only auto-fill when the active VM DeviceTree path is empty
-			QLineEdit *dt_edit = parentWidget()->findChild<QLineEdit*>( QStringLiteral( "Edit_DeviceTree_Path" ) );
-			if( dt_edit && dt_edit->text().trimmed().isEmpty() )
-			{
-				dt_edit->setText( dtb_found );
-				Text_Console_Log->append( QString( tr( "👉 Auto-assigned DeviceTree path to active VM: %1" ) ).arg( dtb_found ) );
-			}
-			else if( dt_edit && ! dt_edit->text().trimmed().isEmpty() )
-			{
-				Text_Console_Log->append( tr( "DeviceTree path already set — left unchanged." ) );
-			}
+			Text_Console_Log->append(
+				tr( "Suggested DeviceTree (extracted): %1" ).arg( dtb_found ) );
+			emit DeviceTree_Path_Suggested( dtb_found );
 		}
 	}
 	else
 	{
-		Text_Console_Log->append( QString( tr( "\n❌ Process failed with exit code %1" ) ).arg( exitCode ) );
+		Text_Console_Log->append(
+			tr( "\nProcess failed with exit code %1" ).arg( exitCode ) );
 	}
 }
 
@@ -330,6 +320,7 @@ void iOS_Firmware_Tool_Window::Copy_Output_Paths()
 	if( ! txt.isEmpty() )
 	{
 		QApplication::clipboard()->setText( txt );
-		QMessageBox::information( this, tr( "Copied" ), tr( "Extracted file locations copied to clipboard!" ) );
+		QMessageBox::information( this, tr( "Copied" ),
+			tr( "Extracted file locations copied to clipboard." ) );
 	}
 }

--- a/src/iOS_Firmware_Tool_Window.h
+++ b/src/iOS_Firmware_Tool_Window.h
@@ -6,7 +6,6 @@
 #include <QTextEdit>
 #include <QPushButton>
 #include <QComboBox>
-#include <QStackedWidget>
 #include <QLabel>
 #include <QProcess>
 
@@ -18,15 +17,17 @@ public:
 	explicit iOS_Firmware_Tool_Window( QWidget *parent = nullptr );
 	~iOS_Firmware_Tool_Window() = default;
 
+signals:
+	/** Emitted when an extracted DeviceTree (.dtb / .dec) is found and may be applied. */
+	void DeviceTree_Path_Suggested( const QString &path );
+
 private slots:
 	void Browse_IPSW_File();
 	void Browse_Output_Dir();
 	void Browse_IM4P_File();
-	void Browse_IM4M_File();
 
 	void Run_IPSW_Extraction();
 	void Run_IM4P_Operation();
-	void Run_Repackage_IMG4();
 	void Copy_Output_Paths();
 
 	void On_Process_Output();
@@ -35,18 +36,14 @@ private slots:
 private:
 	void Setup_Ui();
 	QString Find_PyIMG4_Executable() const;
+	bool Ensure_PyIMG4_Available();
 
-	// UI Controls
-	QStackedWidget *Stack_Pages;
-
-	// Page 1: IPSW Unpack & IM4P Extraction
 	QLineEdit *Edit_IPSW_Path;
 	QLineEdit *Edit_Output_Dir;
 	QPushButton *Btn_Browse_IPSW;
 	QPushButton *Btn_Browse_OutDir;
 	QPushButton *Btn_Start_Unpack;
 
-	// Page 2: IM4P Payload Operation (Extract / Decrypt / Stats)
 	QLineEdit *Edit_IM4P_Path;
 	QLineEdit *Edit_AES_IV;
 	QLineEdit *Edit_AES_Key;
@@ -54,20 +51,10 @@ private:
 	QPushButton *Btn_Browse_IM4P;
 	QPushButton *Btn_Start_IM4P;
 
-	// Page 3: Repackage Bootable IMG4
-	QLineEdit *Edit_Repack_IM4P;
-	QLineEdit *Edit_Repack_IM4M;
-	QLineEdit *Edit_Repack_Output;
-	QPushButton *Btn_Browse_Repack_IM4P;
-	QPushButton *Btn_Browse_Repack_IM4M;
-	QPushButton *Btn_Start_Repack;
-
-	// Output Console & Paths
 	QTextEdit *Text_Console_Log;
 	QTextEdit *Text_Result_Paths;
 	QPushButton *Btn_Copy_Paths;
 
-	// Process Execution
 	QProcess *Process;
 	QString PyIMG4_Exe;
 };

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -39,3 +39,7 @@ Then configure AQEMU:
 That copies every `qemu-system-*`, `qemu-img*`, runtime DLLs (`libslirp`, `libusb`, …), and the `share/` firmware directory next to `aqemu.exe` (required for MSIX).
 
 Install dirs `qemu-build*` / `qemu-install` are gitignored.
+
+## Optional: pyimg4 (iOS firmware tool)
+
+AQEMU’s **File → iOS Firmware Tool** unpacks IPSWs with PowerShell and optionally shells out to an external **`pyimg4`** for IM4P extract/info/decrypt. AQEMU does **not** vendor `img4tool` / `pyimg4` under `third_party/` — install `pyimg4` yourself and keep it on `PATH` (or place `pyimg4.exe` next to `aqemu.exe`).


### PR DESCRIPTION
## Summary
- Fix wizard bug that rewrote Apple Silicon / iOS VMs to `qemu-system-x86_64` OpenCore profile; normalize `reimsvgpu`→x86_64 and `applesoc`→aarch64 for accelerator preference.
- Require kernel + extracted DeviceTree for applesoc starts; verify WSL `qemu-system-reims3d` exists; early Reims path now sets `reims-vgpu-pci` + WSL.
- Honest README/catalog tips; remove Win11 Reims profile; iOS firmware tool via File menu (no Media-tab spam); drop empty repack stub / findChild / msys hardcodes / emoji; Restrict Reims video to x86; redact probe machine paths.

## Test plan
- [ ] Wizard: create `macOS Apple Silicon` VM → computer type stays `qemu-system-applesoc` (not x86_64)
- [ ] Wizard: create `macOS x86_64 vGPU (Reims)` → video `reims-vgpu-pci`, Launch via WSL on
- [ ] Start applesoc without kernel/DTB → clear warning; `.im4p` DTB rejected
- [ ] File → iOS Firmware Tool opens; no always-on Media tab
- [ ] Reims start without `/usr/local/bin/qemu-system-reims3d` in WSL → clear error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM start, wizard template selection, and WSL/Reims launch paths where misclassification could block boots or pick the wrong QEMU binary; changes are mostly guardrails and docs rather than core QEMU arg building.
> 
> **Overview**
> Cleans up **Apple Silicon / iOS** vs **Intel macOS / Reims** so they no longer share the wrong wizard profile or UI.
> 
> **Wizard & VM config:** Apple Silicon/iOS templates stay on `qemu-system-applesoc` (no OpenCore/x86_64 rewrite). Intel/Reims detection drops loose “Reims” name heuristics in favor of `reimsvgpu` computer type. Reims presets default to **`reims-vgpu-pci`** and **Launch via WSL**; **Windows 11 Reims** is removed from `wizard_trees.json`. Apple SoC boot args/kernel lines use **`Uses_Apple_SoC_Boot_UI`**; Intel macOS panels hide for Apple SoC/iOS VMs.
> 
> **Start validation & Reims launch:** `applesoc` starts require existing **kernelcache** and **DeviceTree** (reject raw **`.im4p`**). Reims WSL path **syncs `qemu-system-reims3d` via argv `cp`/`chmod`** (not `sh -c` with interpolated paths), then **fails early** if the binary is missing in WSL; still injects **`reims-vgpu-pci`** when needed.
> 
> **Catalog & video:** Drops **M1/t8101** from built-in applesoc machines; Reims video is **x86-only** (no `reims-vgpu-pci` on virt ARM). **`AQ_Normalize_CPU_Architecture`** maps `reimsvgpu`→x86_64 and `applesoc`→aarch64`; bundled QEMU detection prefers **`qemu-system-reims3d`**.
> 
> **iOS firmware:** Tool moves to **File → iOS Firmware Tool** (Media tab removed); requires **`pyimg4` on PATH**; suggests DeviceTree via signal instead of `findChild`.
> 
> **WSL settings:** Username **sanitize/validate**; **probe cache** clears on save and includes configured user; Advanced Settings/WSL wizard aligned.
> 
> **Docs/probes:** README and probe JSON/MD redact dev paths and state experimental Apple/Reims limits; `third_party/README` notes optional pyimg4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce6510eb7b3def56612af229e48a3ec7bec6505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->