### PR TITLE
AQEMU 1.3.0: Apple SoC Inferno + Reims WSL (AMD/NVIDIA)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+2026-08-08 Chronic Engineering — AQEMU 1.3.0 (Apple SoC Inferno + Reims WSL)
+
+	* Version bump to 1.3.0 across code, MSI/MSIX, WiX, and packaging docs.
+	* Apple SoC / iOS (ChefKiss Inferno):
+	  - Inferno launch profile: trustcache, ticket, SEP FW/ROM, usb-conn, kaslr-off,
+	    multi-ns NVMe + apple-nvram + SEP pflash image set under the VM folder.
+	  - On Windows, applesoc is forced through WSL Linux qemu-system-applesoc
+	    (UNIX sockets / companion restore; not Windows PE alone).
+	  - File → Apple SoC Restore: companion command helper + idevicerestore in WSL.
+	  - Wizard + main UI fields for Inferno firmware paths and USB remote type.
+	* Hardware-accelerated Intel macOS (Reims):
+	  - Always uses Linux qemu-system-reims3d under WSL with reims-vgpu-pci.
+	  - Documents AMD and NVIDIA host GPUs via WSLg Vulkan (not Windows PE Reims).
+	* WSL: prompt for distro/username on boot when missing; passwords are not stored
+	  (KVM access uses wsl -u root). Machine -machine path props rewritten for WSL.
+
 2026-07-31 Chronic Engineering — AQEMU 1.0.2 (Reims vGPU Acceleration Target)
 
 	* Virtual GPU Acceleration Target (qemu-system-reimsvgpu.exe):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,8 @@ SET( aqemu_headers
 	src/VNC_Password_Window.h
 	src/WSL_Wizard_Window.h
 	src/iOS_Firmware_Tool_Window.h
+	src/Apple_SoC_Support.h
+	src/Apple_SoC_Restore_Window.h
 	src/QMP_Client.h
 	src/QEMU_Help_Browser.h
 	src/Blockdev_Graph_Window.h
@@ -162,6 +164,8 @@ SET( aqemu_sources
 	src/Guest_Capabilities.cpp
 	src/ISO_Guess.cpp
 	src/iOS_Firmware_Tool_Window.cpp
+	src/Apple_SoC_Support.cpp
+	src/Apple_SoC_Restore_Window.cpp
 	src/Storage_Browser_Window.cpp
 	src/Serial_Console_Window.cpp
 	src/URL_Fetch.cpp
@@ -600,7 +604,7 @@ ENDIF( INSTALL_MAN )
 # CPack Packaging Configuration
 SET( CPACK_GENERATOR "DEB" )
 SET( CPACK_PACKAGE_NAME "aqemu" )
-SET( CPACK_PACKAGE_VERSION "1.1.0" )
+SET( CPACK_PACKAGE_VERSION "1.3.0" )
 SET( CPACK_PACKAGE_CONTACT "chronic8000" )
 SET( CPACK_PACKAGE_DESCRIPTION_SUMMARY "AQEMU is a graphical user interface for the QEMU emulator." )
 SET( CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON )

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We keep the original authors’ names. We do **not** inherit their old donation 
 
 ## What’s new vs the old AQEMU (tobimensch / ~0.9.x)
 
-The last widely known community tree — [tobimensch/aqemu](https://github.com/tobimensch/aqemu) — went quiet in 2020 (Qt5 port, VNC-era display, you brought your own QEMU). **Calling this revival a reskin misses nearly all of the engineering.** AQEMU 1.1.0 changes the capability model, runtime architecture, VM creation flow, platform support and distribution pipeline—not just the appearance.
+The last widely known community tree — [tobimensch/aqemu](https://github.com/tobimensch/aqemu) — went quiet in 2020 (Qt5 port, VNC-era display, you brought your own QEMU). **Calling this revival a reskin misses nearly all of the engineering.** AQEMU 1.3.0 adds working Apple SoC (Inferno/iOS) and hardware-accelerated Reims macOS on Windows via WSL, on top of the capability model, runtime architecture, VM creation flow, platform support and distribution pipeline from earlier 1.x releases.
 
 ### 1. Ground-truth capability engine
 
@@ -138,7 +138,8 @@ An asynchronous **QMP client** drives pause/resume, ACPI shutdown, reset, media 
 |--|--|
 | **Windows 11 ARM** | Wizard + lifecycle on **x64 Windows hosts via TCG** (and KVM on Pi 5 / aarch64) |
 | **Windows 95 / 98 / ME** | **Force pure TCG** — WHPX hangs classic 9x; we stop that footgun |
-| **Intel macOS** | OpenCore + OVMF + OSK UI, host-matching resolution, optional **WSL/KVM** on Windows |
+| **Apple SoC / iOS** | **1.3.0** — Inferno `qemu-system-applesoc` under **WSL**, trustcache/SEP/NVMe layout, companion + idevicerestore UI |
+| **Intel macOS + Reims** | OpenCore + OVMF + OSK; **Reims** accel via WSL `qemu-system-reims3d` + Vulkan (**AMD and NVIDIA** on Windows) |
 | **Classic Mac OS (PPC)** | `mac99` / PowerPC profiles, no PC floppy nonsense |
 | **Solaris 11.4 / AIX / OS/2 / ReactOS** | Wizard defaults matching real QEMU flags (AIX = `ppc64`/`pseries`, TCG on Windows) |
 
@@ -411,9 +412,11 @@ Get the official **AQEMU VM Manager** package on the Microsoft Store:
 </p>
 
 The Microsoft Store version includes:
+- **AQEMU 1.3.0** with Apple SoC (Inferno/iOS) and Reims hardware-accelerated macOS via WSL
 - **Bundled QEMU 11.0.2** binaries (no separate QEMU setup required)
 - **Automatic background updates** via the Microsoft Store
 - Dedicated Windows app installation & single-click launcher
+- **AMD and NVIDIA** GPU acceleration for Reims guests through WSLg Vulkan (WSL required)
 
 ### Build from Source (Linux / Pi 5 / Windows)
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -19,9 +19,9 @@ WiX Toolset → classic installer under `Program Files\AQEMU`.
 powershell -ExecutionPolicy Bypass -File installer\build-msi.ps1
 ```
 
-Output: `installer\out\AQEMU-1.1.0-win64.msi`
+Output: `installer\out\AQEMU-1.3.0-win64.msi`
 
-Silent install: `msiexec /i AQEMU-1.1.0-win64.msi /qn`
+Silent install: `msiexec /i AQEMU-1.3.0-win64.msi /qn`
 
 Requires: [WiX CLI](https://wixtoolset.org/) (`winget install WiXToolset.WiXCLI`), then `wix eula accept wix7` once (or let the script accept it).
 
@@ -35,7 +35,7 @@ Desktop Bridge package (`runFullTrust`) with the same built-in QEMU payload. Thi
 powershell -ExecutionPolicy Bypass -File installer\build-msix.ps1
 ```
 
-Output: `installer\out\AQEMU-1.1.0-win64.msix`
+Output: `installer\out\AQEMU-1.3.0-win64.msix`
 
 Requires: Windows 10/11 SDK (`makeappx.exe`, `signtool.exe`).
 
@@ -47,7 +47,7 @@ In Partner Center, create an **MSIX or PWA** app (not EXE/MSI), open **Product i
 powershell -ExecutionPolicy Bypass -File installer\build-msix.ps1 `
   -Publisher "CN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" `
   -IdentityName "YourPublisher.AQEMU" `
-  -Version "1.1.0.0"
+  -Version "1.3.0.0"
 ```
 
 - **Publisher** must match the Store `CN=...` exactly (signing cert subject must match too).

--- a/installer/build-msi.ps1
+++ b/installer/build-msi.ps1
@@ -10,7 +10,7 @@
 param(
     [string] $RepoRoot = "",
     [string] $BuildDir = "",
-    [string] $Version = "1.1.0",
+    [string] $Version = "1.3.0",
     [string] $OutDir = ""
 )
 

--- a/installer/build-msix.ps1
+++ b/installer/build-msix.ps1
@@ -11,7 +11,7 @@
 param(
     [string] $RepoRoot = "",
     [string] $BuildDir = "",
-    [string] $Version = "1.1.0.0",
+    [string] $Version = "1.3.0.0",
     [string] $OutDir = "",
     # Must match Partner Center Product identity Publisher (CN=...)
     [string] $Publisher = "CN=16318CB3-C262-4B44-BCCF-310B0DDA3950",

--- a/installer/wix/AQEMU.wixproj
+++ b/installer/wix/AQEMU.wixproj
@@ -6,9 +6,9 @@
   -->
   <PropertyGroup>
     <OutputType>Package</OutputType>
-    <OutputName>AQEMU-1.0.0-win64</OutputName>
+    <OutputName>AQEMU-1.3.0-win64</OutputName>
     <InstallerPlatform>x64</InstallerPlatform>
-    <DefineConstants>ProductVersion=1.0.0</DefineConstants>
+    <DefineConstants>ProductVersion=1.3.0</DefineConstants>
     <AcceptEula>wix7</AcceptEula>
   </PropertyGroup>
   <ItemGroup>

--- a/packaging/README-WINDOWS.txt
+++ b/packaging/README-WINDOWS.txt
@@ -1,7 +1,7 @@
-AQEMU 1.1.0 — Windows portable (x64)
+AQEMU 1.3.0 — Windows portable (x64)
 ====================================
 
-Updated build: 2026-07-29 (full QEMU probe catalogs + wizard CPU defaults).
+Updated build: 2026-08-08 (Apple SoC Inferno + Reims WSL acceleration).
 
 Please file bugs:
   https://github.com/chronic8000/aqemu/issues
@@ -9,7 +9,7 @@ Please file bugs:
 Run:  aqemu.exe
 
 This zip includes:
-  - AQEMU 1.1.0 (Qt5 + embedded SPICE)
+  - AQEMU 1.3.0 (Qt5 + embedded SPICE)
   - QEMU 11.0.2 (full softmmu set + qemu-img)
   - UEFI/BIOS firmware under share/
   - OpenPartitionDxe.efi (Intel macOS OpenCore prep)
@@ -17,9 +17,10 @@ This zip includes:
   - qemu_probe_full_v3/*.json (full per-arch QEMU option lists for VM config)
 
 What's new in this zip:
+  - Apple SoC / Inferno iOS path via WSL + companion restore UI
+  - Reims hardware-accelerated macOS via WSL (AMD and NVIDIA Vulkan)
   - Main Window / Custom: full machines, CPUs, NICs, display devices per arch from probes
-  - Wizard: curated OS defaults with probe-validated CPUs (no more 486 for Ubuntu)
-  - Architecture switch refreshes full option lists without re-running the wizard
+  - Wizard: curated OS defaults with probe-validated CPUs
 
 Notes:
   - GitHub Release zips are NOT auto-updated. Grab a newer zip when we publish one.

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -157,6 +157,7 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 	CB_WSL_Distro = nullptr;
 	Edit_WSL_User = nullptr;
 	Edit_WSL_Qemu_Binary = nullptr;
+	Edit_WSL_AppleSoC_Binary = nullptr;
 	Label_WSL_KVM_Status = nullptr;
 	TB_WSL_Probe = nullptr;
 #ifdef Q_OS_WIN32
@@ -191,6 +192,14 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 		binLay->addWidget( Edit_WSL_Qemu_Binary );
 		wslLay->addLayout( binLay );
 
+		QHBoxLayout *appleBinLay = new QHBoxLayout();
+		appleBinLay->addWidget( new QLabel( tr( "Apple SoC binary in WSL:" ) ) );
+		Edit_WSL_AppleSoC_Binary = new QLineEdit(
+			Settings.value( "WSL_Launch/AppleSoC_Binary",
+			                "/usr/local/bin/qemu-system-applesoc" ).toString() );
+		appleBinLay->addWidget( Edit_WSL_AppleSoC_Binary );
+		wslLay->addLayout( appleBinLay );
+
 		QHBoxLayout *probeLay = new QHBoxLayout();
 		TB_WSL_Probe = new QToolButton();
 		TB_WSL_Probe->setText( tr( "Probe /dev/kvm" ) );
@@ -200,7 +209,10 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 		wslLay->addLayout( probeLay );
 
 		QLabel *note = new QLabel( tr(
-			"SPICE/QMP stay on 127.0.0.1 — requires WSL localhostForwarding." ) );
+			"SPICE/QMP stay on 127.0.0.1 — requires WSL localhostForwarding.\n"
+			"Apple SoC / Reims always use WSL Linux binaries. Passwords are not stored; "
+			"KVM permission fixes use wsl -u root.\n"
+			"Reims Metal/Vulkan acceleration supports AMD and NVIDIA GPUs via WSLg." ) );
 		note->setWordWrap( true );
 		wslLay->addWidget( note );
 
@@ -665,6 +677,9 @@ void Advanced_Settings_Window::done(int r)
 		    Settings.remove( "WSL_Launch/Password" );
 		    Settings.setValue( "WSL_Launch/Qemu_Binary",
 			    Edit_WSL_Qemu_Binary ? Edit_WSL_Qemu_Binary->text().trimmed() : QStringLiteral( "qemu-system-x86_64" ) );
+		    Settings.setValue( "WSL_Launch/AppleSoC_Binary",
+			    Edit_WSL_AppleSoC_Binary ? Edit_WSL_AppleSoC_Binary->text().trimmed()
+			                           : QStringLiteral( "/usr/local/bin/qemu-system-applesoc" ) );
 		    WSL_Clear_Probe_Cache();
 	    }
 #endif

--- a/src/Advanced_Settings_Window.h
+++ b/src/Advanced_Settings_Window.h
@@ -96,6 +96,7 @@ class Advanced_Settings_Window: public QDialog
 		class QComboBox *CB_WSL_Distro;
 		QLineEdit *Edit_WSL_User;
 		QLineEdit *Edit_WSL_Qemu_Binary;
+		QLineEdit *Edit_WSL_AppleSoC_Binary;
 		QLabel *Label_WSL_KVM_Status;
 		QToolButton *TB_WSL_Probe;
 

--- a/src/Apple_SoC_Restore_Window.cpp
+++ b/src/Apple_SoC_Restore_Window.cpp
@@ -3,6 +3,7 @@
 #include "VM.h"
 #include "Utils.h"
 #include "WSL_Launch.h"
+#include "WSL_Wizard_Window.h"
 #include "AQ_UI_Style.h"
 
 #include <QVBoxLayout>
@@ -56,9 +57,16 @@ Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget
 	CB_Conn_Type->setCurrentIndex( ctype.compare( QLatin1String( "ipv4" ), Qt::CaseInsensitive ) == 0 ? 1 : 0 );
 	form->addRow( tr( "USB remote type:" ), CB_Conn_Type );
 
-	Edit_Conn_Addr = new QLineEdit( vm && ! vm->Get_Apple_USB_Conn_Addr().isEmpty()
-		? vm->Get_Apple_USB_Conn_Addr()
-		: QStringLiteral( "127.0.0.1" ) );
+	Edit_Conn_Addr = new QLineEdit();
+	{
+		const QString saved = vm ? vm->Get_Apple_USB_Conn_Addr() : QString();
+		if( ! saved.isEmpty() )
+			Edit_Conn_Addr->setText( saved );
+		else if( CB_Conn_Type->currentData().toString() == QLatin1String( "unix" ) )
+			Edit_Conn_Addr->setText( QStringLiteral( "/tmp/InfernoUSBRemote" ) );
+		else
+			Edit_Conn_Addr->setText( QStringLiteral( "127.0.0.1" ) );
+	}
 	form->addRow( tr( "USB remote addr:" ), Edit_Conn_Addr );
 	lay->addLayout( form );
 
@@ -69,7 +77,18 @@ Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget
 	lay->addWidget( Text_Companion );
 	Copy_Companion_Command();
 	connect( CB_Conn_Type, QOverload<int>::of( &QComboBox::currentIndexChanged ),
-	         this, [this]( int ) { Copy_Companion_Command(); } );
+	         this, [this]( int ) {
+		if( Edit_Conn_Addr->text().trimmed() == QLatin1String( "127.0.0.1" ) ||
+		    Edit_Conn_Addr->text().trimmed() == QLatin1String( "/tmp/InfernoUSBRemote" ) ||
+		    Edit_Conn_Addr->text().trimmed().isEmpty() )
+		{
+			Edit_Conn_Addr->setText(
+				CB_Conn_Type->currentData().toString() == QLatin1String( "unix" )
+					? QStringLiteral( "/tmp/InfernoUSBRemote" )
+					: QStringLiteral( "127.0.0.1" ) );
+		}
+		Copy_Companion_Command();
+	} );
 	connect( Edit_Conn_Addr, &QLineEdit::textChanged, this, [this]( const QString & ) { Copy_Companion_Command(); } );
 
 	QHBoxLayout *btns = new QHBoxLayout();
@@ -150,15 +169,32 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 	}
 #ifdef Q_OS_WIN32
 	QSettings s;
-	const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+	QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+	QString user = s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
+	if( distro.trimmed().isEmpty() || ! WSL_Is_Valid_Username( user ) )
+	{
+		WSL_Wizard_Window wizard( this );
+		if( wizard.exec() != QDialog::Accepted )
+		{
+			QMessageBox::warning( this, tr( "WSL" ),
+				tr( "WSL distro and username are required to run idevicerestore." ) );
+			return;
+		}
+		distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+		user = s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
+		if( distro.trimmed().isEmpty() || ! WSL_Is_Valid_Username( user ) )
+		{
+			QMessageBox::warning( this, tr( "WSL" ),
+				tr( "WSL distro and username are still not configured." ) );
+			return;
+		}
+	}
 	const QString wsl_ipsw = Windows_Path_To_WSL( ipsw );
 	QStringList args;
-	if( ! distro.trimmed().isEmpty() )
-		args << QStringLiteral( "-d" ) << distro.trimmed();
-	const QString user = WSL_Sanitize_Username(
-		s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString() );
-	if( ! user.isEmpty() )
-		args << QStringLiteral( "-u" ) << user;
+	args << QStringLiteral( "-d" ) << distro.trimmed();
+	const QString safe_user = WSL_Sanitize_Username( user );
+	if( ! safe_user.isEmpty() )
+		args << QStringLiteral( "-u" ) << safe_user;
 	args << QStringLiteral( "-e" ) << QStringLiteral( "idevicerestore" )
 	     << QStringLiteral( "-d" ) << QStringLiteral( "-R" ) << wsl_ipsw;
 	Text_Log->append( QStringLiteral( "wsl.exe %1\n" ).arg( args.join( QLatin1Char( ' ' ) ) ) );

--- a/src/Apple_SoC_Restore_Window.cpp
+++ b/src/Apple_SoC_Restore_Window.cpp
@@ -1,0 +1,183 @@
+#include "Apple_SoC_Restore_Window.h"
+#include "Apple_SoC_Support.h"
+#include "VM.h"
+#include "Utils.h"
+#include "WSL_Launch.h"
+#include "AQ_UI_Style.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QLabel>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QApplication>
+#include <QClipboard>
+#include <QSettings>
+#include <QDir>
+#include <QFile>
+
+Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget *parent )
+	: QDialog( parent )
+	, VM( vm )
+	, Process( new QProcess( this ) )
+{
+	setWindowTitle( tr( "Apple SoC Restore (Inferno companion)" ) );
+	resize( AQ_Px( 720, this ), AQ_Px( 560, this ) );
+
+	QVBoxLayout *lay = new QVBoxLayout( this );
+	QLabel *intro = new QLabel( tr(
+		"<p><b>IPSW restore needs a companion VM</b> (ChefKiss Inferno).</p>"
+		"<ol>"
+		"<li>Start the companion QEMU first with <code>usb-tcp-remote</code> matching the "
+		"guest <code>usb-conn-*</code> flags.</li>"
+		"<li>Start the Apple SoC guest (AQEMU forces Linux Inferno under WSL on Windows).</li>"
+		"<li>In the same WSL distro, run patched <code>idevicerestore</code> against the "
+		"virtual iPhone (not a raw Windows PE QEMU — UNIX sockets / usbmux).</li>"
+		"</ol>"
+		"<p>See <a href=\"https://chefkiss.dev/ar/guides/inferno/companion-setup/\">Companion VM setup</a>.</p>" ) );
+	intro->setWordWrap( true );
+	intro->setOpenExternalLinks( true );
+	lay->addWidget( intro );
+
+	QFormLayout *form = new QFormLayout();
+	Edit_IPSW = new QLineEdit( vm ? vm->Get_Apple_IPSW_Path() : QString() );
+	QPushButton *btnIpsw = new QPushButton( tr( "Browse…" ) );
+	connect( btnIpsw, &QPushButton::clicked, this, &Apple_SoC_Restore_Window::Browse_IPSW );
+	QHBoxLayout *ipswLay = new QHBoxLayout();
+	ipswLay->addWidget( Edit_IPSW, 1 );
+	ipswLay->addWidget( btnIpsw );
+	form->addRow( tr( "IPSW:" ), ipswLay );
+
+	CB_Conn_Type = new QComboBox();
+	CB_Conn_Type->addItem( tr( "UNIX socket (WSL / Linux)" ), QStringLiteral( "unix" ) );
+	CB_Conn_Type->addItem( tr( "IPv4 TCP" ), QStringLiteral( "ipv4" ) );
+	const QString ctype = vm ? vm->Get_Apple_USB_Conn_Type() : QString();
+	CB_Conn_Type->setCurrentIndex( ctype.compare( QLatin1String( "ipv4" ), Qt::CaseInsensitive ) == 0 ? 1 : 0 );
+	form->addRow( tr( "USB remote type:" ), CB_Conn_Type );
+
+	Edit_Conn_Addr = new QLineEdit( vm && ! vm->Get_Apple_USB_Conn_Addr().isEmpty()
+		? vm->Get_Apple_USB_Conn_Addr()
+		: QStringLiteral( "127.0.0.1" ) );
+	form->addRow( tr( "USB remote addr:" ), Edit_Conn_Addr );
+	lay->addLayout( form );
+
+	Text_Companion = new QTextEdit();
+	Text_Companion->setReadOnly( true );
+	Text_Companion->setMaximumHeight( AQ_Px( 120, this ) );
+	lay->addWidget( new QLabel( tr( "Companion QEMU snippet (EHCI + usb-tcp-remote):" ) ) );
+	lay->addWidget( Text_Companion );
+	Copy_Companion_Command();
+	connect( CB_Conn_Type, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+	         this, [this]( int ) { Copy_Companion_Command(); } );
+	connect( Edit_Conn_Addr, &QLineEdit::textChanged, this, [this]( const QString & ) { Copy_Companion_Command(); } );
+
+	QHBoxLayout *btns = new QHBoxLayout();
+	QPushButton *btnCopy = new QPushButton( tr( "Copy companion command" ) );
+	connect( btnCopy, &QPushButton::clicked, this, [this]() {
+		QApplication::clipboard()->setText( Text_Companion->toPlainText() );
+		QMessageBox::information( this, tr( "Copied" ), tr( "Companion command copied." ) );
+	} );
+	QPushButton *btnRestore = new QPushButton( tr( "Run idevicerestore in WSL" ) );
+	connect( btnRestore, &QPushButton::clicked, this, &Apple_SoC_Restore_Window::Run_IDeviceRestore );
+	btns->addWidget( btnCopy );
+	btns->addWidget( btnRestore );
+	btns->addStretch();
+	QPushButton *btnClose = new QPushButton( tr( "Close" ) );
+	connect( btnClose, &QPushButton::clicked, this, &QDialog::accept );
+	btns->addWidget( btnClose );
+	lay->addLayout( btns );
+
+	Text_Log = new QTextEdit();
+	Text_Log->setReadOnly( true );
+	lay->addWidget( new QLabel( tr( "Output:" ) ) );
+	lay->addWidget( Text_Log, 1 );
+
+	connect( Process, &QProcess::readyReadStandardOutput, this, &Apple_SoC_Restore_Window::On_Process_Output );
+	connect( Process, &QProcess::readyReadStandardError, this, &Apple_SoC_Restore_Window::On_Process_Output );
+	connect( Process, QOverload<int, QProcess::ExitStatus>::of( &QProcess::finished ),
+	         this, &Apple_SoC_Restore_Window::On_Process_Finished );
+}
+
+void Apple_SoC_Restore_Window::Browse_IPSW()
+{
+	const QString f = QFileDialog::getOpenFileName( this, tr( "Select IPSW" ),
+		Edit_IPSW->text(), tr( "IPSW (*.ipsw *.zip);;All (*)" ) );
+	if( ! f.isEmpty() )
+	{
+		Edit_IPSW->setText( QDir::toNativeSeparators( f ) );
+		if( VM )
+			VM->Set_Apple_IPSW_Path( f );
+	}
+}
+
+void Apple_SoC_Restore_Window::Copy_Companion_Command()
+{
+	const QString type = CB_Conn_Type->currentData().toString();
+	const QString addr = Edit_Conn_Addr->text().trimmed().isEmpty()
+		? ( type == QLatin1String( "unix" ) ? QStringLiteral( "/tmp/InfernoUSBRemote" ) : QStringLiteral( "127.0.0.1" ) )
+		: Edit_Conn_Addr->text().trimmed();
+	const int port = VM && VM->Get_Apple_USB_Conn_Port() > 0 ? VM->Get_Apple_USB_Conn_Port() : 8030;
+
+	if( VM )
+	{
+		VM->Set_Apple_USB_Conn_Type( type );
+		VM->Set_Apple_USB_Conn_Addr( addr );
+	}
+
+	QString remote = QStringLiteral( "usb-tcp-remote,bus=ehci.0,conn-type=%1" ).arg( type );
+	if( type == QLatin1String( "unix" ) )
+		remote += QStringLiteral( ",conn-addr=%1" ).arg( addr );
+	else
+		remote += QStringLiteral( ",conn-addr=%1,conn-port=%2" ).arg( addr ).arg( port );
+
+	Text_Companion->setPlainText(
+		tr( "# Start companion BEFORE the Apple SoC guest\n"
+		    "qemu-system-x86_64 -M q35 -m 2G -accel kvm \\\n"
+		    "  -usb -device usb-ehci,id=ehci -device %1\n\n"
+		    "# Guest machine must use matching usb-conn-type / addr / port.\n"
+		    "# idevicerestore must be the Inferno-patched build inside WSL/Linux." )
+			.arg( remote ) );
+}
+
+void Apple_SoC_Restore_Window::Run_IDeviceRestore()
+{
+	const QString ipsw = Edit_IPSW->text().trimmed();
+	if( ipsw.isEmpty() || ! QFile::exists( ipsw ) )
+	{
+		QMessageBox::warning( this, tr( "IPSW" ), tr( "Select a valid IPSW file first." ) );
+		return;
+	}
+#ifdef Q_OS_WIN32
+	QSettings s;
+	const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+	const QString wsl_ipsw = Windows_Path_To_WSL( ipsw );
+	QStringList args;
+	if( ! distro.trimmed().isEmpty() )
+		args << QStringLiteral( "-d" ) << distro.trimmed();
+	const QString user = WSL_Sanitize_Username(
+		s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString() );
+	if( ! user.isEmpty() )
+		args << QStringLiteral( "-u" ) << user;
+	args << QStringLiteral( "-e" ) << QStringLiteral( "idevicerestore" )
+	     << QStringLiteral( "-d" ) << QStringLiteral( "-R" ) << wsl_ipsw;
+	Text_Log->append( QStringLiteral( "wsl.exe %1\n" ).arg( args.join( QLatin1Char( ' ' ) ) ) );
+	Process->start( QStringLiteral( "wsl.exe" ), args );
+#else
+	Process->start( QStringLiteral( "idevicerestore" ),
+		QStringList() << QStringLiteral( "-d" ) << QStringLiteral( "-R" ) << ipsw );
+#endif
+}
+
+void Apple_SoC_Restore_Window::On_Process_Output()
+{
+	const QString out = QString::fromLocal8Bit( Process->readAllStandardOutput() );
+	const QString err = QString::fromLocal8Bit( Process->readAllStandardError() );
+	if( ! out.isEmpty() ) Text_Log->append( out );
+	if( ! err.isEmpty() ) Text_Log->append( err );
+}
+
+void Apple_SoC_Restore_Window::On_Process_Finished( int code, QProcess::ExitStatus )
+{
+	Text_Log->append( tr( "\nidevicerestore finished with exit code %1" ).arg( code ) );
+}

--- a/src/Apple_SoC_Restore_Window.cpp
+++ b/src/Apple_SoC_Restore_Window.cpp
@@ -17,6 +17,33 @@
 #include <QSettings>
 #include <QDir>
 #include <QFile>
+#include <QRegularExpression>
+
+namespace {
+
+/** Single-quote for POSIX shell so pasted companion commands cannot inject metacharacters. */
+QString Shell_Single_Quote( const QString &raw )
+{
+	QString s = raw;
+	s.replace( QLatin1Char( '\'' ), QLatin1String( "'\\''" ) );
+	return QLatin1Char( '\'' ) + s + QLatin1Char( '\'' );
+}
+
+bool Is_Safe_Unix_Socket_Path( const QString &path )
+{
+	if( ! path.startsWith( QLatin1Char( '/' ) ) || path.contains( QLatin1String( ".." ) ) )
+		return false;
+	static const QRegularExpression re( QStringLiteral( "^[A-Za-z0-9_./-]+$" ) );
+	return re.match( path ).hasMatch();
+}
+
+bool Is_Safe_IPv4_Or_Host( const QString &host )
+{
+	static const QRegularExpression re( QStringLiteral( "^[A-Za-z0-9.-]+$" ) );
+	return ! host.isEmpty() && re.match( host ).hasMatch() && ! host.contains( QLatin1String( ".." ) );
+}
+
+} // namespace
 
 Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget *parent )
 	: QDialog( parent )
@@ -133,9 +160,24 @@ void Apple_SoC_Restore_Window::Browse_IPSW()
 void Apple_SoC_Restore_Window::Copy_Companion_Command()
 {
 	const QString type = CB_Conn_Type->currentData().toString();
-	const QString addr = Edit_Conn_Addr->text().trimmed().isEmpty()
-		? ( type == QLatin1String( "unix" ) ? QStringLiteral( "/tmp/InfernoUSBRemote" ) : QStringLiteral( "127.0.0.1" ) )
-		: Edit_Conn_Addr->text().trimmed();
+	QString addr = Edit_Conn_Addr->text().trimmed();
+	if( addr.isEmpty() )
+		addr = ( type == QLatin1String( "unix" ) )
+			? QStringLiteral( "/tmp/InfernoUSBRemote" )
+			: QStringLiteral( "127.0.0.1" );
+
+	const bool addr_ok = ( type == QLatin1String( "unix" ) )
+		? Is_Safe_Unix_Socket_Path( addr )
+		: Is_Safe_IPv4_Or_Host( addr );
+	if( ! addr_ok )
+	{
+		Text_Companion->setPlainText(
+			tr( "# Invalid USB remote address (rejected for shell safety).\n"
+			    "# Use a path like /tmp/InfernoUSBRemote or an IPv4/hostname with "
+			    "letters, digits, '.', '-' only." ) );
+		return;
+	}
+
 	const int port = VM && VM->Get_Apple_USB_Conn_Port() > 0 ? VM->Get_Apple_USB_Conn_Port() : 8030;
 
 	if( VM )
@@ -144,6 +186,7 @@ void Apple_SoC_Restore_Window::Copy_Companion_Command()
 		VM->Set_Apple_USB_Conn_Addr( addr );
 	}
 
+	// Build -device value without shell metacharacters, then quote it for paste-into-shell.
 	QString remote = QStringLiteral( "usb-tcp-remote,bus=ehci.0,conn-type=%1" ).arg( type );
 	if( type == QLatin1String( "unix" ) )
 		remote += QStringLiteral( ",conn-addr=%1" ).arg( addr );
@@ -156,7 +199,7 @@ void Apple_SoC_Restore_Window::Copy_Companion_Command()
 		    "  -usb -device usb-ehci,id=ehci -device %1\n\n"
 		    "# Guest machine must use matching usb-conn-type / addr / port.\n"
 		    "# idevicerestore must be the Inferno-patched build inside WSL/Linux." )
-			.arg( remote ) );
+			.arg( Shell_Single_Quote( remote ) ) );
 }
 
 void Apple_SoC_Restore_Window::Run_IDeviceRestore()

