### PR TITLE
fix: parse IPSW restore ramdisk from BuildManifest Path

### DIFF
--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -511,31 +511,88 @@ QString iOS_Firmware_Tool_Window::Restore_Ramdisk_From_Manifest( const QString &
 	if( ! f.open( QIODevice::ReadOnly ) )
 		return QString();
 	const QByteArray data = f.readAll();
-	const QString text = QString::fromUtf8( data );
-	QRegularExpression xml_re(
-		QStringLiteral( "RestoreRamDisk</key>\\s*<string>([^<]+\\.dmg)</string>" ),
+	f.close();
+
+	const QString model = CB_Ticket_Model
+		? CB_Ticket_Model->currentData().toString() : QString();
+	const QRegularExpression path_xml(
+		QStringLiteral( "<key>Path</key>\\s*<string>([^<]+\\.dmg)</string>" ),
 		QRegularExpression::CaseInsensitiveOption );
-	const QRegularExpressionMatch xml = xml_re.match( text );
-	QString name;
-	if( xml.hasMatch() )
-		name = QFileInfo( xml.captured( 1 ).trimmed() ).fileName();
-	if( name.isEmpty() )
+	const QRegularExpression numbered_dmg( QStringLiteral( "([0-9]{3}-[0-9]+-[0-9]+\\.dmg)" ) );
+
+	QString best_path;
+	int best_score = -1;
+	int pos = 0;
+	const QByteArray needle( "RestoreRamDisk" );
+	while( ( pos = data.indexOf( needle, pos ) ) >= 0 )
 	{
-		const int key = data.indexOf( "RestoreRamDisk" );
-		if( key >= 0 )
+		const QString ahead = QString::fromUtf8( data.mid( pos, 4096 ) );
+		if( ahead.contains( QLatin1String( "CustomerRamDisk" ), Qt::CaseInsensitive )
+		    && ! ahead.contains( QLatin1String( ".dmg" ), Qt::CaseInsensitive ) )
 		{
-			const QString slice = QString::fromLatin1( data.mid( key, 512 ) );
-			QRegularExpression dmg_re( QStringLiteral( "([0-9A-Za-z._-]+\\.dmg)" ) );
-			const QRegularExpressionMatch dmg = dmg_re.match( slice );
+			pos += needle.size();
+			continue;
+		}
+
+		QString name;
+		const QRegularExpressionMatch xml = path_xml.match( ahead );
+		if( xml.hasMatch() )
+			name = QFileInfo( xml.captured( 1 ).trimmed() ).fileName();
+		if( name.isEmpty() )
+		{
+			const QRegularExpressionMatch dmg = numbered_dmg.match( ahead );
 			if( dmg.hasMatch() )
 				name = dmg.captured( 1 );
 		}
+		if( name.isEmpty() || ! name.endsWith( QLatin1String( ".dmg" ), Qt::CaseInsensitive ) )
+		{
+			pos += needle.size();
+			continue;
+		}
+
+		const QString cand = QDir( extract_dir ).filePath( name );
+		if( ! QFile::exists( cand ) )
+		{
+			pos += needle.size();
+			continue;
+		}
+
+		const QString back = QString::fromUtf8( data.mid( qMax( 0, pos - 8000 ), 8000 ) );
+		int score = 1;
+		if( ! model.isEmpty() && back.contains( model, Qt::CaseInsensitive ) )
+			score += 10;
+		if( back.contains( QLatin1String( "Erase" ), Qt::CaseInsensitive ) )
+			score += 5;
+		if( back.contains( QLatin1String( "Customer" ), Qt::CaseInsensitive ) )
+			score += 2;
+		if( score > best_score )
+		{
+			best_score = score;
+			best_path = cand;
+		}
+		pos += needle.size();
 	}
-	if( name.isEmpty() )
-		return QString();
-	const QString path = QDir( extract_dir ).filePath( name );
-	if( QFile::exists( path ) )
-		return path;
+
+	if( ! best_path.isEmpty() )
+		return best_path;
+
+	const QString restore_plist = QDir( extract_dir ).filePath( QStringLiteral( "Restore.plist" ) );
+	QFile rf( restore_plist );
+	if( rf.open( QIODevice::ReadOnly ) )
+	{
+		const QString rtext = QString::fromUtf8( rf.readAll() );
+		QRegularExpression user_re(
+			QStringLiteral( "RestoreRamDisks</key>\\s*<dict>[\\s\\S]{0,400}?<key>User</key>\\s*<string>([^<]+\\.dmg)</string>" ),
+			QRegularExpression::CaseInsensitiveOption );
+		const QRegularExpressionMatch um = user_re.match( rtext );
+		if( um.hasMatch() )
+		{
+			const QString cand = QDir( extract_dir ).filePath(
+				QFileInfo( um.captured( 1 ).trimmed() ).fileName() );
+			if( QFile::exists( cand ) )
+				return cand;
+		}
+	}
 	return QString();
 }
 


### PR DESCRIPTION
## Summary
- Firmware Tool no longer looks for a `.dmg` string immediately after `RestoreRamDisk` (that key is `CustomerRamDisk` in VariantContents).
- It now walks each `RestoreRamDisk` entry and reads `Info/Path` (typical IPSW layout: `BuildIdentities → Manifest → RestoreRamDisk → Info → Path`).
- Prefers the identity matching the selected model (`n104ap`) and Customer Erase; falls back to `Restore.plist` `RestoreRamDisks/User`.

## Test plan
- [ ] Unpack a real iOS 14 t8030 IPSW in File → iOS Firmware Tool
- [ ] Confirm log shows Restore ramdisk (BuildManifest) pointing at the RestoreRamDisk `.dmg` (e.g. `038-44135-124.dmg`), not the OS image
- [ ] Confirm empty MACHINE restore ramdisk is filled with that file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0a6b3b3d2ec960b1e36b550b7da14164530591c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->