### PR TITLE
feat: in-app iOS tickets, SEP pack, and tool path settings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,9 @@
 	    idevice; IPA install via ideviceinstaller (auto-apt if missing); screenshot.
 	  - extras/Inferno/iOS_Installation.md: starter + re-install walkthrough
 	    (restore, FS patches, internet, IPA vs .deb, 8 GiB vs 32 GiB root).
+	    File → iOS Firmware Tool forges restore/SEP tickets and packs SEP firmware
+	    in-app (bundled create_*ticket.py; img4 / pyimg4). File → Configure sets
+	    Python / pyimg4 / img4 paths (PATH fallback if empty).
 	    wipe-ios-nvme.ps1 for partial-flash / clean NAND. Default auto-created root
 	    is 8 GiB; grow sparse to 32 GiB before restore for App Store / large IPAs.
 	    FS-patch helper selects the iOS NVMe by skipping the cloud-image boot disk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,7 +557,13 @@ ADD_CUSTOM_COMMAND( TARGET aqemu POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different
 		"${CMAKE_SOURCE_DIR}/extras/Inferno/iOS_Installation.md"
 		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/iOS_Installation.md"
-	COMMENT "Bundle extras/Inferno FS-patch scripts and iOS install guide"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/create_apticket.py"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/create_apticket.py"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/create_septicket.py"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/create_septicket.py"
+	COMMENT "Bundle extras/Inferno scripts, ticket helpers, and iOS install guide"
 )
 # companion-bin (idevice* tools) for optional scp into the Ubuntu companion
 IF( EXISTS "${CMAKE_SOURCE_DIR}/extras/Inferno/companion-bin" )

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Full walkthrough (including re-install): [`extras/Inferno/iOS_Installation.md`](
 ### How to run iOS
 
 1. **New VM Wizard → Apple → iOS (ARM64)** — Inferno `t8030`, 4 vCPUs, ≥4 GB RAM.
-2. Fill **kernel**, **DeviceTree** (extracted `.dtb` / `.dec`), trustcache, ticket, SEP, restore ramdisk. **File → iOS Firmware Tool** unpacks an IPSW (`pyimg4` on PATH).
+2. Fill **kernel**, **DeviceTree** (extracted `.dtb` / `.dec`), trustcache, ticket, SEP, restore ramdisk. **File → iOS Firmware Tool** unpacks the IPSW, forges tickets, and can pack SEP firmware (`pyimg4` / `img4` on PATH).
 3. USB remote **`127.0.0.1:8030`**. **File → Apple SoC Restore**: start companion, Power On iOS, restore IPSW.
 4. **File → Apply iOS filesystem patches…** on the guest `root` disk (not the companion). Then Power On for Setup / SpringBoard.
 5. Toolbar **Net** or **File → Guest Internet / iOS Device Tools…** → **Enable guest internet** for Safari / App Store.

--- a/extras/Inferno/README.txt
+++ b/extras/Inferno/README.txt
@@ -11,6 +11,7 @@ That is the iOS README. Linked from the app tree and the project README.
 This folder also contains helper files used by that guide:
 
   create_apticket.py / create_septicket.py
+                            (run from File → iOS Firmware Tool, Step 2)
   idevicerestore.patch          (N104DEV → AP)
   companion-bin/                (Linux idevice* for the companion image)
   apply-fs-patches-wsl.sh

--- a/extras/Inferno/iOS_Installation.md
+++ b/extras/Inferno/iOS_Installation.md
@@ -30,7 +30,7 @@ Do this **in order**. If a step fails, jump to the matching heading in Part B. D
 | Inferno `qemu-system-applesoc` | Used via WSL |
 | Companion disk path | Restore dialog (future: Download + path box) |
 | Companion SSH user + password | Same as Device Tools |
-| IPSW + extracted firmware | Part B §2–4. Reference: iOS **14.0 beta 5** `18A5351d`, iPhone 11 / **t8030** / **n104ap** |
+| IPSW + extracted firmware | **File → iOS Firmware Tool…** (unpack + forge tickets + IM4P). Part B §2–4. Reference: iOS **14.0 beta 5** `18A5351d`, iPhone 11 / **t8030** / **n104ap** |
 | **32 GiB** sparse `root` | Grow **before** first restore (Part B §6) |
 
 ### A1. Create the VM
@@ -40,7 +40,7 @@ Confirm: emulator `qemu-system-applesoc`, machine **`t8030`**, RAM **≥ 4 GiB
 
 ### A2. Point MACHINE at firmware
 
-Fill every row in [Part B §5](#b5-every-aqemu-field). Minimum: Kernel, DeviceTree (`.dtb`/`.dec` not `.im4p`), Trustcache, Restore ticket, SEP firmware **repackaged** `.img4`, SEP ROM (Cebu B1), IPSW, Restore ramdisk `.dmg`, USB **IPv4 `127.0.0.1` port `8030`**. Save.
+**File → iOS Firmware Tool…** first (unpack, **Forge restore + SEP tickets**, DeviceTree IM4P). Then fill remaining rows in [Part B §5](#b5-every-aqemu-field). Minimum: Kernel, DeviceTree (`.dtb`/`.dec` not `.im4p`), Trustcache, Restore ticket, SEP firmware **repackaged** `.img4`, SEP ROM (Cebu B1), IPSW, Restore ramdisk `.dmg`, USB **IPv4 `127.0.0.1` port `8030`**. Save.
 
 ### A3. Grow `root` to 32 GiB
 
@@ -101,13 +101,51 @@ An `.ipsw` is a **ZIP**. You can rename to `.zip` and extract, or use AQEMU’s 
 
 ## B3. Unpack the IPSW (File → iOS Firmware Tool)
 
-**File → iOS Firmware Tool…**
+**File → iOS Firmware Tool…** — do **not** run Python in a terminal. This dialog is the unpack + ticket + IM4P step.
 
 1. **IPSW File** — browse to the `.ipsw` / `.zip`.
 2. **Extraction Output Directory** — default is next to `aqemu.exe` as `firmware_extracted`. Pick a folder you will keep.
-3. **Unpack IPSW**.
+3. **Unpack IPSW** (Step 1). AQEMU fills **BuildManifest.plist**, suggests DeviceTree `.im4p`, restore ramdisk, and (if empty) MACHINE **IPSW**.
 
-That unzip is **Step 1**. IM4P files inside are still wrapped. **Step 2** needs **`pyimg4`** on PATH or `pyimg4.exe` beside `aqemu.exe` (AQEMU does not vendor it).
+Typical files after unpack (names vary by IPSW):
+
+| Look for | Used as |
+| --- | --- |
+| `BuildManifest.plist` | Filled into Step 2 automatically |
+| `DeviceTree.n104ap.im4p` | Step 3 decrypt/extract → **DeviceTree** `.dtb` / `.dec` |
+| `kernelcache.release.*` or research kernel | **Kernel** (decrypted / `.research`) |
+| Large restore **`.dmg`** | MACHINE **Restore ramdisk (-initrd)** (suggested if empty) |
+| `Firmware/all_flash/sep-firmware.n104.RELEASE.im4p` | Later pack into **repackaged** SEP `.img4` — not the MACHINE SEP field raw |
+| Trustcache / img4 pieces from the Inferno recipe | **Trustcache** |
+| `kernelcache` / firmware folders | Keep the whole extract; do not delete until MACHINE paths work |
+
+**Kernel** is the research/decrypted kernelcache Inferno can `-kernel`, not a random Mach-O from the IPSW payload folder unless ChefKiss says that file is the one.
+
+---
+
+## B4. Tickets, SEP ROM, SEP firmware (same Firmware Tool window)
+
+Stay in **File → iOS Firmware Tool…**. Do **not** copy `python3 create_apticket.py …` from older notes.
+
+### Restore ticket + SEP ticket (Step 2)
+
+Unsigned IPSWs need a **forged AP ticket**. A 2-byte placeholder will fail restore.
+
+1. **Model** — `n104ap` (iPhone 11 / t8030).
+2. **BuildManifest.plist** — already filled after Unpack.
+3. **ticket.shsh2** — **Browse…** or **ChefKiss extras…** ([ChefKiss extras](https://chefkiss.dev/Extras/Inferno/)). You can drop the file next to the bundled scripts as `extras/Inferno/ticket.shsh2`. AQEMU remembers the path. AQEMU does **not** ship this blob.
+4. **Forge restore + SEP tickets** — AQEMU runs the bundled scripts (installs `pyasn1` via pip if needed). You never type the command.
+
+Outputs (next to the extract by default):
+
+- `root_ticket.der` → applied to MACHINE **Restore ticket** (used as `idevicerestore -T`)
+- `sep_root_ticket.der` → input for packing SEP firmware (next)
+
+Forge again whenever you **change IPSW build**. Python 3: **File → Configure → iOS firmware tools**, or on PATH (`py -3` / `python`). AQEMU starts it — you do not open a shell.
+
+### DeviceTree / kernel IM4P (Step 4)
+
+IM4P files are still wrapped. Step 4 needs **`pyimg4`** on PATH or `pyimg4.exe` beside `aqemu.exe` (AQEMU does not vendor it).
 
 | Operation | Use |
 | --- | --- |
@@ -115,55 +153,21 @@ That unzip is **Step 1**. IM4P files inside are still wrapped. **Step 2** needs 
 | Decrypt payload | Needs **AES IV** and **AES Key** (hex) from The Apple Wiki for that build/file |
 | Show payload info | Inspect before decrypt |
 
-Typical files after unpack (names vary by IPSW):
+**DeviceTree must not stay `.im4p`.** Start will refuse raw IM4P. Decrypt/extract until you have `.dtb` or `.dec`. Empty MACHINE DeviceTree is filled from a `.dec`/`.dtb` result.
 
-| Look for | Used as |
-| --- | --- |
-| `BuildManifest.plist` | Ticket scripts |
-| `DeviceTree.n104ap.im4p` | Decrypt/extract → **DeviceTree** `.dtb` / `.dec` |
-| `kernelcache.release.*` or research kernel | **Kernel** (decrypted / `.research`) |
-| Large restore **`.dmg`** (tooltip example: `038-44135-124.dmg`) | **Restore ramdisk (-initrd)** |
-| `Firmware/all_flash/sep-firmware.n104.RELEASE.im4p` | Input to **repackaged** SEP `.img4` — **not** the MACHINE SEP field raw |
-| Trustcache / img4 pieces from the Inferno recipe | **Trustcache** |
-| `kernelcache` / firmware folders | Keep the whole extract; do not delete until MACHINE paths work |
+If pyimg4 is missing: **File → Configure → iOS firmware tools → pyimg4**, or copy `pyimg4.exe` next to `aqemu.exe` / on PATH.
 
-**DeviceTree must not stay `.im4p`.** Start will refuse raw IM4P. Use Firmware Tool Step 2 (decrypt if needed) until you have `.dtb` or `.dec`.
-
-**Kernel** is the research/decrypted kernelcache Inferno can `-kernel`, not a random Mach-O from the IPSW payload folder unless ChefKiss says that file is the one.
-
-If pyimg4 is missing: install it, restart AQEMU, or copy `pyimg4.exe` next to `aqemu.exe`.
-
----
-
-## B4. Tickets, SEP ROM, SEP firmware (not inside the IPSW ready-made)
-
-### Restore ticket (`root_ticket.der`)
-
-Unsigned IPSWs need a **forged AP ticket**. A 2-byte placeholder will fail restore.
-
-From `extras/Inferno/` (or [ChefKiss extras](https://chefkiss.dev/Extras/Inferno/)):
-
-```text
-python3 create_apticket.py n104ap BuildManifest.plist ticket.shsh2 root_ticket.der
-```
-
-- `BuildManifest.plist` — from the unpacked IPSW  
-- `ticket.shsh2` — ChefKiss-provided blob for this flow  
-- Rebuild the ticket whenever you **change IPSW build**  
-- MACHINE → **Restore ticket** = this `.der`  
-- On restore, AQEMU stages it for `idevicerestore -T`
-
-Need `pyasn1` / `pyasn1-modules` (pip or distro packages). See ChefKiss file setup.
-
-### SEP ticket + repackaged SEP firmware
+### Repackaged SEP firmware (Step 3 in the same window)
 
 Raw `sep-firmware.n104.RELEASE.im4p` is **not** what Inferno `sep-fw=` wants. Without a **repackaged** `sep-firmware.n104.RELEASE.new.img4`, restore often dies after NORData: **`Could not read data (-256)`**.
 
-```text
-python3 create_septicket.py n104ap BuildManifest.plist ticket.shsh2 sep_root_ticket.der
-```
+Still in **File → iOS Firmware Tool…**:
 
-Then `img4` (img4lib) with Apple Wiki **IV and key concatenated** (`-k IVKEY`), as in ChefKiss file setup, to write `sep-firmware.n104.RELEASE.new.img4`. MACHINE → **SEP firmware**.
+1. **SEP .im4p** — filled after Unpack (`Firmware/all_flash/sep-firmware.n104.RELEASE.im4p`).
+2. **IVKEY** — Apple Wiki IV and key **concatenated** (no space) for that file. **Apple Wiki…** opens the keys page.
+3. **Decrypt + pack SEP firmware** — AQEMU runs `img4` decrypt then wrap with `-T rsep` and the Step 2 SEP ticket. MACHINE **SEP firmware** is set to the `.new.img4`.
+
+Place **`img4.exe`** (xerub [img4lib](https://github.com/xerub/img4lib)) in **File → Configure → iOS firmware tools**, beside `aqemu.exe`, or on PATH. You do not type the ChefKiss `for /f` command.
 
 ### SEP ROM and SecureROM
 

--- a/extras/Inferno/iOS_Installation.md
+++ b/extras/Inferno/iOS_Installation.md
@@ -114,7 +114,7 @@ Typical files after unpack (names vary by IPSW):
 | `BuildManifest.plist` | Filled into Step 2 automatically |
 | `DeviceTree.n104ap.im4p` | Step 3 decrypt/extract → **DeviceTree** `.dtb` / `.dec` |
 | `kernelcache.release.*` or research kernel | **Kernel** (decrypted / `.research`) |
-| Large restore **`.dmg`** | MACHINE **Restore ramdisk (-initrd)** (suggested if empty) |
+| Restore ramdisk **`.dmg`** (`RestoreRamDisk` in BuildManifest, e.g. `038-44135-124.dmg`) | MACHINE **Restore ramdisk (-initrd)** (suggested if empty). Not the largest IPSW `.dmg` |
 | `Firmware/all_flash/sep-firmware.n104.RELEASE.im4p` | Later pack into **repackaged** SEP `.img4` — not the MACHINE SEP field raw |
 | Trustcache / img4 pieces from the Inferno recipe | **Trustcache** |
 | `kernelcache` / firmware folders | Keep the whole extract; do not delete until MACHINE paths work |

--- a/src/Advanced_Settings_Window.cpp
+++ b/src/Advanced_Settings_Window.cpp
@@ -281,6 +281,59 @@ Advanced_Settings_Window::Advanced_Settings_Window( QWidget *parent )
 		connect( CB_WSL_Distro, SIGNAL(currentIndexChanged(int)), this, SLOT(On_CB_WSL_Distro_currentIndexChanged(int)) );
 	}
 #endif
+
+	Edit_FW_Python = nullptr;
+	Edit_FW_Pyimg4 = nullptr;
+	Edit_FW_Img4 = nullptr;
+	{
+		QGroupBox *fwBox = new QGroupBox( tr( "iOS firmware tools" ), ui.Tab_General );
+		QVBoxLayout *fwLay = new QVBoxLayout( fwBox );
+		QLabel *fwHelp = new QLabel( tr(
+			"Used by File → iOS Firmware Tool. A path here is used when the file exists. "
+			"Leave empty to search next to AQEMU, then the system PATH." ) );
+		fwHelp->setWordWrap( true );
+		fwLay->addWidget( fwHelp );
+
+		auto add_fw_row = [this, fwLay]( const QString &label, const QString &key,
+		                                 const QString &browse_title, QLineEdit **edit_out ) {
+			QHBoxLayout *row = new QHBoxLayout();
+			row->addWidget( new QLabel( label ) );
+			QLineEdit *edit = new QLineEdit(
+				Settings.value( key ).toString() );
+			edit->setPlaceholderText( tr( "Empty = PATH" ) );
+			QToolButton *browse = new QToolButton();
+			browse->setText( QStringLiteral( "..." ) );
+			browse->setToolTip( browse_title );
+			row->addWidget( edit, 1 );
+			row->addWidget( browse );
+			fwLay->addLayout( row );
+			*edit_out = edit;
+			connect( browse, &QToolButton::clicked, this, [this, edit, browse_title]() {
+				const QString start = edit->text().trimmed().isEmpty()
+					? QString() : Get_Last_Dir_Path( edit->text() );
+				const QString file = QFileDialog::getOpenFileName(
+					this, browse_title, start,
+#ifdef Q_OS_WIN32
+					tr( "Executables (*.exe);;All Files (*)" )
+#else
+					tr( "All Files (*)" )
+#endif
+				);
+				if( ! file.isEmpty() )
+					edit->setText( QDir::toNativeSeparators( file ) );
+			} );
+		};
+
+		add_fw_row( tr( "Python 3:" ), QStringLiteral( "Apple_SoC_Firmware/Python" ),
+			tr( "Select Python 3 (python.exe or py.exe)" ), &Edit_FW_Python );
+		add_fw_row( tr( "pyimg4:" ), QStringLiteral( "Apple_SoC_Firmware/pyimg4" ),
+			tr( "Select pyimg4" ), &Edit_FW_Pyimg4 );
+		add_fw_row( tr( "img4:" ), QStringLiteral( "Apple_SoC_Firmware/img4" ),
+			tr( "Select img4 (img4lib)" ), &Edit_FW_Img4 );
+
+		if( QGridLayout *gl = qobject_cast<QGridLayout*>( ui.Tab_General->layout() ) )
+			gl->addWidget( fwBox, gl->rowCount(), 0, 1, gl->columnCount() );
+	}
 	
 	QHeaderView *hv = new QHeaderView( Qt::Vertical, ui.Emulators_Table );
 	hv->setSectionResizeMode( QHeaderView::Fixed );
@@ -786,6 +839,12 @@ void Advanced_Settings_Window::done(int r)
 		    WSL_Clear_Probe_Cache();
 	    }
 #endif
+	    if( Edit_FW_Python )
+		    Settings.setValue( "Apple_SoC_Firmware/Python", Edit_FW_Python->text().trimmed() );
+	    if( Edit_FW_Pyimg4 )
+		    Settings.setValue( "Apple_SoC_Firmware/pyimg4", Edit_FW_Pyimg4->text().trimmed() );
+	    if( Edit_FW_Img4 )
+		    Settings.setValue( "Apple_SoC_Firmware/img4", Edit_FW_Img4->text().trimmed() );
 	    // Execute Before Start QEMU
 	    Settings.setValue( "Run_Before_QEMU", ui.Edit_Before_Start_Command->text() );
 	

--- a/src/Advanced_Settings_Window.h
+++ b/src/Advanced_Settings_Window.h
@@ -104,6 +104,10 @@ class Advanced_Settings_Window: public QDialog
 		QLabel *Label_WSL_KVM_Status;
 		QToolButton *TB_WSL_Probe;
 
+		QLineEdit *Edit_FW_Python;
+		QLineEdit *Edit_FW_Pyimg4;
+		QLineEdit *Edit_FW_Img4;
+
 	private slots:
 		void On_CB_WSL_Distro_currentIndexChanged( int index );
 

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -222,8 +222,9 @@ Main_Window::Main_Window( QWidget *parent )
 	{
 		QAction *actIosFw = new QAction( QIcon( QStringLiteral( ":/default_mac.png" ) ),
 			tr( "iOS &Firmware Tool…" ), this );
-		actIosFw->setStatusTip( tr( "Unpack IPSW archives and process IM4P payloads with pyimg4" ) );
 		connect( actIosFw, &QAction::triggered, this, &Main_Window::slot_iOS_Firmware_Tool_triggered );
+		actIosFw->setStatusTip( tr(
+			"Unpack IPSW, forge restore/SEP tickets, process IM4P — stay in AQEMU" ) );
 		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actIosFw );
 	}
 	// File → Apple SoC Restore (always listed — needed while companion Ubuntu is selected)
@@ -6309,15 +6310,34 @@ void Main_Window::sync_arch_CPU_Type_changed( int index )
 void Main_Window::slot_iOS_Firmware_Tool_triggered()
 {
 	iOS_Firmware_Tool_Window dlg( this );
-	connect( &dlg, &iOS_Firmware_Tool_Window::DeviceTree_Path_Suggested,
-	         this, [this]( const QString &path ) {
-		if( path.isEmpty() )
+	auto fill_if = [this]( QLineEdit *edit, const QString &path, bool always ) {
+		if( ! edit || path.isEmpty() )
 			return;
-		if( ui.Edit_DeviceTree_Path->text().trimmed().isEmpty() )
+		if( always || edit->text().trimmed().isEmpty() )
 		{
-			ui.Edit_DeviceTree_Path->setText( path );
+			edit->setText( path );
 			VM_Changed();
 		}
+	};
+	connect( &dlg, &iOS_Firmware_Tool_Window::DeviceTree_Path_Suggested,
+	         this, [this, fill_if]( const QString &path ) {
+		fill_if( ui.Edit_DeviceTree_Path, path, false );
+	} );
+	connect( &dlg, &iOS_Firmware_Tool_Window::Restore_Ticket_Suggested,
+	         this, [this, fill_if]( const QString &path ) {
+		fill_if( Edit_Apple_Ticket, path, true );
+	} );
+	connect( &dlg, &iOS_Firmware_Tool_Window::Ipsw_Path_Suggested,
+	         this, [this, fill_if]( const QString &path ) {
+		fill_if( Edit_Apple_IPSW, path, false );
+	} );
+	connect( &dlg, &iOS_Firmware_Tool_Window::Restore_Ramdisk_Suggested,
+	         this, [this, fill_if]( const QString &path ) {
+		fill_if( Edit_Apple_Initrd, path, false );
+	} );
+	connect( &dlg, &iOS_Firmware_Tool_Window::Sep_Firmware_Suggested,
+	         this, [this, fill_if]( const QString &path ) {
+		fill_if( Edit_Apple_SEP_FW, path, true );
 	} );
 	dlg.exec();
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -2785,3 +2785,54 @@ bool Remove_UCPD_From_Disk_Image( const QString &disk_path, QString *result_mess
 	return true;
 #endif
 }
+
+QString AQ_Resolve_Host_Tool( const QString &settings_key,
+                             const QStringList &exe_names,
+                             const QStringList &app_dir_relatives )
+{
+	const auto existing_file = []( const QString &path ) -> QString {
+		if( path.isEmpty() )
+			return QString();
+		const QFileInfo fi( path );
+		if( fi.exists() && fi.isFile() )
+			return QDir::toNativeSeparators( fi.absoluteFilePath() );
+		return QString();
+	};
+
+	QSettings s;
+	const QString pref = s.value( settings_key ).toString().trimmed();
+	if( ! pref.isEmpty() )
+	{
+		const QString as_file = existing_file( pref );
+		if( ! as_file.isEmpty() )
+			return as_file;
+		const QFileInfo fi( pref );
+		if( fi.exists() && fi.isDir() )
+		{
+			const QDir dir( fi.absoluteFilePath() );
+			for( const QString &name : exe_names )
+			{
+				const QString hit = existing_file( dir.filePath( name ) );
+				if( ! hit.isEmpty() )
+					return hit;
+			}
+		}
+	}
+
+	const QDir app( QCoreApplication::applicationDirPath() );
+	for( const QString &rel : app_dir_relatives )
+	{
+		const QString hit = existing_file( app.filePath( rel ) );
+		if( ! hit.isEmpty() )
+			return hit;
+	}
+
+	for( const QString &name : exe_names )
+	{
+		const QString found = QStandardPaths::findExecutable( name );
+		const QString hit = existing_file( found );
+		if( ! hit.isEmpty() )
+			return hit;
+	}
+	return QString();
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -31,6 +31,7 @@
 #include <QString>
 #include <QByteArray>
 #include <QList>
+#include <QStringList>
 
 #include "VM_Devices.h"
 
@@ -266,6 +267,16 @@ QString AQ_Find_QEMU_Binary_With_Native_Display( const QString &system_name,
  * other common relative locations. Empty if nothing usable is found.
  */
 QString AQ_Get_QEMU_Data_Dir( const QString &qemu_binary_path );
+
+/**
+ * Host helper binaries (Python, pyimg4, img4, …).
+ * If the QSettings key is a file (or a folder that contains one of exe_names)
+ * and that file exists, it wins. Otherwise search files relative to aqemu,
+ * then PATH.
+ */
+QString AQ_Resolve_Host_Tool( const QString &settings_key,
+                             const QStringList &exe_names,
+                             const QStringList &app_dir_relatives = QStringList() );
 
 #endif
 

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -1,5 +1,9 @@
 #include "iOS_Firmware_Tool_Window.h"
 
+#include "Apple_SoC_FS_Patch_Window.h"
+#include "AQ_UI_Style.h"
+#include "Utils.h"
+
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
@@ -9,20 +13,27 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QProcessEnvironment>
-#include "AQ_UI_Style.h"
-#include "Utils.h"
+#include <QUrl>
+#include <QDesktopServices>
+#include <QRegularExpression>
+#include <QWidget>
 
 iOS_Firmware_Tool_Window::iOS_Firmware_Tool_Window( QWidget *parent )
 	: QDialog( parent )
 	, Process( new QProcess( this ) )
+	, Chain_Sep_Ticket( false )
+	, Tried_Pip( false )
 	, Last_Operation( Pending_Op::None )
 {
 	setWindowTitle( tr( "iOS Firmware Tool" ) );
-	resize( AQ_Px( 780, this ), AQ_Px( 560, this ) );
+	resize( AQ_Px( 780, this ), AQ_Px( 860, this ) );
 	PyIMG4_Exe = Find_PyIMG4_Executable();
+	Img4_Exe = Find_Img4_Executable();
 
 	connect( Process, &QProcess::readyReadStandardOutput, this, &iOS_Firmware_Tool_Window::On_Process_Output );
 	connect( Process, &QProcess::readyReadStandardError, this, &iOS_Firmware_Tool_Window::On_Process_Output );
@@ -34,32 +45,49 @@ iOS_Firmware_Tool_Window::iOS_Firmware_Tool_Window( QWidget *parent )
 
 QString iOS_Firmware_Tool_Window::Find_PyIMG4_Executable() const
 {
-	const QString app_dir = QCoreApplication::applicationDirPath();
-	const QStringList candidates = {
-		app_dir + "/pyimg4.exe",
-		app_dir + "/tools/pyimg4.exe",
-		QStandardPaths::findExecutable( "pyimg4" ),
-		QStandardPaths::findExecutable( "pyimg4.exe" )
-	};
+	return AQ_Resolve_Host_Tool(
+		QStringLiteral( "Apple_SoC_Firmware/pyimg4" ),
+		QStringList() << QStringLiteral( "pyimg4" ) << QStringLiteral( "pyimg4.exe" ),
+		QStringList() << QStringLiteral( "pyimg4.exe" )
+		              << QStringLiteral( "tools/pyimg4.exe" ) );
+}
 
-	for( const QString &path : candidates )
+QString iOS_Firmware_Tool_Window::Find_Img4_Executable() const
+{
+	return AQ_Resolve_Host_Tool(
+		QStringLiteral( "Apple_SoC_Firmware/img4" ),
+		QStringList() << QStringLiteral( "img4" ) << QStringLiteral( "img4.exe" ),
+		QStringList() << QStringLiteral( "img4.exe" )
+		              << QStringLiteral( "img4" )
+		              << QStringLiteral( "tools/img4.exe" )
+		              << QStringLiteral( "img4lib/img4.exe" )
+		              << QStringLiteral( "img4lib/img4" )
+		              << QStringLiteral( "extras/Inferno/img4.exe" ) );
+}
+
+bool iOS_Firmware_Tool_Window::Ensure_Img4_Available()
+{
+	Img4_Exe = Find_Img4_Executable();
+	if( Img4_Exe.isEmpty() || ! QFile::exists( Img4_Exe ) )
 	{
-		if( ! path.isEmpty() && QFile::exists( path ) )
-			return QDir::toNativeSeparators( path );
+		QMessageBox::warning( this, tr( "img4 not found" ),
+			tr( "img4 (xerub img4lib) was not found.\n\n"
+			    "Set File → Configure → iOS firmware tools → img4, "
+			    "or place img4.exe beside aqemu.exe / on PATH." ) );
+		return false;
 	}
-	return QString();
+	return true;
 }
 
 bool iOS_Firmware_Tool_Window::Ensure_PyIMG4_Available()
 {
-	if( PyIMG4_Exe.isEmpty() )
-		PyIMG4_Exe = Find_PyIMG4_Executable();
+	PyIMG4_Exe = Find_PyIMG4_Executable();
 	if( PyIMG4_Exe.isEmpty() || ! QFile::exists( PyIMG4_Exe ) )
 	{
 		QMessageBox::warning( this, tr( "pyimg4 not found" ),
-			tr( "pyimg4 was not found next to AQEMU or on PATH.\n\n"
-			    "Install pyimg4 and ensure it is available as `pyimg4` "
-			    "(or place pyimg4.exe beside aqemu.exe)." ) );
+			tr( "pyimg4 was not found.\n\n"
+			    "Set File → Configure → iOS firmware tools → pyimg4, "
+			    "or place pyimg4.exe beside aqemu.exe / on PATH." ) );
 		return false;
 	}
 	return true;
@@ -74,8 +102,9 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 	main_lay->addWidget( title );
 
 	QLabel *subtitle = new QLabel( tr(
-		"Unpack IPSW archives and process Image4 payloads (DeviceTree, kernelcache, SEP) "
-		"for Apple SoC QEMU. Requires an external pyimg4 install for IM4P steps." ) );
+		"Stay in this window: unpack the IPSW, forge restore/SEP tickets, pack SEP firmware, "
+		"then process DeviceTree/kernel IM4P. Python / img4 / pyimg4: File → Configure → "
+		"iOS firmware tools (or PATH / next to aqemu.exe)." ) );
 	subtitle->setWordWrap( true );
 	main_lay->addWidget( subtitle );
 
@@ -104,7 +133,114 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 	grid1->addWidget( Btn_Start_Unpack, 2, 1, 1, 2 );
 	main_lay->addWidget( gb_ipsw );
 
-	QGroupBox *gb_im4p = new QGroupBox( tr( "Step 2: Process IM4P Payload (pyimg4)" ) );
+	QGroupBox *gb_tick = new QGroupBox( tr(
+		"Step 2: Forge restore + SEP tickets (this IPSW — no terminal)" ) );
+	QGridLayout *gridT = new QGridLayout( gb_tick );
+	gridT->addWidget( new QLabel( tr(
+		"Uses bundled extras/Inferno scripts. Needs Python 3 with pyasn1 "
+		"(AQEMU will pip-install if missing). ticket.shsh2 comes from ChefKiss extras." ) ),
+		0, 0, 1, 3 );
+
+	gridT->addWidget( new QLabel( tr( "Model:" ) ), 1, 0 );
+	CB_Ticket_Model = new QComboBox();
+	CB_Ticket_Model->addItem( tr( "n104ap — iPhone 11 / t8030" ), QStringLiteral( "n104ap" ) );
+	gridT->addWidget( CB_Ticket_Model, 1, 1, 1, 2 );
+
+	gridT->addWidget( new QLabel( tr( "BuildManifest.plist:" ) ), 2, 0 );
+	Edit_Manifest = new QLineEdit();
+	Edit_Manifest->setPlaceholderText( tr( "Filled after Unpack IPSW" ) );
+	gridT->addWidget( Edit_Manifest, 2, 1 );
+	auto *btnMan = new QPushButton( tr( "Browse..." ) );
+	connect( btnMan, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_Manifest );
+	gridT->addWidget( btnMan, 2, 2 );
+
+	gridT->addWidget( new QLabel( tr( "ticket.shsh2:" ) ), 3, 0 );
+	Edit_SHSH = new QLineEdit();
+	gridT->addWidget( Edit_SHSH, 3, 1 );
+	auto *shshRow = new QHBoxLayout();
+	auto *btnShsh = new QPushButton( tr( "Browse..." ) );
+	connect( btnShsh, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_SHSH );
+	auto *btnShshWeb = new QPushButton( tr( "ChefKiss extras…" ) );
+	connect( btnShshWeb, &QPushButton::clicked, this, []() {
+		QDesktopServices::openUrl( QUrl( QStringLiteral(
+			"https://chefkiss.dev/Extras/Inferno/" ) ) );
+	} );
+	shshRow->addWidget( btnShsh );
+	shshRow->addWidget( btnShshWeb );
+	QWidget *shshBtns = new QWidget();
+	shshBtns->setLayout( shshRow );
+	gridT->addWidget( shshBtns, 3, 2 );
+
+	gridT->addWidget( new QLabel( tr( "Restore ticket (.der):" ) ), 4, 0 );
+	Edit_Ticket_Out = new QLineEdit();
+	gridT->addWidget( Edit_Ticket_Out, 4, 1, 1, 2 );
+
+	gridT->addWidget( new QLabel( tr( "SEP ticket (.der):" ) ), 5, 0 );
+	Edit_Sep_Ticket_Out = new QLineEdit();
+	gridT->addWidget( Edit_Sep_Ticket_Out, 5, 1, 1, 2 );
+
+	Btn_Forge_Tickets = new QPushButton( tr( "Forge restore + SEP tickets" ) );
+	Btn_Forge_Tickets->setToolTip( tr(
+		"Writes root_ticket.der (MACHINE → Restore ticket) and sep_root_ticket.der "
+		"(input for img4 SEP firmware pack). Applies restore ticket to the current VM." ) );
+	connect( Btn_Forge_Tickets, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Run_Forge_Tickets );
+	gridT->addWidget( Btn_Forge_Tickets, 6, 1, 1, 2 );
+	main_lay->addWidget( gb_tick );
+
+	{
+		QSettings s;
+		const QString extras = Extras_Dir();
+		const QString bundled = QDir( extras ).filePath( QStringLiteral( "ticket.shsh2" ) );
+		Edit_SHSH->setText( QDir::toNativeSeparators(
+			s.value( QStringLiteral( "Apple_SoC_Firmware/SHSH" ),
+			         QFile::exists( bundled ) ? bundled : QString() ).toString() ) );
+	}
+
+	QGroupBox *gb_sep = new QGroupBox( tr(
+		"Step 3: Pack SEP firmware (img4 — same ChefKiss recipe, no cmd.exe)" ) );
+	QGridLayout *gridS = new QGridLayout( gb_sep );
+	gridS->addWidget( new QLabel( tr(
+		"Needs img4 (xerub img4lib) next to AQEMU or on PATH. "
+		"IV+Key concatenated from The Apple Wiki for this SEP IM4P. "
+		"Decrypt then wrap with the SEP ticket from Step 2." ) ),
+		0, 0, 1, 3 );
+
+	gridS->addWidget( new QLabel( tr( "SEP .im4p:" ) ), 1, 0 );
+	Edit_SEP_IM4P = new QLineEdit();
+	Edit_SEP_IM4P->setPlaceholderText( tr( "Firmware/all_flash/sep-firmware.n104.RELEASE.im4p" ) );
+	gridS->addWidget( Edit_SEP_IM4P, 1, 1 );
+	auto *btnSepIm4p = new QPushButton( tr( "Browse..." ) );
+	connect( btnSepIm4p, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_SEP_IM4P );
+	gridS->addWidget( btnSepIm4p, 1, 2 );
+
+	gridS->addWidget( new QLabel( tr( "IVKEY (IV then key, no space):" ) ), 2, 0 );
+	Edit_SEP_IVKEY = new QLineEdit();
+	Edit_SEP_IVKEY->setPlaceholderText( tr( "Paste Apple Wiki IV+key for this build" ) );
+	gridS->addWidget( Edit_SEP_IVKEY, 2, 1 );
+	auto *btnWiki = new QPushButton( tr( "Apple Wiki…" ) );
+	connect( btnWiki, &QPushButton::clicked, this, []() {
+		QDesktopServices::openUrl( QUrl( QStringLiteral(
+			"https://theapplewiki.com/wiki/Firmware_Keys" ) ) );
+	} );
+	gridS->addWidget( btnWiki, 2, 2 );
+
+	gridS->addWidget( new QLabel( tr( "Decrypted SEP:" ) ), 3, 0 );
+	Edit_SEP_Dec = new QLineEdit();
+	gridS->addWidget( Edit_SEP_Dec, 3, 1, 1, 2 );
+
+	gridS->addWidget( new QLabel( tr( "Packed SEP (.img4):" ) ), 4, 0 );
+	Edit_SEP_Out = new QLineEdit();
+	gridS->addWidget( Edit_SEP_Out, 4, 1, 1, 2 );
+
+	Btn_Pack_SEP = new QPushButton( tr( "Decrypt + pack SEP firmware" ) );
+	Btn_Pack_SEP->setToolTip( tr(
+		"Runs img4 decrypt then img4 -A -F -T rsep with sep_root_ticket.der. "
+		"Sets MACHINE → SEP firmware." ) );
+	connect( Btn_Pack_SEP, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Run_Pack_SEP );
+	gridS->addWidget( Btn_Pack_SEP, 5, 1, 1, 2 );
+	main_lay->addWidget( gb_sep );
+
+	QGroupBox *gb_im4p = new QGroupBox( tr( "Step 4: Process IM4P (DeviceTree / kernel — pyimg4)" ) );
 	QGridLayout *grid2 = new QGridLayout( gb_im4p );
 
 	grid2->addWidget( new QLabel( tr( "IM4P Payload File:" ) ), 0, 0 );
@@ -192,6 +328,40 @@ void iOS_Firmware_Tool_Window::Browse_IM4P_File()
 		Edit_IM4P_Path->setText( QDir::toNativeSeparators( file ) );
 }
 
+void iOS_Firmware_Tool_Window::Browse_Manifest()
+{
+	const QString file = QFileDialog::getOpenFileName(
+		this, tr( "BuildManifest.plist" ),
+		Edit_Manifest->text().isEmpty() ? Edit_Output_Dir->text() : Edit_Manifest->text(),
+		tr( "Property list (*.plist);;All (*)" ) );
+	if( ! file.isEmpty() )
+		Edit_Manifest->setText( QDir::toNativeSeparators( file ) );
+}
+
+void iOS_Firmware_Tool_Window::Browse_SHSH()
+{
+	const QString file = QFileDialog::getOpenFileName(
+		this, tr( "ChefKiss ticket.shsh2" ),
+		Edit_SHSH->text(),
+		tr( "SHSH2 (*.shsh2);;All (*)" ) );
+	if( file.isEmpty() )
+		return;
+	Edit_SHSH->setText( QDir::toNativeSeparators( file ) );
+	QSettings s;
+	s.setValue( QStringLiteral( "Apple_SoC_Firmware/SHSH" ), Edit_SHSH->text() );
+}
+
+void iOS_Firmware_Tool_Window::Browse_SEP_IM4P()
+{
+	const QString start = Edit_SEP_IM4P->text().isEmpty()
+		? Edit_Output_Dir->text() : Edit_SEP_IM4P->text();
+	const QString file = QFileDialog::getOpenFileName(
+		this, tr( "SEP firmware IM4P" ), start,
+		tr( "IM4P (*.im4p);;All (*)" ) );
+	if( ! file.isEmpty() )
+		Edit_SEP_IM4P->setText( QDir::toNativeSeparators( file ) );
+}
+
 void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 {
 	const QString ipsw = Edit_IPSW_Path->text().trimmed();
@@ -264,11 +434,251 @@ void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
 	Process->start( PyIMG4_Exe, args );
 }
 
+QString iOS_Firmware_Tool_Window::Extras_Dir() const
+{
+	return AQ_Inferno_Extras_Dir();
+}
+
+QString iOS_Firmware_Tool_Window::Ticket_Script( bool sep_ticket ) const
+{
+	return QDir( Extras_Dir() ).filePath( sep_ticket
+		? QStringLiteral( "create_septicket.py" )
+		: QStringLiteral( "create_apticket.py" ) );
+}
+
+bool iOS_Firmware_Tool_Window::Find_Python( QString *exe_out, QStringList *prefix_args_out ) const
+{
+	if( ! exe_out || ! prefix_args_out )
+		return false;
+	prefix_args_out->clear();
+	*exe_out = AQ_Resolve_Host_Tool(
+		QStringLiteral( "Apple_SoC_Firmware/Python" ),
+		QStringList() << QStringLiteral( "py" ) << QStringLiteral( "py.exe" )
+		              << QStringLiteral( "python3" ) << QStringLiteral( "python3.exe" )
+		              << QStringLiteral( "python" ) << QStringLiteral( "python.exe" ) );
+	if( exe_out->isEmpty() )
+		return false;
+	if( QFileInfo( *exe_out ).completeBaseName().compare( QLatin1String( "py" ), Qt::CaseInsensitive ) == 0 )
+		*prefix_args_out << QStringLiteral( "-3" );
+	return true;
+}
+
+bool iOS_Firmware_Tool_Window::Ensure_Python_Ready()
+{
+	if( ! Find_Python( &Python_Exe, &Python_Prefix ) )
+	{
+		QMessageBox::warning( this, tr( "Python 3" ),
+			tr( "Python 3 was not found.\n\n"
+			    "Set File → Configure → iOS firmware tools → Python 3, "
+			    "or install Python and add it to PATH. AQEMU starts it — you do not type commands." ) );
+		return false;
+	}
+	if( ! QFile::exists( Ticket_Script( false ) ) )
+	{
+		QMessageBox::warning( this, tr( "Missing script" ),
+			tr( "create_apticket.py was not found:\n%1" ).arg( Ticket_Script( false ) ) );
+		return false;
+	}
+	return true;
+}
+
+void iOS_Firmware_Tool_Window::Suggest_From_Extract_Dir()
+{
+	const QString out_dir = Edit_Output_Dir->text().trimmed();
+	if( out_dir.isEmpty() )
+		return;
+	QDir d( out_dir );
+	const QString man = d.filePath( QStringLiteral( "BuildManifest.plist" ) );
+	if( QFile::exists( man ) )
+		Edit_Manifest->setText( QDir::toNativeSeparators( man ) );
+	if( Edit_Ticket_Out->text().trimmed().isEmpty() )
+		Edit_Ticket_Out->setText( QDir::toNativeSeparators(
+			d.filePath( QStringLiteral( "root_ticket.der" ) ) ) );
+	if( Edit_Sep_Ticket_Out->text().trimmed().isEmpty() )
+		Edit_Sep_Ticket_Out->setText( QDir::toNativeSeparators(
+			d.filePath( QStringLiteral( "sep_root_ticket.der" ) ) ) );
+
+	QStringList dt = d.entryList( QStringList() << QStringLiteral( "*DeviceTree*.im4p" ), QDir::Files );
+	QDir flash( d.filePath( QStringLiteral( "Firmware/all_flash" ) ) );
+	if( dt.isEmpty() && flash.exists() )
+		dt = flash.entryList( QStringList() << QStringLiteral( "*DeviceTree*.im4p" ), QDir::Files );
+	if( ! dt.isEmpty() && Edit_IM4P_Path->text().trimmed().isEmpty() )
+	{
+		const QString base = ( flash.exists() && QFile::exists( flash.absoluteFilePath( dt.first() ) ) )
+			? flash.absoluteFilePath( dt.first() ) : d.absoluteFilePath( dt.first() );
+		Edit_IM4P_Path->setText( QDir::toNativeSeparators( base ) );
+	}
+
+	QDir flash2( d.filePath( QStringLiteral( "Firmware/all_flash" ) ) );
+	const QString sep_im4p = flash2.filePath( QStringLiteral( "sep-firmware.n104.RELEASE.im4p" ) );
+	if( QFile::exists( sep_im4p ) && Edit_SEP_IM4P->text().trimmed().isEmpty() )
+		Edit_SEP_IM4P->setText( QDir::toNativeSeparators( sep_im4p ) );
+	if( Edit_SEP_Dec->text().trimmed().isEmpty() )
+		Edit_SEP_Dec->setText( QDir::toNativeSeparators(
+			d.filePath( QStringLiteral( "sep-firmware.n104.RELEASE" ) ) ) );
+	if( Edit_SEP_Out->text().trimmed().isEmpty() )
+		Edit_SEP_Out->setText( QDir::toNativeSeparators(
+			d.filePath( QStringLiteral( "sep-firmware.n104.RELEASE.new.img4" ) ) ) );
+
+	QString ramdisk;
+	qint64 best = 0;
+	const QStringList dmgs = d.entryList( QStringList() << QStringLiteral( "*.dmg" ), QDir::Files );
+	for( const QString &f : dmgs )
+	{
+		const QFileInfo fi( d.absoluteFilePath( f ) );
+		if( fi.size() > best )
+		{
+			best = fi.size();
+			ramdisk = fi.absoluteFilePath();
+		}
+	}
+	if( ! ramdisk.isEmpty() )
+		emit Restore_Ramdisk_Suggested( QDir::toNativeSeparators( ramdisk ) );
+}
+
+void iOS_Firmware_Tool_Window::Run_Forge_Tickets()
+{
+	if( Process->state() != QProcess::NotRunning )
+	{
+		QMessageBox::information( this, tr( "Busy" ), tr( "Wait for the current task to finish." ) );
+		return;
+	}
+	if( ! Ensure_Python_Ready() )
+		return;
+	const QString man = Edit_Manifest->text().trimmed();
+	const QString shsh = Edit_SHSH->text().trimmed();
+	if( man.isEmpty() || ! QFile::exists( man ) )
+	{
+		QMessageBox::warning( this, tr( "BuildManifest" ),
+			tr( "Unpack the IPSW first (Step 1), or browse to BuildManifest.plist." ) );
+		return;
+	}
+	if( shsh.isEmpty() || ! QFile::exists( shsh ) )
+	{
+		QMessageBox::warning( this, tr( "ticket.shsh2" ),
+			tr( "Select ChefKiss ticket.shsh2 (ChefKiss extras… or extras/Inferno/ticket.shsh2)." ) );
+		return;
+	}
+	QSettings s;
+	s.setValue( QStringLiteral( "Apple_SoC_Firmware/SHSH" ), shsh );
+	if( Edit_Ticket_Out->text().trimmed().isEmpty() )
+		Edit_Ticket_Out->setText( QDir::toNativeSeparators(
+			QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "root_ticket.der" ) ) ) );
+	if( Edit_Sep_Ticket_Out->text().trimmed().isEmpty() )
+		Edit_Sep_Ticket_Out->setText( QDir::toNativeSeparators(
+			QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "sep_root_ticket.der" ) ) ) );
+
+	Tried_Pip = false;
+	Chain_Sep_Ticket = true;
+	Last_Operation = Pending_Op::PipInstall;
+	Text_Console_Log->append( tr( "\nChecking Python packages (pyasn1)…" ) );
+	QStringList args = Python_Prefix;
+	args << QStringLiteral( "-c" )
+	     << QStringLiteral( "import pyasn1, pyasn1_modules; print('pyasn1-ok')" );
+	Process->start( Python_Exe, args );
+}
+
+bool iOS_Firmware_Tool_Window::Start_Ticket_Script( bool sep_ticket )
+{
+	const QString out = sep_ticket
+		? Edit_Sep_Ticket_Out->text().trimmed()
+		: Edit_Ticket_Out->text().trimmed();
+	if( out.isEmpty() || ! QFile::exists( Ticket_Script( sep_ticket ) ) )
+		return false;
+	QDir().mkpath( QFileInfo( out ).absolutePath() );
+	Last_Ticket_Out = out;
+	Last_Operation = sep_ticket ? Pending_Op::TicketSep : Pending_Op::TicketAp;
+	QStringList args = Python_Prefix;
+	args << Ticket_Script( sep_ticket )
+	     << CB_Ticket_Model->currentData().toString()
+	     << Edit_Manifest->text().trimmed()
+	     << Edit_SHSH->text().trimmed()
+	     << out;
+	Text_Console_Log->append( tr( "\nForging %1…" )
+		.arg( sep_ticket ? tr( "SEP ticket" ) : tr( "restore ticket" ) ) );
+	Process->start( Python_Exe, args );
+	return true;
+}
+
+void iOS_Firmware_Tool_Window::Run_Pack_SEP()
+{
+	if( Process->state() != QProcess::NotRunning )
+	{
+		QMessageBox::information( this, tr( "Busy" ), tr( "Wait for the current task to finish." ) );
+		return;
+	}
+	if( ! Ensure_Img4_Available() )
+		return;
+	const QString im4p = Edit_SEP_IM4P->text().trimmed();
+	const QString ivkey = Edit_SEP_IVKEY->text().trimmed().remove( QLatin1Char( ' ' ) );
+	const QString ticket = Edit_Sep_Ticket_Out->text().trimmed();
+	if( im4p.isEmpty() || ! QFile::exists( im4p ) )
+	{
+		QMessageBox::warning( this, tr( "SEP IM4P" ),
+			tr( "Unpack the IPSW first, or browse to sep-firmware.n104.RELEASE.im4p." ) );
+		return;
+	}
+	if( ivkey.isEmpty() )
+	{
+		QMessageBox::warning( this, tr( "IVKEY" ),
+			tr( "Paste the Apple Wiki IV and key concatenated (no space) for this SEP file." ) );
+		return;
+	}
+	if( ticket.isEmpty() || ! QFile::exists( ticket ) )
+	{
+		QMessageBox::warning( this, tr( "SEP ticket" ),
+			tr( "Forge restore + SEP tickets (Step 2) first." ) );
+		return;
+	}
+	if( Edit_SEP_Dec->text().trimmed().isEmpty() )
+		Edit_SEP_Dec->setText( QDir::toNativeSeparators(
+			QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "sep-firmware.n104.RELEASE" ) ) ) );
+	if( Edit_SEP_Out->text().trimmed().isEmpty() )
+		Edit_SEP_Out->setText( QDir::toNativeSeparators(
+			QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "sep-firmware.n104.RELEASE.new.img4" ) ) ) );
+	QDir().mkpath( QFileInfo( Edit_SEP_Dec->text() ).absolutePath() );
+	Img4_Stdout_Buf.clear();
+	Last_Operation = Pending_Op::Img4Decrypt;
+	QStringList args;
+	args << QStringLiteral( "-v" )
+	     << QStringLiteral( "-i" ) << im4p
+	     << QStringLiteral( "-o" ) << Edit_SEP_Dec->text().trimmed()
+	     << QStringLiteral( "-k" ) << ivkey;
+	Text_Console_Log->append( tr( "\nDecrypting SEP firmware with img4…" ) );
+	Process->start( Img4_Exe, args );
+}
+
+bool iOS_Firmware_Tool_Window::Start_Img4_Pack()
+{
+	const QString dec = Edit_SEP_Dec->text().trimmed();
+	const QString out = Edit_SEP_Out->text().trimmed();
+	const QString ticket = Edit_Sep_Ticket_Out->text().trimmed();
+	if( ! QFile::exists( dec ) )
+		return false;
+	Last_Operation = Pending_Op::Img4Pack;
+	QStringList args;
+	args << QStringLiteral( "-A" ) << QStringLiteral( "-F" )
+	     << QStringLiteral( "-o" ) << out
+	     << QStringLiteral( "-i" ) << dec
+	     << QStringLiteral( "-M" ) << ticket
+	     << QStringLiteral( "-T" ) << QStringLiteral( "rsep" )
+	     << QStringLiteral( "-V" ) << Last_Img4_Version;
+	Text_Console_Log->append( tr( "\nPacking SEP firmware (tag rsep, version %1)…" )
+		.arg( Last_Img4_Version ) );
+	Process->start( Img4_Exe, args );
+	return true;
+}
+
 void iOS_Firmware_Tool_Window::On_Process_Output()
 {
 	const QString out = QString::fromLocal8Bit( Process->readAllStandardOutput() );
 	const QString err = QString::fromLocal8Bit( Process->readAllStandardError() );
-	if( ! out.isEmpty() ) Text_Console_Log->append( out );
+	if( ! out.isEmpty() )
+	{
+		Text_Console_Log->append( out );
+		if( Last_Operation == Pending_Op::Img4Decrypt )
+			Img4_Stdout_Buf += out;
+	}
 	if( ! err.isEmpty() ) Text_Console_Log->append( err );
 }
 
@@ -277,6 +687,29 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 	Q_UNUSED( exitStatus );
 	const Pending_Op op = Last_Operation;
 	Last_Operation = Pending_Op::None;
+
+	if( op == Pending_Op::PipInstall )
+	{
+		if( exitCode == 0 )
+		{
+			Start_Ticket_Script( false );
+			return;
+		}
+		if( ! Tried_Pip )
+		{
+			Tried_Pip = true;
+			Last_Operation = Pending_Op::PipInstall;
+			Text_Console_Log->append( tr( "Installing pyasn1 + pyasn1-modules (pip)…" ) );
+			QStringList args = Python_Prefix;
+			args << QStringLiteral( "-m" ) << QStringLiteral( "pip" )
+			     << QStringLiteral( "install" ) << QStringLiteral( "--user" )
+			     << QStringLiteral( "pyasn1" ) << QStringLiteral( "pyasn1-modules" );
+			Process->start( Python_Exe, args );
+			return;
+		}
+		Text_Console_Log->append( tr( "\nCould not import/install pyasn1. Install Python 3 and retry." ) );
+		return;
+	}
 
 	if( exitCode != 0 )
 	{
@@ -287,6 +720,41 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 
 	Text_Console_Log->append( tr( "\nTask completed successfully." ) );
 
+	if( op == Pending_Op::TicketAp )
+	{
+		Text_Result_Paths->append( tr( "Restore ticket: %1" ).arg( Last_Ticket_Out ) );
+		emit Restore_Ticket_Suggested( Last_Ticket_Out );
+		if( Chain_Sep_Ticket )
+			Start_Ticket_Script( true );
+		return;
+	}
+	if( op == Pending_Op::TicketSep )
+	{
+		Text_Result_Paths->append( tr( "SEP ticket: %1" ).arg( Last_Ticket_Out ) );
+		Text_Console_Log->append( tr(
+			"Next: Step 3 — paste Apple Wiki IVKEY and Decrypt + pack SEP firmware." ) );
+		return;
+	}
+
+	if( op == Pending_Op::Img4Decrypt )
+	{
+		const QStringList lines = Img4_Stdout_Buf.split( QRegularExpression( QStringLiteral( "[\\r\\n]+" ) ),
+			Qt::SkipEmptyParts );
+		Last_Img4_Version = lines.isEmpty() ? QStringLiteral( "none" ) : lines.last().trimmed();
+		Text_Console_Log->append( tr( "img4 decrypt version token: %1" ).arg( Last_Img4_Version ) );
+		if( ! Start_Img4_Pack() )
+			Text_Console_Log->append( tr( "Could not start img4 pack (decrypted SEP missing)." ) );
+		return;
+	}
+	if( op == Pending_Op::Img4Pack )
+	{
+		const QString packed = Edit_SEP_Out->text().trimmed();
+		Text_Result_Paths->append( tr( "SEP firmware: %1" ).arg( packed ) );
+		emit Sep_Firmware_Suggested( packed );
+		Text_Console_Log->append( tr( "SEP firmware applied to MACHINE if the field was empty or updated." ) );
+		return;
+	}
+
 	if( op == Pending_Op::Im4pOp )
 	{
 		if( ! Last_IM4P_Output.isEmpty() )
@@ -295,6 +763,9 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 				tr( "IM4P output: %1\n" ).arg( Last_IM4P_Output ) ) );
 			Text_Console_Log->append(
 				tr( "IM4P output: %1" ).arg( Last_IM4P_Output ) );
+			if( Last_IM4P_Output.endsWith( QLatin1String( ".dec" ), Qt::CaseInsensitive ) ||
+			    Last_IM4P_Output.endsWith( QLatin1String( ".dtb" ), Qt::CaseInsensitive ) )
+				emit DeviceTree_Path_Suggested( Last_IM4P_Output );
 		}
 		return;
 	}