--- a/src/Apple_SoC_Restore_Window.h
+++ b/src/Apple_SoC_Restore_Window.h
@@ -1,0 +1,36 @@
+#ifndef APPLE_SOC_RESTORE_WINDOW_H
+#define APPLE_SOC_RESTORE_WINDOW_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QTextEdit>
+#include <QPushButton>
+#include <QComboBox>
+#include <QProcess>
+
+class Virtual_Machine;
+
+class Apple_SoC_Restore_Window : public QDialog
+{
+	Q_OBJECT
+public:
+	explicit Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget *parent = nullptr );
+
+private slots:
+	void Browse_IPSW();
+	void Copy_Companion_Command();
+	void Run_IDeviceRestore();
+	void On_Process_Output();
+	void On_Process_Finished( int code, QProcess::ExitStatus st );
+
+private:
+	Virtual_Machine *VM;
+	QLineEdit *Edit_IPSW;
+	QLineEdit *Edit_Conn_Addr;
+	QComboBox *CB_Conn_Type;
+	QTextEdit *Text_Log;
+	QTextEdit *Text_Companion;
+	QProcess *Process;
+};
+
+#endif

--- a/src/Apple_SoC_Support.cpp
+++ b/src/Apple_SoC_Support.cpp
@@ -60,7 +60,12 @@ static bool Write_Sparse_Raw( const QString &path, qint64 size_bytes, QString *e
 
 bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &vm_dir, QString *error_out )
 {
-	QDir().mkpath( vm_dir );
+	if( ! QDir().mkpath( vm_dir ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Cannot create Apple SoC VM directory:\n%1" ).arg( vm_dir );
+		return false;
+	}
 	struct Spec { const char *name; qint64 bytes; };
 	// Sizes mirror common Inferno recipes (small SEP/NVRAM + larger root/firmware).
 	const Spec specs[] = {
@@ -93,7 +98,9 @@ static QString Quote_Drive( const QString &path, bool script )
 
 QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
                                            bool for_script_mode,
-                                           bool via_wsl )
+                                           bool via_wsl,
+                                           bool create_missing_images,
+                                           QString *error_out )
 {
 	QStringList out;
 	if( ! vm || ! AQ_Is_Apple_SoC_VM( vm ) )
@@ -103,7 +110,17 @@ QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
 	if( vm_dir.isEmpty() )
 		vm_dir = QDir::currentPath();
 
-	AQ_Ensure_Apple_SoC_Disk_Images( vm_dir );
+	if( create_missing_images )
+	{
+		QString err;
+		if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_dir, &err ) )
+		{
+			if( error_out )
+				*error_out = err;
+			AQWarning( "AQ_Build_Apple_SoC_Extra_Args", err );
+			return QStringList();
+		}
+	}
 
 	auto p = [&]( const QString &name ) -> QString {
 		const QString override = vm->Get_Apple_SoC_Image_Path( name );

--- a/src/Apple_SoC_Support.cpp
+++ b/src/Apple_SoC_Support.cpp
@@ -1,0 +1,218 @@
+#include "Apple_SoC_Support.h"
+#include "VM.h"
+#include "Utils.h"
+#include "WSL_Launch.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSettings>
+#include <QObject>
+
+bool AQ_Is_Apple_SoC_VM( const Virtual_Machine *vm )
+{
+	if( ! vm )
+		return false;
+	if( vm->Use_Apple_SoC_Profile() )
+		return true;
+	return vm->Get_Computer_Type().contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+	       vm->Get_Machine_Type().contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
+	       vm->Get_Machine_Type().contains( QLatin1String( "s8000" ), Qt::CaseInsensitive );
+}
+
+QString AQ_Apple_SoC_Default_Append()
+{
+	return QStringLiteral(
+		"tlto_us=-1 mtxspin=-1 agm-genuine=1 agm-authentic=1 agm-trusted=1 "
+		"serial=3 wdt=-1 -vm_compressor_wk_sw" );
+}
+
+QString AQ_Apple_SoC_WSL_Qemu_Binary()
+{
+	QSettings s;
+	const QString override = s.value( QStringLiteral( "WSL_Launch/AppleSoC_Binary" ), QString() ).toString().trimmed();
+	if( ! override.isEmpty() )
+		return override;
+	return QStringLiteral( "/usr/local/bin/qemu-system-applesoc" );
+}
+
+static bool Write_Sparse_Raw( const QString &path, qint64 size_bytes, QString *error_out )
+{
+	if( QFile::exists( path ) )
+		return true;
+	QFile f( path );
+	if( ! f.open( QIODevice::WriteOnly ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Cannot create %1" ).arg( path );
+		return false;
+	}
+	if( ! f.resize( size_bytes ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Cannot size %1" ).arg( path );
+		f.close();
+		return false;
+	}
+	f.close();
+	return true;
+}
+
+bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &vm_dir, QString *error_out )
+{
+	QDir().mkpath( vm_dir );
+	struct Spec { const char *name; qint64 bytes; };
+	// Sizes mirror common Inferno recipes (small SEP/NVRAM + larger root/firmware).
+	const Spec specs[] = {
+		{ "sep_nvram", 64 * 1024 },
+		{ "sep_ssc", 64 * 1024 },
+		{ "root", 32LL * 1024 * 1024 * 1024 },
+		{ "firmware", 1LL * 1024 * 1024 * 1024 },
+		{ "syscfg", 1 * 1024 * 1024 },
+		{ "ctrl_bits", 1 * 1024 * 1024 },
+		{ "nvram", 1 * 1024 * 1024 },
+		{ "effaceable", 1 * 1024 * 1024 },
+		{ "panic_log", 16 * 1024 * 1024 },
+	};
+	for( const Spec &s : specs )
+	{
+		const QString path = QDir( vm_dir ).filePath( QString::fromLatin1( s.name ) );
+		if( ! Write_Sparse_Raw( path, s.bytes, error_out ) )
+			return false;
+	}
+	return true;
+}
+
+static QString Quote_Drive( const QString &path, bool script )
+{
+	const QString n = AQ_Normalize_File_Path( path );
+	if( script )
+		return QStringLiteral( "\"%1\"" ).arg( n );
+	return n;
+}
+
+QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
+                                           bool for_script_mode,
+                                           bool via_wsl )
+{
+	QStringList out;
+	if( ! vm || ! AQ_Is_Apple_SoC_VM( vm ) )
+		return out;
+
+	QString vm_dir = QFileInfo( vm->Get_VM_XML_File_Path() ).absolutePath();
+	if( vm_dir.isEmpty() )
+		vm_dir = QDir::currentPath();
+
+	AQ_Ensure_Apple_SoC_Disk_Images( vm_dir );
+
+	auto p = [&]( const QString &name ) -> QString {
+		const QString override = vm->Get_Apple_SoC_Image_Path( name );
+		if( ! override.trimmed().isEmpty() )
+			return AQ_Normalize_File_Path( override );
+		return QDir( vm_dir ).filePath( name );
+	};
+
+	// SEP pflash pair
+	out << QStringLiteral( "-drive" )
+	    << QStringLiteral( "file=%1,if=pflash,format=raw" )
+	           .arg( Quote_Drive( p( QStringLiteral( "sep_nvram" ) ), for_script_mode ) );
+	out << QStringLiteral( "-drive" )
+	    << QStringLiteral( "file=%1,if=pflash,format=raw" )
+	           .arg( Quote_Drive( p( QStringLiteral( "sep_ssc" ) ), for_script_mode ) );
+
+	struct Ns { const char *file; int nsid; int nstype; bool apple_nvram; };
+	const Ns namespaces[] = {
+		{ "root", 1, 1, false },
+		{ "firmware", 2, 2, false },
+		{ "syscfg", 3, 3, false },
+		{ "ctrl_bits", 4, 4, false },
+		{ "nvram", 5, 5, true },
+		{ "effaceable", 6, 6, false },
+		{ "panic_log", 7, 8, false },
+	};
+
+	for( const Ns &ns : namespaces )
+	{
+		const QString id = QString::fromLatin1( ns.file );
+		const QString file = Quote_Drive( p( id ), for_script_mode );
+		out << QStringLiteral( "-drive" )
+		    << QStringLiteral( "file=%1,format=raw,if=none,id=%2" ).arg( file, id );
+		if( ns.apple_nvram )
+		{
+			out << QStringLiteral( "-device" )
+			    << QStringLiteral(
+				       "apple-nvram,drive=%1,bus=nvme-bus.0,nsid=%2,nstype=%3,id=nvram,"
+				       "logical_block_size=4096,physical_block_size=4096" )
+			           .arg( id ).arg( ns.nsid ).arg( ns.nstype );
+		}
+		else
+		{
+			out << QStringLiteral( "-device" )
+			    << QStringLiteral(
+				       "nvme-ns,drive=%1,bus=nvme-bus.0,nsid=%2,nstype=%3,"
+				       "logical_block_size=4096,physical_block_size=4096" )
+			           .arg( id ).arg( ns.nsid ).arg( ns.nstype );
+		}
+	}
+
+	Q_UNUSED( via_wsl );
+	return out;
+}
+
+QString AQ_Build_Apple_SoC_Machine_Props( const Virtual_Machine *vm, bool via_wsl )
+{
+	if( ! vm )
+		return QString();
+
+	QString machine = vm->Get_Machine_Type().trimmed();
+	if( machine.isEmpty() )
+		machine = QStringLiteral( "t8030" );
+
+	QStringList props;
+	props << machine;
+
+	auto add_path_prop = [&]( const char *key, const QString &path ) {
+		const QString n = AQ_Normalize_File_Path( path );
+		if( ! n.isEmpty() )
+			props << QStringLiteral( "%1=%2" ).arg( QString::fromLatin1( key ), n );
+	};
+
+	add_path_prop( "trustcache", vm->Get_Apple_Trustcache_Path() );
+	add_path_prop( "ticket", vm->Get_Apple_Ticket_Path() );
+	add_path_prop( "sep-fw", vm->Get_Apple_SEP_FW_Path() );
+	add_path_prop( "sep-rom", vm->Get_Apple_SEP_ROM_Path() );
+	props << QStringLiteral( "kaslr-off=true" );
+
+	// USB remote for companion / idevicerestore. Prefer TCP on Windows host native;
+	// unix socket when launching under WSL (Linux Inferno).
+	QString conn = vm->Get_Apple_USB_Conn_Type().trimmed().toLower();
+	if( conn.isEmpty() )
+	{
+#ifdef Q_OS_WIN32
+		conn = via_wsl ? QStringLiteral( "unix" ) : QStringLiteral( "ipv4" );
+#else
+		conn = QStringLiteral( "unix" );
+#endif
+	}
+	props << QStringLiteral( "usb-conn-type=%1" ).arg( conn );
+	if( conn == QLatin1String( "unix" ) )
+	{
+		QString addr = vm->Get_Apple_USB_Conn_Addr().trimmed();
+		if( addr.isEmpty() )
+			addr = QStringLiteral( "/tmp/InfernoUSBRemote" );
+		props << QStringLiteral( "usb-conn-addr=%1" ).arg( addr );
+	}
+	else
+	{
+		QString addr = vm->Get_Apple_USB_Conn_Addr().trimmed();
+		if( addr.isEmpty() )
+			addr = QStringLiteral( "127.0.0.1" );
+		props << QStringLiteral( "usb-conn-addr=%1" ).arg( addr );
+		int port = vm->Get_Apple_USB_Conn_Port();
+		if( port <= 0 )
+			port = 8030;
+		props << QStringLiteral( "usb-conn-port=%1" ).arg( port );
+	}
+
+	return props.join( QLatin1Char( ',' ) );
+}

--- a/src/Apple_SoC_Support.h
+++ b/src/Apple_SoC_Support.h
@@ -1,0 +1,36 @@
+#ifndef APPLE_SOC_SUPPORT_H
+#define APPLE_SOC_SUPPORT_H
+
+#include <QString>
+#include <QStringList>
+
+class Virtual_Machine;
+
+/** True when this VM should use the Inferno Apple SoC launch profile. */
+bool AQ_Is_Apple_SoC_VM( const Virtual_Machine *vm );
+
+/** Default research-kernel boot args used by Inferno t8030 restore/boot recipes. */
+QString AQ_Apple_SoC_Default_Append();
+
+/**
+ * Ensure the standard raw image set exists under vm_dir (sep_nvram, root, …).
+ * Creates missing files with sensible sizes. Returns false on I/O failure.
+ */
+bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &vm_dir, QString *error_out = nullptr );
+
+/**
+ * Build Inferno-specific argv pieces that AQEMU would not emit from generic UI:
+ * enhanced -machine props, SEP pflash, multi-ns NVMe layout, usb-conn for companion.
+ * Caller still supplies -kernel/-dtb/-append via normal App_Kernel/DeviceTree fields.
+ */
+QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
+                                           bool for_script_mode,
+                                           bool via_wsl );
+
+/** Comma-joined Inferno -machine value (t8030,trustcache=…,usb-conn-type=…). */
+QString AQ_Build_Apple_SoC_Machine_Props( const Virtual_Machine *vm, bool via_wsl );
+
+/** Linux Inferno binary path inside WSL. */
+QString AQ_Apple_SoC_WSL_Qemu_Binary();
+
+#endif

--- a/src/Apple_SoC_Support.h
+++ b/src/Apple_SoC_Support.h
@@ -20,17 +20,20 @@ bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &vm_dir, QString *error_out 
 
 /**
  * Build Inferno-specific argv pieces that AQEMU would not emit from generic UI:
- * enhanced -machine props, SEP pflash, multi-ns NVMe layout, usb-conn for companion.
- * Caller still supplies -kernel/-dtb/-append via normal App_Kernel/DeviceTree fields.
+ * SEP pflash, multi-ns NVMe layout. Does not create missing images unless
+ * create_missing_images is true (real Start only — never for args preview/script).
+ * On create failure returns an empty list and sets error_out.
  */
 QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
                                            bool for_script_mode,
-                                           bool via_wsl );
+                                           bool via_wsl,
+                                           bool create_missing_images = false,
+                                           QString *error_out = nullptr );
 
 /** Comma-joined Inferno -machine value (t8030,trustcache=…,usb-conn-type=…). */
 QString AQ_Build_Apple_SoC_Machine_Props( const Virtual_Machine *vm, bool via_wsl );
 
-/** Linux Inferno binary path inside WSL. */
+/** Linux Inferno binary path / command name inside WSL. */
 QString AQ_Apple_SoC_WSL_Qemu_Binary();
 
 #endif

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -1936,8 +1936,9 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Set_Initrd_Path( ui.Edit_Linux_Initrd_Path->text() );
 	tmp_vm->Set_DeviceTree_Path( ui.Edit_DeviceTree_Path->text() );
 	tmp_vm->Set_App_Kernel_Path( ui.Edit_App_Kernel_Path->text() );
-	// Must match the DeviceTree UI that is actually visible (not name-heuristics alone).
-	if( ui.Widget_DeviceTree_Main->isVisible() )
+	// Prefer authoritative Apple SoC markers on tmp_vm (computer/machine type), not widget
+	// visibility which may lag until Update_DeviceTree_Visibility runs.
+	if( Uses_Apple_SoC_Boot_UI( tmp_vm ) )
 		tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
 	else
 		tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
@@ -6081,6 +6082,7 @@ void Main_Window::Computer_Type_Changed()
 	// Other Options
 	Update_Win11_Lifecycle_Ui();
 	Update_Intel_MacOS_Settings_Ui();
+	Update_DeviceTree_Visibility();
 	Enforce_Accel_Honesty();
 	Enforce_Disk_Bus_Honesty();
 	Update_Disabled_Controls();
@@ -6108,6 +6110,7 @@ void Main_Window::on_CB_Machine_Type_Main_currentIndexChanged( int index )
 	}
 
 	Enforce_Disk_Bus_Honesty();
+	Update_DeviceTree_Visibility();
 	VM_Changed();
 }
 
@@ -6154,6 +6157,7 @@ void Main_Window::sync_arch_Machine_Type_changed( int index )
 		live_vm->Set_Machine_Type( ui.CB_Machine_Type_Main->currentText() );
 	}
 
+	Update_DeviceTree_Visibility();
 	VM_Changed();
 }
 

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -1936,8 +1936,8 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 	tmp_vm->Set_Initrd_Path( ui.Edit_Linux_Initrd_Path->text() );
 	tmp_vm->Set_DeviceTree_Path( ui.Edit_DeviceTree_Path->text() );
 	tmp_vm->Set_App_Kernel_Path( ui.Edit_App_Kernel_Path->text() );
-	// Must match Update_DeviceTree_Visibility / Uses_Apple_SoC_Boot_UI — not path emptiness.
-	if( Uses_Apple_SoC_Boot_UI( tmp_vm ) )
+	// Must match the DeviceTree UI that is actually visible (not name-heuristics alone).
+	if( ui.Widget_DeviceTree_Main->isVisible() )
 		tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
 	else
 		tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
@@ -4407,9 +4407,7 @@ bool Main_Window::Boot_Is_Correct( Virtual_Machine *tmp_vm )
 	    tmp_vm->Get_Machine_Type().contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
 	    tmp_vm->Get_Machine_Type().contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) )
 	{
-		const QString kernel = ! tmp_vm->Get_App_Kernel_Path().trimmed().isEmpty()
-			? tmp_vm->Get_App_Kernel_Path().trimmed()
-			: ( tmp_vm->Get_Use_Linux_Boot() ? tmp_vm->Get_bzImage_Path().trimmed() : QString() );
+		const QString kernel = tmp_vm->Get_App_Kernel_Path().trimmed();
 		const QString dtb = tmp_vm->Get_DeviceTree_Path().trimmed();
 
 		if( kernel.isEmpty() || ! QFile::exists( kernel ) )
@@ -6322,7 +6320,12 @@ void Main_Window::Apply_Apple_SoC_Fields_To_VM( Virtual_Machine *vm )
 {
 	if( ! vm )
 		return;
-	if( Uses_Apple_SoC_Boot_UI( vm ) )
+	// Persist profile only from authoritative target markers — never from VM name heuristics.
+	const QString c_type = vm->Get_Computer_Type();
+	const QString m_type = vm->Get_Machine_Type();
+	if( c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+	    m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
+	    m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) )
 		vm->Use_Apple_SoC_Profile( true );
 	if( Edit_Apple_Trustcache )
 		vm->Set_Apple_Trustcache_Path( Edit_Apple_Trustcache->text() );

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -59,9 +59,13 @@
 #include <QToolButton>
 #include <QAbstractButton>
 #include "iOS_Firmware_Tool_Window.h"
+#include "Apple_SoC_Restore_Window.h"
+#include "Apple_SoC_Support.h"
+#include "WSL_Launch.h"
 #include <QStyle>
 #include <QFontMetrics>
 #include <QLineEdit>
+#include <QSpinBox>
 #include <QClipboard>
 #include <QScrollArea>
 #include <QFrame>
@@ -127,6 +131,14 @@ Main_Window::Main_Window( QWidget *parent )
 	, Session_User_Detached( false )
 	, Session_Block_During_Start( false )
 	, GPU_Scan_Busy( false )
+	, Edit_Apple_Trustcache( nullptr )
+	, Edit_Apple_Ticket( nullptr )
+	, Edit_Apple_SEP_FW( nullptr )
+	, Edit_Apple_SEP_ROM( nullptr )
+	, Edit_Apple_IPSW( nullptr )
+	, Edit_Apple_USB_Conn_Addr( nullptr )
+	, CB_Apple_USB_Conn_Type( nullptr )
+	, SB_Apple_USB_Conn_Port( nullptr )
 	, Tray_Icon( nullptr )
 	, Act_Tray_Show( nullptr )
 	, Act_Tray_Quit( nullptr )
@@ -152,6 +164,7 @@ Main_Window::Main_Window( QWidget *parent )
 
     ui.setupUi( this );
 	ui_ao.setupUi( Advanced_Options );
+	Build_Apple_SoC_Inferno_Ui();
 
 	// Make the options body inside Advanced Options scrollable while keeping OK/Cancel fixed at the bottom
 	if( ui_ao.groupBox_options && ui_ao.groupBox_options->parentWidget() )
@@ -202,6 +215,14 @@ Main_Window::Main_Window( QWidget *parent )
 		actIosFw->setStatusTip( tr( "Unpack IPSW archives and process IM4P payloads with pyimg4" ) );
 		connect( actIosFw, &QAction::triggered, this, &Main_Window::slot_iOS_Firmware_Tool_triggered );
 		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actIosFw );
+	}
+	// File → Apple SoC Restore (companion + idevicerestore)
+	{
+		QAction *actRestore = new QAction( QIcon( QStringLiteral( ":/default_mac.png" ) ),
+			tr( "Apple SoC &Restore…" ), this );
+		actRestore->setStatusTip( tr( "Companion VM helper and idevicerestore for Inferno iOS guests" ) );
+		connect( actRestore, &QAction::triggered, this, &Main_Window::slot_Apple_SoC_Restore_triggered );
+		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actRestore );
 	}
 	if( ui.actionCopy )
 		ui.actionCopy->setText( tr( "Clone &VM…" ) );
@@ -444,6 +465,9 @@ Main_Window::Main_Window( QWidget *parent )
     block_VM_changed_signals = false;
 
 	Init_System_Tray();
+#ifdef Q_OS_WIN32
+	QTimer::singleShot( 0, this, [this]() { Maybe_Prompt_WSL_Config_On_Boot(); } );
+#endif
 }
 
 void Main_Window::Init_System_Tray()