@@ -310,7 +781,6 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 	QDir d( out_dir + "/Firmware/all_flash" );
 	if( d.exists() )
 	{
-		// Prefer extracted DeviceTree (.dtb / .dec), never raw .im4p for -dtb.
 		const QStringList files = d.entryList(
 			QStringList() << "*.dtb" << "*.dec" << "*.im4p" << "*.dmg", QDir::Files );
 		for( const QString &f : files )
@@ -326,6 +796,8 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 		}
 	}
 	Text_Result_Paths->setText( QDir::toNativeSeparators( summary ) );
+	Suggest_From_Extract_Dir();
+	emit Ipsw_Path_Suggested( Edit_IPSW_Path->text().trimmed() );
 
 	if( ! dtb_found.isEmpty() )
 	{
@@ -333,6 +805,7 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 			tr( "Suggested DeviceTree (extracted): %1" ).arg( dtb_found ) );
 		emit DeviceTree_Path_Suggested( dtb_found );
 	}
+	Text_Console_Log->append( tr( "Next: Step 2 — Forge restore + SEP tickets." ) );
 }
 
 void iOS_Firmware_Tool_Window::Copy_Output_Paths()

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -16,6 +16,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QSettings>
+#include <QIODevice>
 #include <QStandardPaths>
 #include <QProcessEnvironment>
 #include <QUrl>