@@ -1917,6 +1941,7 @@ bool Main_Window::Create_VM_From_Ui( Virtual_Machine *tmp_vm, Virtual_Machine *o
 		tmp_vm->Set_Kernel_ComLine( ui.Edit_App_Kernel_Args->text() );
 	else
 		tmp_vm->Set_Kernel_ComLine( ui.Edit_Linux_Command_Line->text() );
+	Apply_Apple_SoC_Fields_To_VM( tmp_vm );
 
 	// Optional Images
 	// ROM File
@@ -2999,6 +3024,7 @@ void Main_Window::Update_VM_Ui(bool update_info_tab)
 	ui.Edit_App_Kernel_Path->setText( tmp_vm->Get_App_Kernel_Path() );
 	ui.Edit_App_Kernel_Args->setText( tmp_vm->Get_Kernel_ComLine() );
 	ui.Edit_Linux_Command_Line->setText( tmp_vm->Get_Kernel_ComLine() );
+	Load_Apple_SoC_Fields_From_VM( tmp_vm );
 
 	// ROM File
 	ui.CH_ROM_File->setChecked( tmp_vm->Get_Use_ROM_File() );
@@ -4400,11 +4426,14 @@ bool Main_Window::Boot_Is_Correct( Virtual_Machine *tmp_vm )
 				    "(.dtb or extracted payload)." ) );
 			return false;
 		}
-		if( dtb.endsWith( QLatin1String( ".im4p" ), Qt::CaseInsensitive ) )
+		if( dtb.endsWith( QLatin1String( ".im4p" ), Qt::CaseInsensitive ) &&
+		    ! AQ_Is_Apple_SoC_VM( tmp_vm ) )
 		{
 			AQGraphic_Warning( tr( "Error!" ),
 				tr( "DeviceTree is still an .im4p payload. Extract/decrypt it to a "
-				    "raw .dtb (or .dec) with the iOS Firmware Tool before starting." ) );
+				    "raw .dtb (or .dec) with the iOS Firmware Tool before starting.\n\n"
+				    "Inferno Apple SoC guests may use .im4p DeviceTrees with the full "
+				    "trustcache / SEP recipe." ) );
 			return false;
 		}
 		// Disk image is optional at first boot (kernel+dtb only), but warn if missing.
@@ -6169,6 +6198,179 @@ void Main_Window::slot_iOS_Firmware_Tool_triggered()
 	dlg.exec();
 }
 
+void Main_Window::slot_Apple_SoC_Restore_triggered()
+{
+	Virtual_Machine *vm = Get_Current_VM();
+	if( vm )
+		Apply_Apple_SoC_Fields_To_VM( vm );
+	Apple_SoC_Restore_Window dlg( vm, this );
+	dlg.exec();
+	if( vm )
+		Load_Apple_SoC_Fields_From_VM( vm );
+}
+
+void Main_Window::Maybe_Prompt_WSL_Config_On_Boot()
+{
+#ifdef Q_OS_WIN32
+	const QString distro = Settings.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+	const QString user = Settings.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
+	if( ! distro.trimmed().isEmpty() && WSL_Is_Valid_Username( user ) )
+		return;
+
+	bool needs = Settings.value( QStringLiteral( "WSL_Launch/Enabled" ), false ).toBool();
+	for( int i = 0; ! needs && i < VM_List.count(); ++i )
+	{
+		Virtual_Machine *vm = VM_List[i];
+		if( ! vm )
+			continue;
+		if( AQ_Is_Apple_SoC_VM( vm ) ||
+		    vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) ||
+		    vm->Use_Launch_Via_WSL() )
+			needs = true;
+	}
+	if( ! needs )
+		return;
+
+	const auto ans = QMessageBox::question( this, tr( "WSL configuration" ),
+		tr( "AQEMU 1.3.0 uses WSL for Apple SoC (Inferno) and hardware-accelerated "
+		    "macOS (Reims) on Windows.\n\n"
+		    "WSL distro / username are not configured yet. Set them now?\n\n"
+		    "(Passwords are not stored — KVM fixes use wsl -u root.)" ),
+		QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes );
+	if( ans == QMessageBox::Yes )
+	{
+		WSL_Wizard_Window wizard( this );
+		wizard.exec();
+	}
+#endif
+}
+
+void Main_Window::Build_Apple_SoC_Inferno_Ui()
+{
+	QVBoxLayout *lay = ui.Widget_DeviceTree_Main
+		? qobject_cast<QVBoxLayout *>( ui.Widget_DeviceTree_Main->layout() )
+		: nullptr;
+	if( ! lay )
+		return;
+
+	auto add_path_row = [&]( const QString &label, QLineEdit **editOut, const QString &filter ) {
+		QHBoxLayout *row = new QHBoxLayout();
+		row->addWidget( new QLabel( label ) );
+		QLineEdit *edit = new QLineEdit();
+		*editOut = edit;
+		row->addWidget( edit, 1 );
+		QToolButton *tb = new QToolButton();
+		tb->setText( QStringLiteral( "..." ) );
+		tb->setIcon( QIcon( QStringLiteral( ":/open-file.png" ) ) );
+		connect( tb, &QToolButton::clicked, this, [this, edit, filter, label]() {
+			const QString f = QFileDialog::getOpenFileName( this, label,
+				Get_Last_Dir_Path( edit->text() ), filter );
+			if( ! f.isEmpty() )
+			{
+				edit->setText( QDir::toNativeSeparators( f ) );
+				VM_Changed();
+			}
+		} );
+		row->addWidget( tb );
+		lay->addLayout( row );
+		connect( edit, &QLineEdit::textChanged, this, [this]( const QString & ) { VM_Changed(); } );
+	};
+
+	add_path_row( tr( "Trustcache:" ), &Edit_Apple_Trustcache,
+		tr( "Trustcache (*);;All (*)" ) );
+	add_path_row( tr( "Restore ticket:" ), &Edit_Apple_Ticket,
+		tr( "Ticket (*);;All (*)" ) );
+	add_path_row( tr( "SEP firmware:" ), &Edit_Apple_SEP_FW,
+		tr( "SEP FW (*);;All (*)" ) );
+	add_path_row( tr( "SEP ROM:" ), &Edit_Apple_SEP_ROM,
+		tr( "SEP ROM (*);;All (*)" ) );
+	add_path_row( tr( "IPSW (restore):" ), &Edit_Apple_IPSW,
+		tr( "IPSW (*.ipsw *.zip);;All (*)" ) );
+
+	QHBoxLayout *usbRow = new QHBoxLayout();
+	usbRow->addWidget( new QLabel( tr( "USB remote:" ) ) );
+	CB_Apple_USB_Conn_Type = new QComboBox();
+	CB_Apple_USB_Conn_Type->addItem( tr( "UNIX (WSL/Linux)" ), QStringLiteral( "unix" ) );
+	CB_Apple_USB_Conn_Type->addItem( tr( "IPv4 TCP" ), QStringLiteral( "ipv4" ) );
+	usbRow->addWidget( CB_Apple_USB_Conn_Type );
+	Edit_Apple_USB_Conn_Addr = new QLineEdit();
+	Edit_Apple_USB_Conn_Addr->setPlaceholderText( QStringLiteral( "/tmp/InfernoUSBRemote or 127.0.0.1" ) );
+	usbRow->addWidget( Edit_Apple_USB_Conn_Addr, 1 );
+	SB_Apple_USB_Conn_Port = new QSpinBox();
+	SB_Apple_USB_Conn_Port->setRange( 1, 65535 );
+	SB_Apple_USB_Conn_Port->setValue( 8030 );
+	SB_Apple_USB_Conn_Port->setToolTip( tr( "TCP port when USB remote type is IPv4" ) );
+	usbRow->addWidget( SB_Apple_USB_Conn_Port );
+	lay->addLayout( usbRow );
+
+	connect( CB_Apple_USB_Conn_Type, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+	         this, [this]( int ) { VM_Changed(); } );
+	connect( Edit_Apple_USB_Conn_Addr, &QLineEdit::textChanged,
+	         this, [this]( const QString & ) { VM_Changed(); } );
+	connect( SB_Apple_USB_Conn_Port, QOverload<int>::of( &QSpinBox::valueChanged ),
+	         this, [this]( int ) { VM_Changed(); } );
+
+	QHBoxLayout *btnRow = new QHBoxLayout();
+	QPushButton *btnRestore = new QPushButton( tr( "Apple SoC Restore…" ) );
+	connect( btnRestore, &QPushButton::clicked, this, &Main_Window::slot_Apple_SoC_Restore_triggered );
+	btnRow->addWidget( btnRestore );
+	btnRow->addStretch();
+	lay->addLayout( btnRow );
+}
+
+void Main_Window::Apply_Apple_SoC_Fields_To_VM( Virtual_Machine *vm )
+{
+	if( ! vm )
+		return;
+	if( Uses_Apple_SoC_Boot_UI( vm ) )
+		vm->Use_Apple_SoC_Profile( true );
+	if( Edit_Apple_Trustcache )
+		vm->Set_Apple_Trustcache_Path( Edit_Apple_Trustcache->text() );
+	if( Edit_Apple_Ticket )
+		vm->Set_Apple_Ticket_Path( Edit_Apple_Ticket->text() );
+	if( Edit_Apple_SEP_FW )
+		vm->Set_Apple_SEP_FW_Path( Edit_Apple_SEP_FW->text() );
+	if( Edit_Apple_SEP_ROM )
+		vm->Set_Apple_SEP_ROM_Path( Edit_Apple_SEP_ROM->text() );
+	if( Edit_Apple_IPSW )
+		vm->Set_Apple_IPSW_Path( Edit_Apple_IPSW->text() );
+	if( CB_Apple_USB_Conn_Type )
+		vm->Set_Apple_USB_Conn_Type( CB_Apple_USB_Conn_Type->currentData().toString() );
+	if( Edit_Apple_USB_Conn_Addr )
+		vm->Set_Apple_USB_Conn_Addr( Edit_Apple_USB_Conn_Addr->text() );
+	if( SB_Apple_USB_Conn_Port )
+		vm->Set_Apple_USB_Conn_Port( SB_Apple_USB_Conn_Port->value() );
+}
+
+void Main_Window::Load_Apple_SoC_Fields_From_VM( const Virtual_Machine *vm )
+{
+	if( ! vm )
+		return;
+	if( Edit_Apple_Trustcache )
+		Edit_Apple_Trustcache->setText( vm->Get_Apple_Trustcache_Path() );
+	if( Edit_Apple_Ticket )
+		Edit_Apple_Ticket->setText( vm->Get_Apple_Ticket_Path() );
+	if( Edit_Apple_SEP_FW )
+		Edit_Apple_SEP_FW->setText( vm->Get_Apple_SEP_FW_Path() );
+	if( Edit_Apple_SEP_ROM )
+		Edit_Apple_SEP_ROM->setText( vm->Get_Apple_SEP_ROM_Path() );
+	if( Edit_Apple_IPSW )
+		Edit_Apple_IPSW->setText( vm->Get_Apple_IPSW_Path() );
+	if( CB_Apple_USB_Conn_Type )
+	{
+		const QString t = vm->Get_Apple_USB_Conn_Type();
+		const int idx = CB_Apple_USB_Conn_Type->findData(
+			t.compare( QLatin1String( "ipv4" ), Qt::CaseInsensitive ) == 0
+				? QStringLiteral( "ipv4" ) : QStringLiteral( "unix" ) );
+		if( idx >= 0 )
+			CB_Apple_USB_Conn_Type->setCurrentIndex( idx );
+	}
+	if( Edit_Apple_USB_Conn_Addr )
+		Edit_Apple_USB_Conn_Addr->setText( vm->Get_Apple_USB_Conn_Addr() );
+	if( SB_Apple_USB_Conn_Port )
+		SB_Apple_USB_Conn_Port->setValue( vm->Get_Apple_USB_Conn_Port() > 0 ? vm->Get_Apple_USB_Conn_Port() : 8030 );
+}
+
 void Main_Window::Update_Machine_Accelerators()
 {
 	const QString keep = ui.CB_Machine_Accelerator->currentData( Qt::UserRole ).toString().toLower();
@@ -6945,14 +7147,17 @@ bool Main_Window::Uses_Apple_SoC_Boot_UI( const Virtual_Machine *vm ) const
 	const QString c_type = vm->Get_Computer_Type();
 	const QString m_type = vm->Get_Machine_Type();
 
-	return ( m_name.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) ||
-	         m_name.contains( QLatin1String( "iPhone" ), Qt::CaseInsensitive ) ||
-	         m_name.contains( QLatin1String( "iPad" ), Qt::CaseInsensitive ) ||
-	         m_name.contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
-	         c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
-	         m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
-	         m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive ) ) &&
-	       ! c_type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
+	if( c_type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive ) )
+		return false;
+
+	return vm->Use_Apple_SoC_Profile() ||
+	       m_name.contains( QLatin1String( "iOS" ), Qt::CaseInsensitive ) ||
+	       m_name.contains( QLatin1String( "iPhone" ), Qt::CaseInsensitive ) ||
+	       m_name.contains( QLatin1String( "iPad" ), Qt::CaseInsensitive ) ||
+	       m_name.contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
+	       c_type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive ) ||
+	       m_type.contains( QLatin1String( "t8030" ), Qt::CaseInsensitive ) ||
+	       m_type.contains( QLatin1String( "s8000" ), Qt::CaseInsensitive );
 }
 
 void Main_Window::Update_Intel_Mac_GPU_Passthrough_Ui()
@@ -6984,6 +7189,53 @@ void Main_Window::Start_Host_GPU_Scan()
 void Main_Window::Apply_Intel_Mac_GPU_Passthrough_Ui_From_Cache()
 {
 	const bool has_amd = System_Info::Has_AMD_Display_GPU();
+	const bool has_nvidia = System_Info::Has_NVIDIA_Display_GPU();
+	const bool has_wsl_gpu = System_Info::Has_WSL_Vulkan_GPU();
+
+	Virtual_Machine *vm = Get_Current_VM();
+	const bool is_reims = vm &&
+		vm->Get_Computer_Type().contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
+
+	// Reims: show GPU status for AMD and NVIDIA (WSL Vulkan), even without VFIO.
+	if( is_reims )
+	{
+		ui.GB_Intel_Mac_GPU_Passthrough->setVisible( true );
+		ui.CH_Intel_Mac_GPU_Passthrough->setEnabled( false );
+		ui.CB_Intel_Mac_GPU->setEnabled( false );
+		ui.Edit_Intel_Mac_GPU_Audio->setEnabled( false );
+		ui.Edit_Intel_Mac_GPU_ROM->setEnabled( false );
+		ui.TB_Intel_Mac_GPU_ROM_Browse->setEnabled( false );
+		ui.TB_Intel_Mac_GPU_Refresh->setEnabled( true );
+		ui.CH_Intel_Mac_GPU_Passthrough->setChecked( false );
+
+		QString vendors;
+		if( has_amd && has_nvidia )
+			vendors = tr( "AMD and NVIDIA" );
+		else if( has_amd )
+			vendors = tr( "AMD" );
+		else if( has_nvidia )
+			vendors = tr( "NVIDIA" );
+		else if( System_Info::Host_GPU_Was_Scanned() )
+			vendors = tr( "no AMD/NVIDIA display GPU detected" );
+		else
+			vendors = tr( "scanning…" );
+
+#ifdef Q_OS_WIN32
+		ui.Label_Intel_Mac_GPU_Status->setText( tr(
+			"Reims hardware acceleration uses Linux qemu-system-reims3d under WSL with "
+			"host GPU Vulkan (AMD and NVIDIA via WSLg). Detected: %1.\n"
+			"PCIe Metal passthrough is not available on Windows — leave VFIO off." )
+			.arg( vendors ) );
+#else
+		ui.Label_Intel_Mac_GPU_Status->setText( tr(
+			"Reims acceleration needs qemu-system-reims3d with Vulkan. Detected: %1.\n"
+			"AMD Metal VFIO passthrough is separate and only on bare-metal Linux." )
+			.arg( vendors ) );
+#endif
+		Q_UNUSED( has_wsl_gpu );
+		return;
+	}
+
 	ui.GB_Intel_Mac_GPU_Passthrough->setVisible( has_amd || ! System_Info::Host_GPU_Was_Scanned() );
 	if( ! has_amd )
 	{
@@ -7032,17 +7284,15 @@ void Main_Window::Apply_Intel_Mac_GPU_Passthrough_Ui_From_Cache()
 	{
 #ifdef Q_OS_WIN32
 		ui.Label_Intel_Mac_GPU_Status->setText( tr(
-			"AMD GPU detected. Metal passthrough needs QEMU on bare-metal Linux with VFIO — "
-			"WSLg can accelerate Linux apps but cannot PCIe-assign this GPU into the guest. "
-			"Software VMware SVGA remains the working default here. "
-			"Saved passthrough settings are kept but cannot be changed here." ) );
+			"AMD GPU detected. Metal PCIe passthrough needs bare-metal Linux VFIO.\n"
+			"For hardware-accelerated macOS on Windows, use the Reims (reims3d) target "
+			"under WSL — AMD and NVIDIA GPUs both work via WSLg Vulkan.\n"
+			"Saved VFIO settings are kept but cannot be changed here." ) );
 #else
 		ui.Label_Intel_Mac_GPU_Status->setText( tr(
 			"AMD GPU detected, but PCIe passthrough is not available in this environment "
-			"(WSL or no host PCI). Use bare-metal Linux for Metal. "
-			"Saved passthrough settings are kept but cannot be changed here." ) );
+			"(WSL or no host PCI). Use bare-metal Linux for Metal VFIO, or Reims + Vulkan." ) );
 #endif
-		// Do not clear the checkbox — keep stored intent visible while disabled (PR #2 / Qodo)
 	}
 }
 

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -136,6 +136,11 @@ class Main_Window: public QMainWindow
 		void on_actionCreate_Shell_Script_triggered();
 		void on_actionShow_QEMU_Error_Log_Window_triggered();
 		void slot_iOS_Firmware_Tool_triggered();
+		void slot_Apple_SoC_Restore_triggered();
+		void Maybe_Prompt_WSL_Config_On_Boot();
+		void Build_Apple_SoC_Inferno_Ui();
+		void Apply_Apple_SoC_Fields_To_VM( Virtual_Machine *vm );
+		void Load_Apple_SoC_Fields_From_VM( const Virtual_Machine *vm );
 		
 		void on_Tabs_currentChanged( int index );
 		
@@ -371,6 +376,15 @@ class Main_Window: public QMainWindow
 		/** True while Start() runs under the busy dialog — do not attach SPICE yet. */
 		bool Session_Block_During_Start;
 		bool GPU_Scan_Busy;
+
+		QLineEdit *Edit_Apple_Trustcache;
+		QLineEdit *Edit_Apple_Ticket;
+		QLineEdit *Edit_Apple_SEP_FW;
+		QLineEdit *Edit_Apple_SEP_ROM;
+		QLineEdit *Edit_Apple_IPSW;
+		QLineEdit *Edit_Apple_USB_Conn_Addr;
+		QComboBox *CB_Apple_USB_Conn_Type;
+		QSpinBox *SB_Apple_USB_Conn_Port;
 
 		QSystemTrayIcon *Tray_Icon;
 		QAction *Act_Tray_Show;

--- a/src/System_Info.cpp
+++ b/src/System_Info.cpp
@@ -3783,6 +3783,22 @@ bool System_Info::Has_AMD_Display_GPU()
 	return false;
 }
 
+bool System_Info::Has_NVIDIA_Display_GPU()
+{
+	const QList<Host_GPU> &list = All_Host_GPU;
+	for( int i = 0; i < list.count(); ++i )
+	{
+		if( list[i].Is_Display && list[i].Vendor == QLatin1String( "NVIDIA" ) )
+			return true;
+	}
+	return false;
+}
+
+bool System_Info::Has_WSL_Vulkan_GPU()
+{
+	return Has_AMD_Display_GPU() || Has_NVIDIA_Display_GPU();
+}
+
 QString System_Info::Suggest_AMD_Audio_For( const QString &display_pci_address )
 {
 	const QString bdf = display_pci_address.trimmed();

--- a/src/System_Info.h
+++ b/src/System_Info.h
@@ -101,6 +101,9 @@ class System_Info
 		static bool Host_GPU_Was_Scanned();
 		static const QList<Host_GPU> &Get_Host_GPU_List();
 		static bool Has_AMD_Display_GPU();
+		static bool Has_NVIDIA_Display_GPU();
+		/** AMD or NVIDIA display GPU — Reims/WSL Vulkan acceleration candidates. */
+		static bool Has_WSL_Vulkan_GPU();
 		/** Native Linux with PCI (not Windows, not WSL). Required for vfio-pci into QEMU. */
 		static bool Host_Supports_PCI_Passthrough();
 		static bool Host_Is_WSL();

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -24,8 +24,8 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#define CURRENT_AQEMU_VERSION "1.1.0"
-#define CURRENT_AQEMU_RELEASE_DATE "2026-07-29"
+#define CURRENT_AQEMU_VERSION "1.3.0"
+#define CURRENT_AQEMU_RELEASE_DATE "2026-08-08"
 
 #include <functional>
 #include <QString>

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -10195,6 +10195,23 @@ bool Virtual_Machine::Start_impl()
 		}
 	}
 
+	if( AQ_Is_Apple_SoC_VM( this ) )
+	{
+		QString vm_dir = QFileInfo( Get_VM_XML_File_Path() ).absolutePath();
+		if( vm_dir.isEmpty() )
+			vm_dir = QDir::currentPath();
+		QString img_err;
+		if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_dir, &img_err ) )
+		{
+			AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+				img_err.isEmpty()
+					? tr( "Failed to create Apple SoC disk images." )
+					: img_err, false );
+			Start_Snapshot_Tag = "";
+			return false;
+		}
+	}
+
 	#ifdef Q_OS_WIN32
 	// Prefer WSL/KVM for Intel macOS when enabled globally or on this VM.
 	// Reims vGPU always requires Linux qemu-system-reims3d (Windows PE has no reims-vgpu-pci).
@@ -10206,22 +10223,6 @@ bool Virtual_Machine::Start_impl()
 		const bool is_applesoc = AQ_Is_Apple_SoC_VM( this );
 		if( is_reims || is_applesoc )
 			Launch_Via_WSL = true;
-		if( is_applesoc )
-		{
-			QString vm_dir = QFileInfo( Get_VM_XML_File_Path() ).absolutePath();
-			if( vm_dir.isEmpty() )
-				vm_dir = QDir::currentPath();
-			QString img_err;
-			if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_dir, &img_err ) )
-			{
-				AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
-					img_err.isEmpty()
-						? tr( "Failed to create Apple SoC disk images." )
-						: img_err, false );
-				Start_Snapshot_Tag = "";
-				return false;
-			}
-		}
 		if( Launch_Via_WSL || ( Intel_MacOS_Profile && global_wsl ) )
 		{
 			const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -7037,7 +7037,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	else
 		props << "accel="+VM::Accel_To_String( Machine_Accelerator );
 	#else
-	if( legacy_force_tcg || Machine_Accelerator == VM::TCG )
+	if( apple_soc )
+		use_separate_tcg_accel = true; // Inferno is cross-arch TCG on x86 Linux hosts too
+	else if( legacy_force_tcg || Machine_Accelerator == VM::TCG )
 		use_separate_tcg_accel = true;
 	else if( want_native_accel )
 		props << "accel=kvm:tcg";
@@ -9051,7 +9053,11 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	}
 
 	if( AQ_Is_Apple_SoC_VM( this ) )
-		Args << AQ_Build_Apple_SoC_Extra_Args( this, Build_QEMU_Args_for_Script_Mode, Launch_Via_WSL );
+	{
+		// Preview/script must not create 32GiB images; Start_impl ensures them first.
+		Args << AQ_Build_Apple_SoC_Extra_Args(
+			this, Build_QEMU_Args_for_Script_Mode, Launch_Via_WSL, false, nullptr );
+	}
 	
 	// Use ROM File
 	if( Use_ROM_File )
@@ -10200,6 +10206,22 @@ bool Virtual_Machine::Start_impl()
 		const bool is_applesoc = AQ_Is_Apple_SoC_VM( this );
 		if( is_reims || is_applesoc )
 			Launch_Via_WSL = true;
+		if( is_applesoc )
+		{
+			QString vm_dir = QFileInfo( Get_VM_XML_File_Path() ).absolutePath();
+			if( vm_dir.isEmpty() )
+				vm_dir = QDir::currentPath();
+			QString img_err;
+			if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_dir, &img_err ) )
+			{
+				AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+					img_err.isEmpty()
+						? tr( "Failed to create Apple SoC disk images." )
+						: img_err, false );
+				Start_Snapshot_Tag = "";
+				return false;
+			}
+		}
 		if( Launch_Via_WSL || ( Intel_MacOS_Profile && global_wsl ) )
 		{
 			const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
@@ -10671,17 +10693,34 @@ bool Virtual_Machine::Start_impl()
 				QStringList test_args;
 				if( ! distro.trimmed().isEmpty() )
 					test_args << QStringLiteral( "-d" ) << distro.trimmed();
-				test_args << QStringLiteral( "-e" ) << QStringLiteral( "test" )
-				          << QStringLiteral( "-x" ) << linux_qemu;
+				// Absolute/relative paths: test -x. Bare command names: PATH lookup.
+				const bool path_lookup = ! linux_qemu.contains( QLatin1Char( '/' ) );
+				if( path_lookup )
+				{
+					test_args << QStringLiteral( "-e" ) << QStringLiteral( "sh" )
+					          << QStringLiteral( "-c" )
+					          << QStringLiteral( "command -v -- \"$1\" >/dev/null" )
+					          << QStringLiteral( "sh" ) << linux_qemu;
+				}
+				else
+				{
+					test_args << QStringLiteral( "-e" ) << QStringLiteral( "test" )
+					          << QStringLiteral( "-x" ) << linux_qemu;
+				}
 				QProcess test_proc;
 				test_proc.start( QStringLiteral( "wsl.exe" ), test_args );
 				if( ! test_proc.waitForFinished( 10000 ) || test_proc.exitCode() != 0 )
 				{
 					AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
-						tr( "Linux Inferno binary not found in WSL:\n%1\n\n"
-						    "Install qemu-system-applesoc into your WSL distro "
-						    "(default /usr/local/bin/qemu-system-applesoc)." )
-							.arg( linux_qemu ), false );
+						path_lookup
+							? tr( "Linux Inferno binary not found on WSL PATH:\n%1\n\n"
+							      "Install qemu-system-applesoc or set an absolute path in "
+							      "Advanced Settings ? Apple SoC binary in WSL." )
+								.arg( linux_qemu )
+							: tr( "Linux Inferno binary not found or not executable in WSL:\n%1\n\n"
+							      "Install qemu-system-applesoc into your WSL distro "
+							      "(default /usr/local/bin/qemu-system-applesoc)." )
+								.arg( linux_qemu ), false );
 					Start_Snapshot_Tag = "";
 					return false;
 				}

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -62,6 +62,7 @@
 #include "Utils.h"
 #include "WSL_Launch.h"
 #include "WSL_Wizard_Window.h"
+#include "Apple_SoC_Support.h"
 #include "Emulator_Control_Window.h"
 #include "System_Info.h"
 #include "QEMU_Probe_Catalog.h"
@@ -310,6 +311,16 @@ Virtual_Machine::Virtual_Machine( const Virtual_Machine &vm )
 	this->GPU_Audio_PCI_Address = vm.Get_GPU_Audio_PCI_Address();
 	this->GPU_ROM_File = vm.Get_GPU_ROM_File();
 	this->GPU_Passthrough_Multifunction = vm.Use_GPU_Passthrough_Multifunction();
+	this->Apple_SoC_Profile = vm.Use_Apple_SoC_Profile();
+	this->Apple_Trustcache_Path = vm.Get_Apple_Trustcache_Path();
+	this->Apple_Ticket_Path = vm.Get_Apple_Ticket_Path();
+	this->Apple_SEP_FW_Path = vm.Get_Apple_SEP_FW_Path();
+	this->Apple_SEP_ROM_Path = vm.Get_Apple_SEP_ROM_Path();
+	this->Apple_IPSW_Path = vm.Get_Apple_IPSW_Path();
+	this->Apple_USB_Conn_Type = vm.Get_Apple_USB_Conn_Type();
+	this->Apple_USB_Conn_Addr = vm.Get_Apple_USB_Conn_Addr();
+	this->Apple_USB_Conn_Port = vm.Get_Apple_USB_Conn_Port();
+	this->Apple_SoC_Image_Paths = vm.Get_Apple_SoC_Image_Paths();
 
 	this->Enable_KVM = vm.Use_KVM();
 	this->KVM_IRQChip = vm.Use_KVM_IRQChip();
@@ -581,6 +592,16 @@ void Virtual_Machine::Shared_Constructor()
 	GPU_Audio_PCI_Address = "";
 	GPU_ROM_File = "";
 	GPU_Passthrough_Multifunction = true;
+	Apple_SoC_Profile = false;
+	Apple_Trustcache_Path.clear();
+	Apple_Ticket_Path.clear();
+	Apple_SEP_FW_Path.clear();
+	Apple_SEP_ROM_Path.clear();
+	Apple_IPSW_Path.clear();
+	Apple_USB_Conn_Type.clear();
+	Apple_USB_Conn_Addr.clear();
+	Apple_USB_Conn_Port = 8030;
+	Apple_SoC_Image_Paths.clear();
 
 	Enable_KVM = true;
 	KVM_IRQChip = false;
@@ -1064,6 +1085,16 @@ Virtual_Machine &Virtual_Machine::operator=( const Virtual_Machine &vm )
 	GPU_Audio_PCI_Address = vm.Get_GPU_Audio_PCI_Address();
 	GPU_ROM_File = vm.Get_GPU_ROM_File();
 	GPU_Passthrough_Multifunction = vm.Use_GPU_Passthrough_Multifunction();
+	Apple_SoC_Profile = vm.Use_Apple_SoC_Profile();
+	Apple_Trustcache_Path = vm.Get_Apple_Trustcache_Path();
+	Apple_Ticket_Path = vm.Get_Apple_Ticket_Path();
+	Apple_SEP_FW_Path = vm.Get_Apple_SEP_FW_Path();
+	Apple_SEP_ROM_Path = vm.Get_Apple_SEP_ROM_Path();
+	Apple_IPSW_Path = vm.Get_Apple_IPSW_Path();
+	Apple_USB_Conn_Type = vm.Get_Apple_USB_Conn_Type();
+	Apple_USB_Conn_Addr = vm.Get_Apple_USB_Conn_Addr();
+	Apple_USB_Conn_Port = vm.Get_Apple_USB_Conn_Port();
+	Apple_SoC_Image_Paths = vm.Get_Apple_SoC_Image_Paths();
 
 	Enable_KVM = vm.Use_KVM();
 	KVM_IRQChip = vm.Use_KVM_IRQChip();
@@ -3548,6 +3579,43 @@ bool Virtual_Machine::Create_VM_File( const QString &file_name, bool template_mo
 	VM_Element.appendChild( Dom_Element );
 	Dom_Text = New_Dom_Document.createTextNode( GPU_Passthrough_Multifunction ? "true" : "false" );
 	Dom_Element.appendChild( Dom_Text );
+
+	Dom_Element = New_Dom_Document.createElement( "Apple_SoC_Profile" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_SoC_Profile ? "true" : "false" );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_Trustcache_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_Trustcache_Path );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_Ticket_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_Ticket_Path );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_SEP_FW_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_SEP_FW_Path );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_SEP_ROM_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_SEP_ROM_Path );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_IPSW_Path" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_IPSW_Path );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_USB_Conn_Type" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_USB_Conn_Type );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_USB_Conn_Addr" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( Apple_USB_Conn_Addr );
+	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_USB_Conn_Port" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( QString::number( Apple_USB_Conn_Port > 0 ? Apple_USB_Conn_Port : 8030 ) );
+	Dom_Element.appendChild( Dom_Text );
 	
 	// Additional Arguments
 	Dom_Element = New_Dom_Document.createElement( "Additional_Args" );