@@ -364,6 +365,8 @@ void iOS_Firmware_Tool_Window::Browse_SEP_IM4P()
 
 void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 {
+	if( ! Ensure_Process_Idle() )
+		return;
 	const QString ipsw = Edit_IPSW_Path->text().trimmed();
 	const QString out_dir = Edit_Output_Dir->text().trimmed();
 
@@ -395,6 +398,8 @@ void iOS_Firmware_Tool_Window::Run_IPSW_Extraction()
 
 void iOS_Firmware_Tool_Window::Run_IM4P_Operation()
 {
+	if( ! Ensure_Process_Idle() )
+		return;
 	if( ! Ensure_PyIMG4_Available() )
 		return;
 
@@ -455,7 +460,10 @@ bool iOS_Firmware_Tool_Window::Find_Python( QString *exe_out, QStringList *prefi
 		QStringLiteral( "Apple_SoC_Firmware/Python" ),
 		QStringList() << QStringLiteral( "py" ) << QStringLiteral( "py.exe" )
 		              << QStringLiteral( "python3" ) << QStringLiteral( "python3.exe" )
-		              << QStringLiteral( "python" ) << QStringLiteral( "python.exe" ) );
+		              << QStringLiteral( "python" ) << QStringLiteral( "python.exe" ),
+		QStringList() << QStringLiteral( "python.exe" ) << QStringLiteral( "python3.exe" )
+		              << QStringLiteral( "py.exe" ) << QStringLiteral( "python" )
+		              << QStringLiteral( "python3" ) << QStringLiteral( "py" ) );
 	if( exe_out->isEmpty() )
 		return false;
 	if( QFileInfo( *exe_out ).completeBaseName().compare( QLatin1String( "py" ), Qt::CaseInsensitive ) == 0 )
@@ -479,7 +487,56 @@ bool iOS_Firmware_Tool_Window::Ensure_Python_Ready()
 			tr( "create_apticket.py was not found:\n%1" ).arg( Ticket_Script( false ) ) );
 		return false;
 	}
+	if( ! QFile::exists( Ticket_Script( true ) ) )
+	{
+		QMessageBox::warning( this, tr( "Missing script" ),
+			tr( "create_septicket.py was not found:\n%1" ).arg( Ticket_Script( true ) ) );
+		return false;
+	}
 	return true;
+}
+
+bool iOS_Firmware_Tool_Window::Ensure_Process_Idle()
+{
+	if( Process->state() == QProcess::NotRunning )
+		return true;
+	QMessageBox::information( this, tr( "Busy" ), tr( "Wait for the current task to finish." ) );
+	return false;
+}
+
+QString iOS_Firmware_Tool_Window::Restore_Ramdisk_From_Manifest( const QString &manifest_path,
+                                                                const QString &extract_dir ) const
+{
+	QFile f( manifest_path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return QString();
+	const QByteArray data = f.readAll();
+	const QString text = QString::fromUtf8( data );
+	QRegularExpression xml_re(
+		QStringLiteral( "RestoreRamDisk</key>\\s*<string>([^<]+\\.dmg)</string>" ),
+		QRegularExpression::CaseInsensitiveOption );
+	const QRegularExpressionMatch xml = xml_re.match( text );
+	QString name;
+	if( xml.hasMatch() )
+		name = QFileInfo( xml.captured( 1 ).trimmed() ).fileName();
+	if( name.isEmpty() )
+	{
+		const int key = data.indexOf( "RestoreRamDisk" );
+		if( key >= 0 )
+		{
+			const QString slice = QString::fromLatin1( data.mid( key, 512 ) );
+			QRegularExpression dmg_re( QStringLiteral( "([0-9A-Za-z._-]+\\.dmg)" ) );
+			const QRegularExpressionMatch dmg = dmg_re.match( slice );
+			if( dmg.hasMatch() )
+				name = dmg.captured( 1 );
+		}
+	}
+	if( name.isEmpty() )
+		return QString();
+	const QString path = QDir( extract_dir ).filePath( name );
+	if( QFile::exists( path ) )
+		return path;
+	return QString();
 }
 
 void iOS_Firmware_Tool_Window::Suggest_From_Extract_Dir()
@@ -520,29 +577,27 @@ void iOS_Firmware_Tool_Window::Suggest_From_Extract_Dir()
 		Edit_SEP_Out->setText( QDir::toNativeSeparators(
 			d.filePath( QStringLiteral( "sep-firmware.n104.RELEASE.new.img4" ) ) ) );
 
-	QString ramdisk;
-	qint64 best = 0;
-	const QStringList dmgs = d.entryList( QStringList() << QStringLiteral( "*.dmg" ), QDir::Files );
-	for( const QString &f : dmgs )
+	QString ramdisk = Restore_Ramdisk_From_Manifest(
+		Edit_Manifest->text().trimmed().isEmpty() ? man : Edit_Manifest->text().trimmed(),
+		out_dir );
+	if( ramdisk.isEmpty() )
 	{
-		const QFileInfo fi( d.absoluteFilePath( f ) );
-		if( fi.size() > best )
-		{
-			best = fi.size();
-			ramdisk = fi.absoluteFilePath();
-		}
+		Text_Console_Log->append( tr(
+			"No RestoreRamDisk in BuildManifest — not filling restore ramdisk "
+			"(do not use the largest IPSW .dmg; that is usually the OS image)." ) );
 	}
-	if( ! ramdisk.isEmpty() )
+	else
+	{
+		Text_Console_Log->append( tr( "Restore ramdisk (BuildManifest): %1" ).arg(
+			QDir::toNativeSeparators( ramdisk ) ) );
 		emit Restore_Ramdisk_Suggested( QDir::toNativeSeparators( ramdisk ) );
+	}
 }
 
 void iOS_Firmware_Tool_Window::Run_Forge_Tickets()
 {
-	if( Process->state() != QProcess::NotRunning )
-	{
-		QMessageBox::information( this, tr( "Busy" ), tr( "Wait for the current task to finish." ) );
+	if( ! Ensure_Process_Idle() )
 		return;
-	}
 	if( ! Ensure_Python_Ready() )
 		return;
 	const QString man = Edit_Manifest->text().trimmed();
@@ -602,11 +657,8 @@ bool iOS_Firmware_Tool_Window::Start_Ticket_Script( bool sep_ticket )
 
 void iOS_Firmware_Tool_Window::Run_Pack_SEP()
 {
-	if( Process->state() != QProcess::NotRunning )
-	{
-		QMessageBox::information( this, tr( "Busy" ), tr( "Wait for the current task to finish." ) );
+	if( ! Ensure_Process_Idle() )
 		return;
-	}
 	if( ! Ensure_Img4_Available() )
 		return;
 	const QString im4p = Edit_SEP_IM4P->text().trimmed();
@@ -692,7 +744,12 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 	{
 		if( exitCode == 0 )
 		{
-			Start_Ticket_Script( false );
+			if( ! Start_Ticket_Script( false ) )
+			{
+				QMessageBox::warning( this, tr( "Restore ticket" ),
+					tr( "Could not start create_apticket.py:\n%1" )
+						.arg( Ticket_Script( false ) ) );
+			}
 			return;
 		}
 		if( ! Tried_Pip )
@@ -724,8 +781,13 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 	{
 		Text_Result_Paths->append( tr( "Restore ticket: %1" ).arg( Last_Ticket_Out ) );
 		emit Restore_Ticket_Suggested( Last_Ticket_Out );
-		if( Chain_Sep_Ticket )
-			Start_Ticket_Script( true );
+		if( Chain_Sep_Ticket && ! Start_Ticket_Script( true ) )
+		{
+			QMessageBox::warning( this, tr( "SEP ticket" ),
+				tr( "Restore ticket was written, but create_septicket.py could not be started:\n%1" )
+					.arg( Ticket_Script( true ) ) );
+			Text_Console_Log->append( tr( "SEP ticket step skipped — missing script or output path." ) );
+		}
 		return;
 	}
 	if( op == Pending_Op::TicketSep )
@@ -765,7 +827,10 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 				tr( "IM4P output: %1" ).arg( Last_IM4P_Output ) );
 			if( Last_IM4P_Output.endsWith( QLatin1String( ".dec" ), Qt::CaseInsensitive ) ||
 			    Last_IM4P_Output.endsWith( QLatin1String( ".dtb" ), Qt::CaseInsensitive ) )
-				emit DeviceTree_Path_Suggested( Last_IM4P_Output );
+			{
+				if( Edit_IM4P_Path->text().contains( QLatin1String( "DeviceTree" ), Qt::CaseInsensitive ) )
+					emit DeviceTree_Path_Suggested( Last_IM4P_Output );
+			}
 		}
 		return;
 	}