@@ -4292,7 +4360,7 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 				if( ! remapped )
 				{
 					const QFileInfo icon_fi( Icon_Path );
-					// Absolute paths (esp. Windows C:/...) must not be prefixed ù
+					// Absolute paths (esp. Windows C:/...) must not be prefixed -
 					// old code did data_folder + absolute and blanked the list icon.
 					if( ! icon_fi.isAbsolute() )
 					{
@@ -5388,6 +5456,20 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 				const QString mf = Child_Element.firstChildElement( "GPU_Passthrough_Multifunction" ).text();
 				GPU_Passthrough_Multifunction = ( mf.isEmpty() || mf == QLatin1String( "true" ) );
 			}
+			Apple_SoC_Profile = ( Child_Element.firstChildElement( "Apple_SoC_Profile" ).text() == "true" ) ||
+				Computer_Type.contains( QLatin1String( "applesoc" ), Qt::CaseInsensitive );
+			Apple_Trustcache_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_Trustcache_Path" ).text() );
+			Apple_Ticket_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_Ticket_Path" ).text() );
+			Apple_SEP_FW_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_SEP_FW_Path" ).text() );
+			Apple_SEP_ROM_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_SEP_ROM_Path" ).text() );
+			Apple_IPSW_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_IPSW_Path" ).text() );
+			Apple_USB_Conn_Type = Child_Element.firstChildElement( "Apple_USB_Conn_Type" ).text().trimmed();
+			Apple_USB_Conn_Addr = Child_Element.firstChildElement( "Apple_USB_Conn_Addr" ).text().trimmed();
+			{
+				bool ok = false;
+				const int p = Child_Element.firstChildElement( "Apple_USB_Conn_Port" ).text().toInt( &ok );
+				Apple_USB_Conn_Port = ( ok && p > 0 ) ? p : 8030;
+			}
 			
 			// Enable KVM
 			Enable_KVM = ! (Child_Element.firstChildElement("Enable_KVM").text() == "false" );
@@ -5660,7 +5742,7 @@ VM_Native_Storage_Device Virtual_Machine::Load_VM_Native_Storage_Device( const Q
 	else
 	{
 		AQWarning( "VM_Native_Storage_Device Virtual_Machine::Load_VM_Native_Storage_Device( const QDomElement &Second_Element ) const",
-		           QStringLiteral( "Unknown Media \"%1\" ù treating as Disk" ).arg( media_str ) );
+		           QStringLiteral( "Unknown Media \"%1\" - treating as Disk" ).arg( media_str ) );
 		tmp_device.Set_Media( VM::DM_Disk );
 	}
 	
@@ -6107,7 +6189,7 @@ static quint16 Allocate_Embedded_Monitor_Port( int embedded_display_port, quint1
 		{
 			return candidate;
 		}
-		candidate = Find_Free_TCP_Port( 0 ); // OS ephemeral ù avoids reserved ranges
+		candidate = Find_Free_TCP_Port( 0 ); // OS ephemeral - avoids reserved ranges
 	}
 
 	candidate = Find_Free_TCP_Port( 0 );
@@ -6187,7 +6269,7 @@ static bool Media_Is_Bootable_Now( const Virtual_Machine &vm, VM::Boot_Device ty
 				if( d.Get_Enabled() && ! p.isEmpty() && QFile::exists( p ) )
 					return true;
 			}
-			// Native / Device Manager extra storage (virtio, NVMe, ù)
+			// Native / Device Manager extra storage (virtio, NVMe, -)
 			const QList<VM_Native_Storage_Device> &extra = vm.Get_Storage_Devices_List();
 			for( int i = 0; i < extra.count(); ++i )
 			{
@@ -6519,7 +6601,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// CPU Model
 	// TCG aarch64 / Win11 ARM: -cpu max,pauth-impdef=on (PAuth without full crypto cost).
 	// KVM on ARM hosts: -cpu host. Bare -cpu max without pauth-impdef is too slow under TCG.
-	// Win95/98 (Force_TCG): period CPU ù modern "max"/"host" hangs at splash under WHPX/TCG.
+	// Win95/98 (Force_TCG): period CPU - modern "max"/"host" hangs at splash under WHPX/TCG.
 	{
 		QString cpu_arg;
 		if( ! CPU_Type.trimmed().isEmpty() )
@@ -6547,7 +6629,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 
 		if( Force_TCG )
 		{
-			// pentium2 is x86-only ù never rewrite POWER/SPARC/etc CPUs.
+			// pentium2 is x86-only - never rewrite POWER/SPARC/etc CPUs.
 			const bool is_x86_guest =
 				Computer_Type.contains( QLatin1String( "x86_64" ), Qt::CaseInsensitive ) ||
 				Computer_Type.contains( QLatin1String( "i386" ), Qt::CaseInsensitive );
@@ -6707,7 +6789,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// Effective machine type. aarch64/arm/riscv have no QEMU default ? must pass virt
 	// (matches win11-pi5-kiosk: -M virt,accel=kvm).
 	QString effective_machine = Machine_Type;
-	// qemu-system-ppc64 with an empty -M defaults to pseries (SLOF) ù fine for AIX,
+	// qemu-system-ppc64 with an empty -M defaults to pseries (SLOF) - fine for AIX,
 	// catastrophic for classic Mac OS X if the user left Machine blank after a bad import.
 	// qemu-system-ppc defaults to g3beige; prefer mac99 (New World / OS X era).
 	if( effective_machine.isEmpty() &&
@@ -6845,7 +6927,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 		else if( !is_reims_vgpu && effective_video != "none" )
 		{
-			// Arbitrary display device from -device help / probe catalog (ati-vga, sm501, ù)
+			// Arbitrary display device from -device help / probe catalog (ati-vga, sm501, -)
 			Args << "-device" << effective_video;
 		}
 	}
@@ -6864,7 +6946,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-vga" << "none";
 		else if( Intel_MacOS_Profile && GPU_Passthrough && ! GPU_PCI_Address.trimmed().isEmpty() )
 		{
-			// Real AMD dGPU via VFIO ù no emulated VGA.
+			// Real AMD dGPU via VFIO - no emulated VGA.
 			Args << "-vga" << "none";
 		}
 		else if( Intel_MacOS_Profile &&
@@ -6891,19 +6973,27 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// (putting it on -machine causes: Property 'virt-*.thread' not found).
 	Args << "-machine";
 	QStringList props;
-	if( ! effective_machine.isEmpty() )
-		props << effective_machine;
-
-	// GICv3 + ITS + highmem for modern aarch64 guests (Win11 ARM / Linux virt).
-	// Explicit gic-version=3 (not max) so TCG on x86 never silently falls back to GICv2.
-	if( is_virt_arch &&
-		( Computer_Type.contains( "aarch64", Qt::CaseInsensitive ) ||
-		  Computer_Type.contains( "qemu-system-arm", Qt::CaseInsensitive ) ) &&
-		effective_machine.contains( QLatin1String( "virt" ), Qt::CaseInsensitive ) )
+	const bool apple_soc = AQ_Is_Apple_SoC_VM( this );
+	if( apple_soc )
 	{
-		props << QStringLiteral( "gic-version=3" );
-		props << QStringLiteral( "highmem=on" );
-		props << QStringLiteral( "its=on" );
+		props << AQ_Build_Apple_SoC_Machine_Props( this, Launch_Via_WSL );
+	}
+	else
+	{
+		if( ! effective_machine.isEmpty() )
+			props << effective_machine;
+
+		// GICv3 + ITS + highmem for modern aarch64 guests (Win11 ARM / Linux virt).
+		// Explicit gic-version=3 (not max) so TCG on x86 never silently falls back to GICv2.
+		if( is_virt_arch &&
+			( Computer_Type.contains( "aarch64", Qt::CaseInsensitive ) ||
+			  Computer_Type.contains( "qemu-system-arm", Qt::CaseInsensitive ) ) &&
+			effective_machine.contains( QLatin1String( "virt" ), Qt::CaseInsensitive ) )
+		{
+			props << QStringLiteral( "gic-version=3" );
+			props << QStringLiteral( "highmem=on" );
+			props << QStringLiteral( "its=on" );
+		}
 	}
 
 	bool use_separate_tcg_accel = false;
@@ -6915,9 +7005,11 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// UI "TCG" / Force_TCG / cross-arch must win. Never upgrade TCG?KVM/WHPX silently,
 	// and never force KVM just because Launch_Via_WSL is set (PPC/ARM on x86 WSL).
 	const bool want_native_accel =
-		( Machine_Accelerator == VM::KVM ) && ! legacy_force_tcg && is_x86_guest;
+		( Machine_Accelerator == VM::KVM ) && ! legacy_force_tcg && is_x86_guest && ! apple_soc;
 	#ifdef Q_OS_WIN32
-	if( Launch_Via_WSL && ! is_virt_arch )
+	if( apple_soc )
+		use_separate_tcg_accel = true; // Inferno is TCG on x86 hosts (even under WSL)
+	else if( Launch_Via_WSL && ! is_virt_arch )
 	{
 		// Linux QEMU inside WSL: KVM only when the UI asked for KVM, guest is x86,
 		// and /dev/kvm is writable. Otherwise honor TCG (e.g. Mac OS X PPC).
@@ -6934,7 +7026,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		use_separate_tcg_accel = true;
 	else if( ! is_x86_guest || Machine_Accelerator == VM::TCG )
 		// WHPX/HAX only accelerate x86. Also: selecting TCG in the UI must mean TCG
-		// (do not silently map it to whpx:hax:tcg ù that is what "KVM" means on Windows).
+		// (do not silently map it to whpx:hax:tcg - that is what "KVM" means on Windows).
 		use_separate_tcg_accel = true;
 	else if( want_native_accel )
 		// Prefer Hyper-V WHPX (or HAX) for x86; fall back to TCG. Pure TCG makes
@@ -6974,8 +7066,8 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	Args << props.join(",");
 
 	// TCG: multi-thread + larger TB cache (Gemini/Linaro tips). tb-size is an -accel prop, not -tb-size.
-	// Legacy Win9x (Force_TCG): thread=single ù multi-thread TCG also breaks splash?desktop.
-	// PowerPC (and other non-MTTCG guests) warn/break with thread=multi ù use single.
+	// Legacy Win9x (Force_TCG): thread=single - multi-thread TCG also breaks splash?desktop.
+	// PowerPC (and other non-MTTCG guests) warn/break with thread=multi - use single.
 	if( use_separate_tcg_accel )
 	{
 		const bool no_mttcg =
@@ -7060,7 +7152,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-no-fd-bootchk";
 	}
 	
-	// No ACPI ù only pass -no-acpi if target explicitly advertises -no-acpi and guest ACPI is disabled.
+	// No ACPI - only pass -no-acpi if target explicitly advertises -no-acpi and guest ACPI is disabled.
 	const QString qemu_target_name = Current_Emulator_Devices.System.QEMU_Name.trimmed().toLower();
 	const bool target_supports_no_acpi_flag = Current_Emulator_Devices.PSO_No_ACPI &&
 	                                         ! qemu_target_name.contains( QLatin1String( "reimsvgpu" ) ) &&
@@ -7136,7 +7228,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 							QString("Image \"%1\" doesn't exists!").arg(FD0.Get_File_Name()) );
 			}
 		}
-		// virt/pseries/etc: classic floppy not supported ù skip
+		// virt/pseries/etc: classic floppy not supported - skip
 	}
 	else if( ! no_pc_fdd_ide && embedded_session )
 	{
@@ -7209,7 +7301,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			attach_cdrom = false;
 	}
 
-	// Intel macOS Recovery/installer ISO is attached separately ù do not also take IDE index 2.
+	// Intel macOS Recovery/installer ISO is attached separately - do not also take IDE index 2.
 	if( mac_recovery_active && attach_cdrom )
 	{
 		const QString cd = AQ_Normalize_File_Path( CD_ROM.Get_File_Name() );
@@ -7261,7 +7353,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		else if( is_next_cube )
 		{
 			// NeXT Cube has onboard ESP SCSI (block_default_type=IF_SCSI).
-			// Do NOT invent virtio-scsi-pci ù that device does not exist on m68k.
+			// Do NOT invent virtio-scsi-pci - that device does not exist on m68k.
 			// Keep CD off SCSI ID 0: NeXT `bsd` / default sd boots unit 0 (the HD).
 			if( QFile::exists( CD_ROM.Get_File_Name() ) || Build_QEMU_Args_for_Tab_Info )
 			{
@@ -7276,7 +7368,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 		else if( no_pc_fdd_ide && ! is_virt_arch )
 		{
-			// pSeries / PowerNV: no IDE ù present CD on virtio-scsi when a real ISO is set.
+			// pSeries / PowerNV: no IDE - present CD on virtio-scsi when a real ISO is set.
 			if( QFile::exists( CD_ROM.Get_File_Name() ) || Build_QEMU_Args_for_Tab_Info )
 			{
 				has_virt_scsi = true;
@@ -7422,7 +7514,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	}
 
 	// Recovery / installer on same AHCI as OpenCore (OSX-KVM style).
-	// MIST/Pyenb "*.iso" = APM+HFS disk images ù must be ide-hd, not ide-cd.
+	// MIST/Pyenb "*.iso" = APM+HFS disk images - must be ide-hd, not ide-cd.
 	// With OpenPartitionDxe present, attach the whole APM disk (no offset) so the
 	// kernel can re-find the same volume UUID after ExitBootServices.
 	// Fallback: raw HFS offset when PartitionDxe prep failed.
@@ -7496,7 +7588,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
         else if( HDA.Get_Native_Mode() )
         {
             VM_Native_Storage_Device native_hda = HDA.Get_Native_Device();
-			// aarch64/arm/riscv virt: never emit AHCI/IDE ù UEFI cannot boot the
+			// aarch64/arm/riscv virt: never emit AHCI/IDE - UEFI cannot boot the
 			// guest disk and falls through to the USB installer ("USB HARDDRIVE").
 			if( is_virt_arch )
 			{
@@ -7750,9 +7842,9 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	//      (further) problems ...
 	Args << StorageArgs;
 
-	// Boot Device ù PC BIOS only. aarch64/arm/riscv UEFI uses bootindex on devices.
+	// Boot Device - PC BIOS only. aarch64/arm/riscv UEFI uses bootindex on devices.
 	//
-	// Windows + our bundled QEMU 11.0.2: ANY `-boot ù` argument triggers
+	// Windows + our bundled QEMU 11.0.2: ANY `-boot -` argument triggers
 	// STATUS_ACCESS_VIOLATION / HEAP_CORRUPTION (0xC0000005 / 0xC0000374) with
 	// empty stderr. System QEMU is fine; this is a Windows softmmu build bug.
 	// Skip `-boot` on Windows so VMs can actually start; SeaBIOS still boots
@@ -7769,7 +7861,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-boot" << bootStr;
 		else
 			AQWarning( "QStringList Virtual_Machine::Build_QEMU_Args()",
-					   "No bootable media in order list ù omitting -boot" );
+					   "No bootable media in order list - omitting -boot" );
 #endif
 	}
 	
@@ -7866,7 +7958,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 						break;
 				}
 				
-				// Create String ù never emit deprecated vlan= on modern QEMU (tobimensch#44/#58)
+				// Create String - never emit deprecated vlan= on modern QEMU (tobimensch#44/#58)
 				if( Network_Cards_Nativ[nc].Use_VLAN() && u_vlan &&
 				    Current_Emulator.Get_Version() == VM::Obsolete &&
 				    Network_Cards_Nativ[nc].Get_VLAN() > 0 )
@@ -8039,7 +8131,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				if( Network_Cards_Nativ[nc].Use_VHostFd() && u_vhostfd && Current_Emulator_Devices.PSO_Net_vhostfd )
 					nic_str += ",vhostfd=" + QString::number( Network_Cards_Nativ[nc].Get_VHostFd() );
 				
-				// Add to Args ù modern -netdev+device when enabled (qemu-doc ù Network)
+				// Add to Args - modern -netdev+device when enabled (qemu-doc - Network)
 				const VM::Network_Mode_Nativ ntype = Network_Cards_Nativ[nc].Get_Network_Type();
 				const bool can_modern =
 					Modern_Netdev &&
@@ -8050,7 +8142,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 				{
 					const QString nid = QStringLiteral( "aqnet%1" ).arg( nc );
 					QString nd = nic_str;
-					// nic_str is like "user,..." or "tap,..." without type prefix issues ù already has type
+					// nic_str is like "user,..." or "tap,..." without type prefix issues - already has type
 					const int comma = nd.indexOf( QLatin1Char( ',' ) );
 					QString ntype_s = comma > 0 ? nd.left( comma ) : nd;
 					QString rest = comma > 0 ? nd.mid( comma + 1 ) : QString();
@@ -8266,7 +8358,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			}
 		}
 		
-		// Network Tab. Redirections ù merge into one -net user (tobimensch#59)
+		// Network Tab. Redirections - merge into one -net user (tobimensch#59)
 		if( Use_Redirections )
 		{
 			QStringList hostfwds;
@@ -8308,7 +8400,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 	
-	// TFTP Prefix ù merge into existing user netdev when possible (tobimensch#19)
+	// TFTP Prefix - merge into existing user netdev when possible (tobimensch#19)
 	if( ! TFTP_Prefix.isEmpty() )
 	{
 		const QString tftp_part = Build_QEMU_Args_for_Script_Mode
@@ -8350,7 +8442,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-net" << ( "user," + smb_part );
 	}
 	
-	// Ports Tabs ù allocate a TCP serial for the session console without mutating saved config
+	// Ports Tabs - allocate a TCP serial for the session console without mutating saved config
 	Serial_Console_Port = 0;
 	QList<VM_Port> serial_for_args = Serial_Ports;
 	{
@@ -8494,7 +8586,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 					cdev = QStringLiteral( "braille,id=" ) + cid;
 					break;
 				case VM::PR_mon:
-					// Mux monitor onto this chardev after create ù fall back to legacy
+					// Mux monitor onto this chardev after create - fall back to legacy
 					cdev.clear();
 					break;
 				default:
@@ -8678,7 +8770,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			if( Build_QEMU_Args_for_Tab_Info == false ) System_Info::Update_Host_USB();
 			QList<VM_USB> all_usb = System_Info::Get_All_Host_USB();
 
-			// Auto-attach Xbox / USB gamepads when enabled (local list ù do not mutate USB_Ports)
+			// Auto-attach Xbox / USB gamepads when enabled (local list - do not mutate USB_Ports)
 			QList<VM_USB> ports = USB_Ports;
 			if( Pass_Through_Gamepads )
 			{
@@ -8803,7 +8895,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 							
 							usbControllerID = "ehci.0";
 						}
-						else // USB 1.1 ù modern QEMU uses usb-bus.0 (tobimensch#76/#111)
+						else // USB 1.1 - modern QEMU uses usb-bus.0 (tobimensch#76/#111)
 						{
 							usbControllerID = "usb-bus.0";
 						}
@@ -8832,7 +8924,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 						if( ! use_vid_pid && no_bus_path )
 						{
 							AQWarning( "QStringList Virtual_Machine::Build_QEMU_Args()",
-								QStringLiteral( "Skipping USB device %1 ù no bus/port or VID:PID" )
+								QStringLiteral( "Skipping USB device %1 - no bus/port or VID:PID" )
 									.arg( current_USB_Device.Get_Product_Name().isEmpty()
 										? current_USB_Device.Get_ID_Line()
 										: current_USB_Device.Get_Product_Name() ) );
@@ -8889,7 +8981,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 	
-	// Emulated USB gamepad (QEMU usb-gamepad ù maps host joystick when supported)
+	// Emulated USB gamepad (QEMU usb-gamepad - maps host joystick when supported)
 	if( Emulate_USB_Gamepad )
 	{
 		if( ! Args.contains( QStringLiteral( "-usb" ) ) )
@@ -8952,7 +9044,14 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			else
 				Args << "-append" << Kernel_ComLine;
 		}
+		else if( AQ_Is_Apple_SoC_VM( this ) )
+		{
+			Args << "-append" << AQ_Apple_SoC_Default_Append();
+		}
 	}
+
+	if( AQ_Is_Apple_SoC_VM( this ) )
+		Args << AQ_Build_Apple_SoC_Extra_Args( this, Build_QEMU_Args_for_Script_Mode, Launch_Via_WSL );
 	
 	// Use ROM File
 	if( Use_ROM_File )
@@ -9050,7 +9149,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 
-	// Apple SMC (Intel macOS) ù only emit OSK if the user supplied one (never invent a key)
+	// Apple SMC (Intel macOS) - only emit OSK if the user supplied one (never invent a key)
 	if( Intel_MacOS_Profile && Use_Apple_SMC_Flag && ! Apple_SMC_OSK.trimmed().isEmpty() )
 	{
 		QString osk = Apple_SMC_OSK;
@@ -9061,7 +9160,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	if( Intel_MacOS_Profile )
 		Args << "-smbios" << "type=2";
 
-	// AMD GPU VFIO passthrough (Metal) ù native Linux only; gated at Start_vm()
+	// AMD GPU VFIO passthrough (Metal) - native Linux only; gated at Start_vm()
 	if( Intel_MacOS_Profile && GPU_Passthrough && ! GPU_PCI_Address.trimmed().isEmpty() )
 	{
 		QString gpu_dev = QStringLiteral( "vfio-pci,host=%1" ).arg( GPU_PCI_Address.trimmed() );
@@ -9350,7 +9449,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	}
 	else if( embedded_session )
 	{
-		// Headless: no QEMU SDL/GTK chrome ù AQEMU owns the window
+		// Headless: no QEMU SDL/GTK chrome - AQEMU owns the window
 		Args << "-display" << "none";
 
 #ifdef Q_OS_WIN32
@@ -9380,7 +9479,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Embedded_Spice_Port = 0;
 		}
 
-		// VNC for LibVNC client ù bind a free TCP port (not a fixed display index)
+		// VNC for LibVNC client - bind a free TCP port (not a fixed display index)
 		if( Embedded_VNC_Port <= 0 )
 		{
 			const int first_vnc = Settings.value( "First_VNC_Port", "5910" ).toString().toInt();
@@ -9760,7 +9859,7 @@ QStringList Virtual_Machine::Build_Native_Device_Args( VM_Native_Storage_Device 
 				break;
 
 			case VM::DI_NVMe:
-				// SteamOS installer expects /dev/nvme0n1 ù needs -device nvme + serial
+				// SteamOS installer expects /dev/nvme0n1 - needs -device nvme + serial
 				opt << "if=none,id=" + vsname;
 				break;
 
@@ -10098,30 +10197,50 @@ bool Virtual_Machine::Start_impl()
 		const bool global_wsl = s.value( QStringLiteral( "WSL_Launch/Enabled" ), false ).toBool();
 		const bool is_reims =
 			Computer_Type.contains( QLatin1String( "reimsvgpu" ), Qt::CaseInsensitive );
-		if( is_reims )
+		const bool is_applesoc = AQ_Is_Apple_SoC_VM( this );
+		if( is_reims || is_applesoc )
 			Launch_Via_WSL = true;
 		if( Launch_Via_WSL || ( Intel_MacOS_Profile && global_wsl ) )
 		{
 			const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
-			// Fresh probe on start ù a prior cold-start timeout must not stick.
+			const QString wslUser = s.value( QStringLiteral( "WSL_Launch/Username" ), QString() ).toString();
+			if( ( is_reims || is_applesoc || Launch_Via_WSL ) &&
+			    ( distro.trimmed().isEmpty() || wslUser.trimmed().isEmpty() ||
+			      ! WSL_Is_Valid_Username( wslUser ) ) )
+			{
+				WSL_Wizard_Window wizard;
+				if( wizard.exec() != QDialog::Accepted )
+				{
+					AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+						tr( "WSL distro and username are required for this VM." ), false );
+					Start_Snapshot_Tag = "";
+					return false;
+				}
+			}
+			// Fresh probe on start - a prior cold-start timeout must not stick.
 			WSL_Clear_Probe_Cache();
 			if( WSL_Is_Available( true ) )
 			{
 				Launch_Via_WSL = true;
 				// Fix /dev/kvm permissions automatically (wsl -u root); no user commands.
-				if( ! WSL_Ensure_KVM_Access( distro ) )
+				if( ! WSL_Ensure_KVM_Access( s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString() ) )
 				{
 					AQWarning( "Virtual_Machine::Start_impl()",
-						"WSL /dev/kvm still not writable after automatic fix ù using TCG" );
+						"WSL /dev/kvm still not writable after automatic fix - using TCG" );
 				}
 			}
-			else if( is_reims )
+			else if( is_reims || is_applesoc )
 			{
 				AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
-					tr( "Reims vGPU requires WSL with the Linux binary "
-					    "/usr/local/bin/qemu-system-reims3d.\n\n"
-					    "The Windows qemu-system-reimsvgpu.exe build does not expose "
-					    "reims-vgpu-pci and cannot accelerate Metal/Vulkan." ), false );
+					is_applesoc
+						? tr( "Apple SoC / Inferno requires WSL with the Linux binary "
+						      "qemu-system-applesoc.\n\n"
+						      "Windows PE cannot use UNIX sockets for the companion USB remote "
+						      "needed by idevicerestore." )
+						: tr( "Reims vGPU requires WSL with the Linux binary "
+						      "/usr/local/bin/qemu-system-reims3d.\n\n"
+						      "The Windows qemu-system-reimsvgpu.exe build does not expose "
+						      "reims-vgpu-pci and cannot accelerate Metal/Vulkan." ), false );
 				Start_Snapshot_Tag = "";
 				return false;
 			}
@@ -10141,7 +10260,7 @@ bool Virtual_Machine::Start_impl()
 	if( QEMU_Process && QEMU_Process->state() != QProcess::NotRunning )
 	{
 		AQWarning( "bool Virtual_Machine::Start_impl()",
-		           "Previous QEMU process still running ù terminating it before restart" );
+		           "Previous QEMU process still running - terminating it before restart" );
 		QEMU_Process->kill();
 		if( ! QEMU_Process->waitForFinished( 5000 ) )
 		{
@@ -10468,7 +10587,7 @@ bool Virtual_Machine::Start_impl()
 					if( ! path_ok )
 					{
 						AQWarning( "bool Virtual_Machine::Start()",
-						           QString( "Skipping Reims3D sync ó unsafe WSL path: %1" ).arg( wsl_src ) );
+						           QString( "Skipping Reims3D sync - unsafe WSL path: %1" ).arg( wsl_src ) );
 					}
 					else
 					{
@@ -10495,7 +10614,7 @@ bool Virtual_Machine::Start_impl()
 							return p.exitStatus() == QProcess::NormalExit && p.exitCode() == 0;
 						};
 
-						// Never interpolate the path into sh -c ó pass as argv to cp/chmod.
+						// Never interpolate the path into sh -c - pass as argv to cp/chmod.
 						const bool copied = run_wsl_root( QStringList()
 							<< QStringLiteral( "cp" ) << QStringLiteral( "-f" )
 							<< wsl_src
@@ -10503,7 +10622,7 @@ bool Virtual_Machine::Start_impl()
 						const bool chmodded = copied && run_wsl_root( QStringList()
 							<< QStringLiteral( "chmod" ) << QStringLiteral( "+x" )
 							<< QStringLiteral( "/usr/local/bin/qemu-system-reims3d" ) );
-						// Optional firmware symlinks ó fixed script, no user-controlled path.
+						// Optional firmware symlinks - fixed script, no user-controlled path.
 						if( chmodded )
 						{
 							run_wsl_root( QStringList()
@@ -10544,6 +10663,27 @@ bool Virtual_Machine::Start_impl()
 						Start_Snapshot_Tag = "";
 						return false;
 					}
+				}
+			}
+			else if( AQ_Is_Apple_SoC_VM( this ) )
+			{
+				linux_qemu = AQ_Apple_SoC_WSL_Qemu_Binary();
+				QStringList test_args;
+				if( ! distro.trimmed().isEmpty() )
+					test_args << QStringLiteral( "-d" ) << distro.trimmed();
+				test_args << QStringLiteral( "-e" ) << QStringLiteral( "test" )
+				          << QStringLiteral( "-x" ) << linux_qemu;
+				QProcess test_proc;
+				test_proc.start( QStringLiteral( "wsl.exe" ), test_args );
+				if( ! test_proc.waitForFinished( 10000 ) || test_proc.exitCode() != 0 )
+				{
+					AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
+						tr( "Linux Inferno binary not found in WSL:\n%1\n\n"
+						    "Install qemu-system-applesoc into your WSL distro "
+						    "(default /usr/local/bin/qemu-system-applesoc)." )
+							.arg( linux_qemu ), false );
+					Start_Snapshot_Tag = "";
+					return false;
 				}
 			}
 
@@ -10807,7 +10947,7 @@ void Virtual_Machine::Kill_Orphan_QEMU_Using_Disks()
 	}
 
 	// Launch-via-WSL: Linux qemu-system often survives after wsl.exe is killed.
-	// Match on file basenames (paths differ: D:\ù vs /mnt/d/ù).
+	// Match on file basenames (paths differ: D:\- vs /mnt/d/-).
 	if( ! Launch_Via_WSL )
 		return;
 
@@ -10822,7 +10962,7 @@ void Virtual_Machine::Kill_Orphan_QEMU_Using_Disks()
 	}
 	if( ! basenames.isEmpty() && WSL_Is_Available( false ) )
 	{
-		// Fixed-string match only (grep -F) ù never regex wildcards (PR #1 / Qodo)
+		// Fixed-string match only (grep -F) - never regex wildcards (PR #1 / Qodo)
 		QString hit_checks;
 		for( const QString &b : basenames )
 		{
@@ -11551,7 +11691,7 @@ void Virtual_Machine::Ensure_Windows_XP_Family_Defaults()
 		Set_Mouse_USB_Version( 1 );
 	}
 
-	// XP setup has no VirtIO drivers ù disk must be IDE or setup sees "no hard disks".
+	// XP setup has no VirtIO drivers - disk must be IDE or setup sees "no hard disks".
 	if( HDA.Get_Enabled() )
 	{
 		VM_Native_Storage_Device native = HDA.Get_Native_Device();
@@ -11643,7 +11783,7 @@ void Virtual_Machine::Ensure_ReactOS_Defaults()
 	if( Memory_Size < 1024 )
 		Set_Memory_Size( 1024 );
 
-	// Single AC97 only ù HDA / multiple cards can prevent boot (Installing ReactOS wiki).
+	// Single AC97 only - HDA / multiple cards can prevent boot (Installing ReactOS wiki).
 	VM::Sound_Cards audio;
 	audio.Audio_AC97 = true;
 	Set_Audio_Cards( audio );
@@ -12998,6 +13138,38 @@ bool Virtual_Machine::Use_GPU_Passthrough_Multifunction() const
 void Virtual_Machine::Use_GPU_Passthrough_Multifunction( bool use )
 {
 	GPU_Passthrough_Multifunction = use;
+}
+
+bool Virtual_Machine::Use_Apple_SoC_Profile() const { return Apple_SoC_Profile; }
+void Virtual_Machine::Use_Apple_SoC_Profile( bool use ) { Apple_SoC_Profile = use; }
+const QString &Virtual_Machine::Get_Apple_Trustcache_Path() const { return Apple_Trustcache_Path; }
+void Virtual_Machine::Set_Apple_Trustcache_Path( const QString &path ) { Apple_Trustcache_Path = AQ_Normalize_File_Path( path ); }
+const QString &Virtual_Machine::Get_Apple_Ticket_Path() const { return Apple_Ticket_Path; }
+void Virtual_Machine::Set_Apple_Ticket_Path( const QString &path ) { Apple_Ticket_Path = AQ_Normalize_File_Path( path ); }
+const QString &Virtual_Machine::Get_Apple_SEP_FW_Path() const { return Apple_SEP_FW_Path; }
+void Virtual_Machine::Set_Apple_SEP_FW_Path( const QString &path ) { Apple_SEP_FW_Path = AQ_Normalize_File_Path( path ); }
+const QString &Virtual_Machine::Get_Apple_SEP_ROM_Path() const { return Apple_SEP_ROM_Path; }
+void Virtual_Machine::Set_Apple_SEP_ROM_Path( const QString &path ) { Apple_SEP_ROM_Path = AQ_Normalize_File_Path( path ); }
+const QString &Virtual_Machine::Get_Apple_IPSW_Path() const { return Apple_IPSW_Path; }
+void Virtual_Machine::Set_Apple_IPSW_Path( const QString &path ) { Apple_IPSW_Path = AQ_Normalize_File_Path( path ); }
+const QString &Virtual_Machine::Get_Apple_USB_Conn_Type() const { return Apple_USB_Conn_Type; }
+void Virtual_Machine::Set_Apple_USB_Conn_Type( const QString &type ) { Apple_USB_Conn_Type = type.trimmed(); }
+const QString &Virtual_Machine::Get_Apple_USB_Conn_Addr() const { return Apple_USB_Conn_Addr; }
+void Virtual_Machine::Set_Apple_USB_Conn_Addr( const QString &addr ) { Apple_USB_Conn_Addr = addr.trimmed(); }
+int Virtual_Machine::Get_Apple_USB_Conn_Port() const { return Apple_USB_Conn_Port; }
+void Virtual_Machine::Set_Apple_USB_Conn_Port( int port ) { Apple_USB_Conn_Port = port; }
+QString Virtual_Machine::Get_Apple_SoC_Image_Path( const QString &name ) const
+{
+	return Apple_SoC_Image_Paths.value( name );
+}
+void Virtual_Machine::Set_Apple_SoC_Image_Path( const QString &name, const QString &path )
+{
+	if( name.trimmed().isEmpty() )
+		return;
+	if( path.trimmed().isEmpty() )
+		Apple_SoC_Image_Paths.remove( name );
+	else
+		Apple_SoC_Image_Paths.insert( name, AQ_Normalize_File_Path( path ) );
 }
 
 bool Virtual_Machine::Use_KVM() const

--- a/src/VM.h
+++ b/src/VM.h
@@ -28,6 +28,7 @@
 #include <QProcess>
 #include <QTcpSocket>
 #include <QFile>
+#include <QMap>
 
 #include "VM_Devices.h"
 #include "Error_Log_Window.h"
@@ -617,6 +618,30 @@ class Virtual_Machine: public QObject
 		void Set_GPU_ROM_File( const QString &path );
 		bool Use_GPU_Passthrough_Multifunction() const;
 		void Use_GPU_Passthrough_Multifunction( bool use );
+
+		/** ChefKiss Inferno Apple SoC (iOS) profile — multi-NS NVMe + SEP + USB remote. */
+		bool Use_Apple_SoC_Profile() const;
+		void Use_Apple_SoC_Profile( bool use );
+		const QString &Get_Apple_Trustcache_Path() const;
+		void Set_Apple_Trustcache_Path( const QString &path );
+		const QString &Get_Apple_Ticket_Path() const;
+		void Set_Apple_Ticket_Path( const QString &path );
+		const QString &Get_Apple_SEP_FW_Path() const;
+		void Set_Apple_SEP_FW_Path( const QString &path );
+		const QString &Get_Apple_SEP_ROM_Path() const;
+		void Set_Apple_SEP_ROM_Path( const QString &path );
+		const QString &Get_Apple_IPSW_Path() const;
+		void Set_Apple_IPSW_Path( const QString &path );
+		const QString &Get_Apple_USB_Conn_Type() const;
+		void Set_Apple_USB_Conn_Type( const QString &type );
+		const QString &Get_Apple_USB_Conn_Addr() const;
+		void Set_Apple_USB_Conn_Addr( const QString &addr );
+		int Get_Apple_USB_Conn_Port() const;
+		void Set_Apple_USB_Conn_Port( int port );
+		/** Optional override for a named Inferno image (root, firmware, …). */
+		QString Get_Apple_SoC_Image_Path( const QString &name ) const;
+		void Set_Apple_SoC_Image_Path( const QString &name, const QString &path );
+		const QMap<QString, QString> &Get_Apple_SoC_Image_Paths() const { return Apple_SoC_Image_Paths; }
 		
 		bool Use_KVM() const;
 		void Use_KVM( bool use );
@@ -951,6 +976,17 @@ class Virtual_Machine: public QObject
 		QString GPU_Audio_PCI_Address;
 		QString GPU_ROM_File;
 		bool GPU_Passthrough_Multifunction;
+
+		bool Apple_SoC_Profile;
+		QString Apple_Trustcache_Path;
+		QString Apple_Ticket_Path;
+		QString Apple_SEP_FW_Path;
+		QString Apple_SEP_ROM_Path;
+		QString Apple_IPSW_Path;
+		QString Apple_USB_Conn_Type;
+		QString Apple_USB_Conn_Addr;
+		int Apple_USB_Conn_Port;
+		QMap<QString, QString> Apple_SoC_Image_Paths;
 
 		bool Enable_KVM;
 		bool KVM_IRQChip;

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -54,6 +54,7 @@
 
 #include "Utils.h"
 #include "AQ_UI_Style.h"
+#include "Apple_SoC_Support.h"
 #include "WSL_Launch.h"
 #include "VM_Wizard_Window.h"
 #include "System_Info.h"
@@ -2245,6 +2246,7 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 		    os.contains( QLatin1String( "Apple Silicon" ), Qt::CaseInsensitive ) ||
 		    Selected_Target == QLatin1String( "applesoc" ) )
 		{
+			New_VM->Use_Apple_SoC_Profile( true );
 			New_VM->Set_Computer_Type( QStringLiteral( "qemu-system-applesoc" ) );
 			if( New_VM->Get_Machine_Type().isEmpty() || New_VM->Get_Machine_Type() == QLatin1String( "virt" ) )
 				New_VM->Set_Machine_Type( QStringLiteral( "t8030" ) );
@@ -2255,6 +2257,11 @@ void VM_Wizard_Window::Apply_Guest_Hardware_To_New_VM()
 			New_VM->Set_Video_Card( QStringLiteral( "std" ) );
 			New_VM->Set_Mouse_Type( QStringLiteral( "usb-tablet" ) );
 			New_VM->Use_USB_Hub( true );
+			New_VM->Use_Launch_Via_WSL( true );
+			New_VM->Set_Kernel_ComLine( AQ_Apple_SoC_Default_Append() );
+			New_VM->Set_Apple_USB_Conn_Type( QStringLiteral( "unix" ) );
+			New_VM->Set_Apple_USB_Conn_Addr( QStringLiteral( "/tmp/InfernoUSBRemote" ) );
+			New_VM->Set_Apple_USB_Conn_Port( 8030 );
 		}
 
 		if( qnx )
@@ -4867,6 +4874,8 @@ bool VM_Wizard_Window::Create_New_VM(bool simulate)
 	
 	if( Is_Windows11_ARM_Template() )
 		Apply_Windows11_ARM_Profile( simulate );
+	else if( Is_Apple_Silicon_Or_iOS_Template() )
+		Apply_Apple_SoC_Profile( simulate );
 	else if( Is_Intel_MacOS_Template() )
 		Apply_Intel_MacOS_Profile( simulate );
 	else if( New_VM->Get_Computer_Type().contains( "aarch64", Qt::CaseInsensitive ) ||
@@ -4945,14 +4954,15 @@ void VM_Wizard_Window::Update_Finish_Page_Guidance()
 	}
 	else if( Is_Apple_Silicon_Or_iOS_Template() )
 	{
-		help = tr( "<p><b>Apple Silicon / iOS (experimental)</b></p><ul>"
-			"<li>Uses <code>qemu-system-applesoc</code> (ChefKiss Inferno) with machines such as "
-			"<code>t8030</code> or <code>s8000</code>.</li>"
-			"<li>Supply a kernelcache and DeviceTree via the DeviceTree / Kernel fields on the VM "
-			"(not Additional Args).</li>"
-			"<li>AQEMU does not ship IPSW files, kernels, or DeviceTrees. Use "
-			"<b>File → iOS Firmware Tool</b> if you have <code>pyimg4</code> installed.</li>"
-			"<li>On x86 Windows hosts this is TCG-only and very slow.</li>"
+		help = tr( "<p><b>Apple SoC / iOS (Inferno) — AQEMU 1.3.0</b></p><ul>"
+			"<li>Uses Linux <code>qemu-system-applesoc</code> (ChefKiss Inferno). "
+			"On Windows this is forced through <b>WSL</b> (UNIX sockets / companion restore).</li>"
+			"<li>Set kernelcache, DeviceTree, trustcache, restore ticket, and SEP firmware "
+			"on the VM page. AQEMU creates the Inferno NVMe image set under the VM folder.</li>"
+			"<li>IPSW restore needs a <b>companion VM</b> first, then "
+			"<b>File → Apple SoC Restore</b> (patched <code>idevicerestore</code> in WSL). "
+			"See <a href=\"https://chefkiss.dev/ar/guides/inferno/companion-setup/\">Companion setup</a>.</li>"
+			"<li>Use <b>File → iOS Firmware Tool</b> to unpack IPSW / IM4P when needed.</li>"
 			"</ul>" );
 	}
 	else if( Selected_OS_Name.contains( "Reims", Qt::CaseInsensitive ) ||
@@ -4961,12 +4971,14 @@ void VM_Wizard_Window::Update_Finish_Page_Guidance()
 	         Selected_OS_Name.compare( QLatin1String( "macOS" ), Qt::CaseInsensitive ) == 0 ||
 	         Selected_OS_Name.compare( QLatin1String( "Darwin" ), Qt::CaseInsensitive ) == 0 )
 	{
-		help = tr( "<p><b>Intel macOS (experimental)</b></p><ul>"
+		help = tr( "<p><b>Intel macOS / Reims — AQEMU 1.3.0</b></p><ul>"
 			"<li>You must supply OpenCore boot disk, OVMF firmware, OSK, and install/system disks.</li>"
-			"<li>AQEMU does not ship Apple OS files or a default OSK.</li>"
-			"<li>Reims vGPU needs Linux <code>qemu-system-reims3d</code> under WSL — the Windows "
-			"<code>qemu-system-reimsvgpu.exe</code> helper does not expose <code>reims-vgpu-pci</code>.</li>"
-			"<li>On Windows, WHPX is used unless you enable Launch via WSL/KVM.</li>"
+			"<li><b>Reims vGPU</b> (hardware-accelerated Metal path) uses Linux "
+			"<code>qemu-system-reims3d</code> under <b>WSL</b> with host Vulkan — "
+			"<b>AMD and NVIDIA</b> GPUs on Windows via WSLg.</li>"
+			"<li>The Windows <code>qemu-system-reimsvgpu.exe</code> helper does not expose "
+			"<code>reims-vgpu-pci</code>.</li>"
+			"<li>AMD Metal <b>PCIe VFIO</b> remains bare-metal Linux only — not available on Windows.</li>"
 			"</ul>" );
 	}
 	else if( Selected_OS_Name == QLatin1String( "SteamOS" ) )
@@ -5149,6 +5161,44 @@ void VM_Wizard_Window::Apply_Windows11_ARM_Profile( bool simulate )
 	New_VM->Set_UEFI_VARS_File( vars_dest );
 	if( ! simulate )
 		Prepare_UEFI_VARS_File( vars_dest, qemu_bin );
+}
+
+void VM_Wizard_Window::Apply_Apple_SoC_Profile( bool simulate )
+{
+	QString vm_dir = Settings.value( "VM_Directory", "~" ).toString();
+	QString vm_base = Get_FS_Compatible_VM_Name( ui.Edit_VM_Name->text() );
+	const QString vm_folder = QDir( vm_dir ).filePath( vm_base );
+
+	New_VM->Use_Apple_SoC_Profile( true );
+	New_VM->Set_Computer_Type( QStringLiteral( "qemu-system-applesoc" ) );
+	if( New_VM->Get_Machine_Type().isEmpty() ||
+	    New_VM->Get_Machine_Type() == QLatin1String( "virt" ) )
+		New_VM->Set_Machine_Type( QStringLiteral( "t8030" ) );
+	New_VM->Set_CPU_Type( QStringLiteral( "max" ) );
+	if( New_VM->Get_Memory_Size() < 4096 )
+		New_VM->Set_Memory_Size( 4096 );
+	New_VM->Set_SMP_CPU_Count( 4 );
+	New_VM->Set_Video_Card( QStringLiteral( "std" ) );
+	New_VM->Set_Mouse_Type( QStringLiteral( "usb-tablet" ) );
+	New_VM->Use_USB_Hub( true );
+	New_VM->Use_Launch_Via_WSL( true );
+	New_VM->Set_Kernel_ComLine( AQ_Apple_SoC_Default_Append() );
+#ifdef Q_OS_WIN32
+	New_VM->Set_Apple_USB_Conn_Type( QStringLiteral( "unix" ) );
+	New_VM->Set_Apple_USB_Conn_Addr( QStringLiteral( "/tmp/InfernoUSBRemote" ) );
+	Settings.setValue( QStringLiteral( "WSL_Launch/Enabled" ), true );
+#else
+	New_VM->Set_Apple_USB_Conn_Type( QStringLiteral( "unix" ) );
+	New_VM->Set_Apple_USB_Conn_Addr( QStringLiteral( "/tmp/InfernoUSBRemote" ) );
+#endif
+	New_VM->Set_Apple_USB_Conn_Port( 8030 );
+
+	if( ! simulate )
+	{
+		QString err;
+		if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_folder, &err ) )
+			AQWarning( "VM_Wizard_Window::Apply_Apple_SoC_Profile", err );
+	}
 }
 
 void VM_Wizard_Window::Apply_Intel_MacOS_Profile( bool simulate )

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -122,6 +122,7 @@ class VM_Wizard_Window: public QDialog
 		void Build_Windows11_ARM_Page();
 		bool Is_Apple_Silicon_Or_iOS_Template() const;
 		bool Is_Intel_MacOS_Template() const;
+		void Apply_Apple_SoC_Profile( bool simulate );
 		void Apply_Intel_MacOS_Profile( bool simulate );
 		void Build_Intel_MacOS_Page();
 		void Show_Intel_MacOS_Page();

--- a/src/WSL_Launch.cpp
+++ b/src/WSL_Launch.cpp
@@ -369,7 +369,7 @@ static QString Escape_Qemu_Option_Commas( QString val )
 
 static QString Rewrite_Drive_File_Option( const QString &opt )
 {
-	// Rewrite file= / file.filename= path segments inside -drive / similar options
+	// Rewrite file= / file.filename= / Inferno machine path props inside -drive / -machine
 	QStringList parts = Split_Qemu_Option_Commas( opt );
 	for( int i = 0; i < parts.size(); ++i )
 	{
@@ -384,10 +384,23 @@ static QString Rewrite_Drive_File_Option( const QString &opt )
 			key == QLatin1String( "filename" ) ||
 			key == QLatin1String( "file.filename" ) ||
 			key.endsWith( QLatin1String( ".filename" ) ) ||
-			key.endsWith( QLatin1String( ".path" ) );
+			key.endsWith( QLatin1String( ".path" ) ) ||
+			key == QLatin1String( "trustcache" ) ||
+			key == QLatin1String( "ticket" ) ||
+			key == QLatin1String( "sep-fw" ) ||
+			key == QLatin1String( "sep-rom" ) ||
+			key == QLatin1String( "usb-conn-addr" );
 		if( ! is_path_key )
 			continue;
-		QString val = AQ_Normalize_File_Path( part.mid( eq + 1 ) );
+		QString val = part.mid( eq + 1 );
+		// Keep pure Linux unix socket paths as-is; convert Windows host paths.
+		if( key == QLatin1String( "usb-conn-addr" ) &&
+		    ( val.startsWith( QLatin1Char( '/' ) ) || val.contains( QLatin1Char( '.' ) ) ) &&
+		    ! val.contains( QLatin1Char( ':' ) ) && ! val.contains( QLatin1Char( '\\' ) ) )
+		{
+			continue;
+		}
+		val = AQ_Normalize_File_Path( val );
 		parts[i] = key + QLatin1Char( '=' ) + Escape_Qemu_Option_Commas( Windows_Path_To_WSL( val ) );
 	}
 	return parts.join( QLatin1Char( ',' ) );
@@ -425,7 +438,8 @@ QStringList Rewrite_Args_For_WSL( const QStringList &win_args )
 		}
 
 		if( a == QLatin1String( "-drive" ) || a == QLatin1String( "-blockdev" ) ||
-		    a == QLatin1String( "-fsdev" ) || a == QLatin1String( "-chardev" ) )
+		    a == QLatin1String( "-fsdev" ) || a == QLatin1String( "-chardev" ) ||
+		    a == QLatin1String( "-machine" ) )
 		{
 			out << a;
 			if( i + 1 < win_args.size() )

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -18,6 +18,7 @@
 iOS_Firmware_Tool_Window::iOS_Firmware_Tool_Window( QWidget *parent )
 	: QDialog( parent )
 	, Process( new QProcess( this ) )
+	, Last_Operation( Pending_Op::None )
 {
 	setWindowTitle( tr( "iOS Firmware Tool" ) );
 	resize( AQ_Px( 780, this ), AQ_Px( 560, this ) );
@@ -212,6 +213,7 @@ void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 	env.insert( QStringLiteral( "AQEMU_IPSW_PATH" ), ipsw );
 	env.insert( QStringLiteral( "AQEMU_IPSW_OUT" ), out_dir );
 	Process->setProcessEnvironment( env );
+	Last_Operation = Pending_Op::IpswExtract;
 	Process->start( QStringLiteral( "powershell.exe" ), QStringList()
 		<< QStringLiteral( "-NoProfile" )
 		<< QStringLiteral( "-NonInteractive" )
@@ -257,6 +259,8 @@ void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
 	}
 
 	Text_Console_Log->append( QString( "\nExecuting: %1 %2\n" ).arg( PyIMG4_Exe, args.join( " " ) ) );
+	Last_IM4P_Output = ( action == QLatin1String( "info" ) ) ? QString() : out_raw;
+	Last_Operation = Pending_Op::Im4pOp;
 	Process->start( PyIMG4_Exe, args );
 }
 
@@ -271,46 +275,63 @@ void iOS_Firmware_Tool_Window::On_Process_Output()
 void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::ExitStatus exitStatus )
 {
 	Q_UNUSED( exitStatus );
-	if( exitCode == 0 )
-	{
-		Text_Console_Log->append( tr( "\nTask completed successfully." ) );
-		const QString out_dir = Edit_Output_Dir->text().trimmed();
+	const Pending_Op op = Last_Operation;
+	Last_Operation = Pending_Op::None;
 
-		QString summary;
-		summary += QString( "Extraction Folder: %1\n" ).arg( out_dir );
-
-		QString dtb_found;
-		QDir d( out_dir + "/Firmware/all_flash" );
-		if( d.exists() )
-		{
-			// Prefer extracted DeviceTree (.dtb / .dec), never raw .im4p for -dtb.
-			const QStringList files = d.entryList(
-				QStringList() << "*.dtb" << "*.dec" << "*.im4p" << "*.dmg", QDir::Files );
-			for( const QString &f : files )
-			{
-				const QString full = QDir::toNativeSeparators( d.absoluteFilePath( f ) );
-				summary += QString( "Payload: %1\n" ).arg( full );
-				const bool is_dt = f.contains( "DeviceTree", Qt::CaseInsensitive ) ||
-				                   f.contains( "dtb", Qt::CaseInsensitive );
-				const bool usable = f.endsWith( QLatin1String( ".dtb" ), Qt::CaseInsensitive ) ||
-				                    f.endsWith( QLatin1String( ".dec" ), Qt::CaseInsensitive );
-				if( is_dt && usable && dtb_found.isEmpty() )
-					dtb_found = full;
-			}
-		}
-		Text_Result_Paths->setText( QDir::toNativeSeparators( summary ) );
-
-		if( ! dtb_found.isEmpty() )
-		{
-			Text_Console_Log->append(
-				tr( "Suggested DeviceTree (extracted): %1" ).arg( dtb_found ) );
-			emit DeviceTree_Path_Suggested( dtb_found );
-		}
-	}
-	else
+	if( exitCode != 0 )
 	{
 		Text_Console_Log->append(
 			tr( "\nProcess failed with exit code %1" ).arg( exitCode ) );
+		return;
+	}
+
+	Text_Console_Log->append( tr( "\nTask completed successfully." ) );
+
+	if( op == Pending_Op::Im4pOp )
+	{
+		if( ! Last_IM4P_Output.isEmpty() )
+		{
+			Text_Result_Paths->setText( QDir::toNativeSeparators(
+				tr( "IM4P output: %1\n" ).arg( Last_IM4P_Output ) ) );
+			Text_Console_Log->append(
+				tr( "IM4P output: %1" ).arg( Last_IM4P_Output ) );
+		}
+		return;
+	}
+
+	if( op != Pending_Op::IpswExtract )
+		return;
+
+	const QString out_dir = Edit_Output_Dir->text().trimmed();
+	QString summary;
+	summary += QString( "Extraction Folder: %1\n" ).arg( out_dir );
+
+	QString dtb_found;
+	QDir d( out_dir + "/Firmware/all_flash" );
+	if( d.exists() )
+	{
+		// Prefer extracted DeviceTree (.dtb / .dec), never raw .im4p for -dtb.
+		const QStringList files = d.entryList(
+			QStringList() << "*.dtb" << "*.dec" << "*.im4p" << "*.dmg", QDir::Files );
+		for( const QString &f : files )
+		{
+			const QString full = QDir::toNativeSeparators( d.absoluteFilePath( f ) );
+			summary += QString( "Payload: %1\n" ).arg( full );
+			const bool is_dt = f.contains( "DeviceTree", Qt::CaseInsensitive ) ||
+			                   f.contains( "dtb", Qt::CaseInsensitive );
+			const bool usable = f.endsWith( QLatin1String( ".dtb" ), Qt::CaseInsensitive ) ||
+			                    f.endsWith( QLatin1String( ".dec" ), Qt::CaseInsensitive );
+			if( is_dt && usable && dtb_found.isEmpty() )
+				dtb_found = full;
+		}
+	}
+	Text_Result_Paths->setText( QDir::toNativeSeparators( summary ) );
+
+	if( ! dtb_found.isEmpty() )
+	{
+		Text_Console_Log->append(
+			tr( "Suggested DeviceTree (extracted): %1" ).arg( dtb_found ) );
+		emit DeviceTree_Path_Suggested( dtb_found );
 	}
 }
 

--- a/src/iOS_Firmware_Tool_Window.h
+++ b/src/iOS_Firmware_Tool_Window.h
@@ -57,6 +57,10 @@ private:
 
 	QProcess *Process;
 	QString PyIMG4_Exe;
+	QString Last_IM4P_Output;
+
+	enum class Pending_Op { None, IpswExtract, Im4pOp };
+	Pending_Op Last_Operation;
 };
 
 #endif // IOS_FIRMWARE_TOOL_WINDOW_H


### PR DESCRIPTION
## Summary
- Bumps the app globally to **1.3.0** (code, MSI/MSIX/WiX, README/CHANGELOG).
- Adds a real Inferno Apple SoC profile: trustcache/ticket/SEP, NVMe ns layout, WSL Linux `qemu-system-applesoc`, companion + `idevicerestore` restore UI.
- Makes Reims hardware-accelerated macOS honest on Windows: forced WSL `qemu-system-reims3d`, AMD **and** NVIDIA via WSLg Vulkan; prompts for WSL distro/username on boot when missing (no stored passwords).

## Test plan
- [ ] Cold start with empty WSL settings → prompt appears; Configure WSL saves distro/username
- [ ] Create iOS / Apple Silicon wizard VM → Apple SoC fields visible; images created under VM folder
- [ ] Start Apple SoC VM on Windows → uses WSL Inferno binary; fails clearly if missing
- [ ] File → Apple SoC Restore → companion snippet + idevicerestore launch path
- [ ] Create Reims macOS VM → GPU status mentions AMD/NVIDIA WSL Vulkan; start forces reims3d in WSL
- [ ] About / Store package version shows 1.3.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to VM start and QEMU argv generation for Apple SoC and WSL paths; failures are mostly operational (missing WSL binaries) rather than security-sensitive, but regressions could affect non-Apple x86 WSL launches.
> 
> **Overview**
> **AQEMU 1.3.0** extends Windows guest support by wiring **ChefKiss Inferno** Apple SoC/iOS end-to-end and tightening **Reims** hardware-accelerated Intel macOS on **WSL**.
> 
> **Apple SoC / Inferno:** New `Apple_SoC_Support` builds Inferno `-machine` props (trustcache, ticket, SEP, `kaslr-off`, USB companion `usb-conn-*`) and extra argv (SEP pflash, multi-namespace NVMe + `apple-nvram`). VMs gain persisted Apple SoC fields (XML + UI on the DeviceTree section). Wizard and iOS templates set `qemu-system-applesoc`, `t8030`, WSL launch, default append, and create the standard raw image set under the VM folder on start/wizard. On Windows, Apple SoC **always** launches Linux `qemu-system-applesoc` in WSL (with binary probe and WSL wizard if distro/user missing). **File → Apple SoC Restore** opens a dialog for companion QEMU snippets (shell-safe quoting) and **idevicerestore** via WSL.
> 
> **Reims / WSL UX:** Reims VMs also force WSL; startup validates `qemu-system-reims3d` (existing sync path retained). Main window prompts for WSL distro/username on boot when any Reims/Apple SoC/WSL VM needs it (passwords not stored; KVM fix via `wsl -u root`). Advanced Settings adds **Apple SoC binary in WSL**; `Rewrite_Args_For_WSL` now rewrites Inferno paths on `-machine` and related drive keys.
> 
> **Other:** Intel Mac GPU panel distinguishes Reims (WSL Vulkan for AMD/NVIDIA) from VFIO on Linux. Boot validation for Apple SoC prefers kernelcache; `.im4p` DeviceTree allowed for full Inferno profile. Packaging/docs/version constants updated to **1.3.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11d105746bc615caf5aca6241a9667b3e5493aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->