@@ -787,8 +852,7 @@ void iOS_Firmware_Tool_Window::On_Process_Finished( int exitCode, QProcess::Exit
 		{
 			const QString full = QDir::toNativeSeparators( d.absoluteFilePath( f ) );
 			summary += QString( "Payload: %1\n" ).arg( full );
-			const bool is_dt = f.contains( "DeviceTree", Qt::CaseInsensitive ) ||
-			                   f.contains( "dtb", Qt::CaseInsensitive );
+			const bool is_dt = f.contains( "DeviceTree", Qt::CaseInsensitive );
 			const bool usable = f.endsWith( QLatin1String( ".dtb" ), Qt::CaseInsensitive ) ||
 			                    f.endsWith( QLatin1String( ".dec" ), Qt::CaseInsensitive );
 			if( is_dt && usable && dtb_found.isEmpty() )

--- a/src/iOS_Firmware_Tool_Window.h
+++ b/src/iOS_Firmware_Tool_Window.h
@@ -48,6 +48,8 @@ private:
 	bool Find_Python( QString *exe_out, QStringList *prefix_args_out ) const;
 	bool Ensure_Python_Ready();
 	void Suggest_From_Extract_Dir();
+	QString Restore_Ramdisk_From_Manifest( const QString &manifest_path, const QString &extract_dir ) const;
+	bool Ensure_Process_Idle();
 	bool Start_Ticket_Script( bool sep_ticket );
 	QString Extras_Dir() const;
 	QString Ticket_Script( bool sep_ticket ) const;

--- a/src/iOS_Firmware_Tool_Window.h
+++ b/src/iOS_Firmware_Tool_Window.h
@@ -18,16 +18,24 @@ public:
 	~iOS_Firmware_Tool_Window() = default;
 
 signals:
-	/** Emitted when an extracted DeviceTree (.dtb / .dec) is found and may be applied. */
 	void DeviceTree_Path_Suggested( const QString &path );
+	void Restore_Ticket_Suggested( const QString &path );
+	void Ipsw_Path_Suggested( const QString &path );
+	void Restore_Ramdisk_Suggested( const QString &path );
+	void Sep_Firmware_Suggested( const QString &path );
 
 private slots:
 	void Browse_IPSW_File();
 	void Browse_Output_Dir();
 	void Browse_IM4P_File();
+	void Browse_Manifest();
+	void Browse_SHSH();
+	void Browse_SEP_IM4P();
+	void Run_Pack_SEP();
 
 	void Run_IPSW_Extraction();
 	void Run_IM4P_Operation();
+	void Run_Forge_Tickets();
 	void Copy_Output_Paths();
 
 	void On_Process_Output();
@@ -37,12 +45,34 @@ private:
 	void Setup_Ui();
 	QString Find_PyIMG4_Executable() const;
 	bool Ensure_PyIMG4_Available();
+	bool Find_Python( QString *exe_out, QStringList *prefix_args_out ) const;
+	bool Ensure_Python_Ready();
+	void Suggest_From_Extract_Dir();
+	bool Start_Ticket_Script( bool sep_ticket );
+	QString Extras_Dir() const;
+	QString Ticket_Script( bool sep_ticket ) const;
+	QString Find_Img4_Executable() const;
+	bool Ensure_Img4_Available();
+	bool Start_Img4_Pack();
 
 	QLineEdit *Edit_IPSW_Path;
 	QLineEdit *Edit_Output_Dir;
 	QPushButton *Btn_Browse_IPSW;
 	QPushButton *Btn_Browse_OutDir;
 	QPushButton *Btn_Start_Unpack;
+
+	QComboBox *CB_Ticket_Model;
+	QLineEdit *Edit_Manifest;
+	QLineEdit *Edit_SHSH;
+	QLineEdit *Edit_Ticket_Out;
+	QLineEdit *Edit_Sep_Ticket_Out;
+	QPushButton *Btn_Forge_Tickets;
+
+	QLineEdit *Edit_SEP_IM4P;
+	QLineEdit *Edit_SEP_IVKEY;
+	QLineEdit *Edit_SEP_Dec;
+	QLineEdit *Edit_SEP_Out;
+	QPushButton *Btn_Pack_SEP;
 
 	QLineEdit *Edit_IM4P_Path;
 	QLineEdit *Edit_AES_IV;
@@ -57,10 +87,19 @@ private:
 
 	QProcess *Process;
 	QString PyIMG4_Exe;
+	QString Python_Exe;
+	QStringList Python_Prefix;
+	QString Img4_Exe;
 	QString Last_IM4P_Output;
+	QString Last_Ticket_Out;
+	QString Img4_Stdout_Buf;
+	QString Last_Img4_Version;
+	bool Chain_Sep_Ticket;
+	bool Tried_Pip;
 
-	enum class Pending_Op { None, IpswExtract, Im4pOp };
+	enum class Pending_Op { None, IpswExtract, Im4pOp, PipInstall, TicketAp, TicketSep,
+	                        Img4Decrypt, Img4Pack };
 	Pending_Op Last_Operation;
 };
 
-#endif // IOS_FIRMWARE_TOOL_WINDOW_H
+#endif

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -42,4 +42,4 @@ Install dirs `qemu-build*` / `qemu-install` are gitignored.
 
 ## Optional: pyimg4 (iOS firmware tool)
 
-AQEMU’s **File → iOS Firmware Tool** unpacks IPSWs with PowerShell and optionally shells out to an external **`pyimg4`** for IM4P extract/info/decrypt. AQEMU does **not** vendor `img4tool` / `pyimg4` under `third_party/` — install `pyimg4` yourself and keep it on `PATH` (or place `pyimg4.exe` next to `aqemu.exe`).
+AQEMU’s **File → iOS Firmware Tool** unpacks IPSWs, forges restore/SEP tickets (bundled Python scripts), packs SEP firmware with external **`img4`**, and processes IM4P with **`pyimg4`**. AQEMU does **not** vendor `img4lib` / `pyimg4` under `third_party/` — put `img4.exe` / `pyimg4.exe` next to `aqemu.exe` or on PATH. Python 3 is only started from the GUI (pip-installs pyasn1 if needed).


### PR DESCRIPTION
## Summary
- File → iOS Firmware Tool now unpacks the IPSW, forges restore/SEP tickets (bundled ChefKiss scripts), and can decrypt/pack SEP firmware with img4 — no terminal Python/`for /f` steps.
- Forged ticket, IPSW, ramdisk, DeviceTree, and packed SEP firmware are applied to the current VM MACHINE fields.
- File → Configure → iOS firmware tools: optional Python 3 / pyimg4 / img4 paths win when the file exists; otherwise search next to AQEMU then PATH.
- Guide (`extras/Inferno/iOS_Installation.md`) and README match the in-app flow. Ticket scripts are copied next to `aqemu.exe` at build time.

## Test plan
- [ ] File → iOS Firmware Tool: unpack IPSW, confirm BuildManifest and SEP IM4P fill in
- [ ] Forge restore + SEP tickets with ChefKiss `ticket.shsh2`; MACHINE Restore ticket updates
- [ ] With img4 + Apple Wiki IVKEY, Decrypt + pack SEP firmware; MACHINE SEP firmware updates
- [ ] File → Configure: set Python/pyimg4/img4 to non-PATH locations and confirm Firmware Tool uses them
- [ ] Clear those settings and confirm PATH / beside-aqemu fallback still works
- [ ] Confirm `ticket.shsh2` and IPSW extracts are not in the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dab9213e6660d9dd19269f29b17d6d8b4809d984. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->