### PR TITLE
iOS: NAND sizing, SOS workaround, zsign IPA install, and install guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ installer/wix/.wix/
 *.msix
 *.msixbundle
 
+# Local xerub/img4lib clone (Windows port: scripts/build_img4_windows.ps1)
+third_party/img4lib/
+
 # Bundled QEMU build outputs
 third_party/qemu-build/
 third_party/qemu-build-win/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,24 @@ ADD_CUSTOM_COMMAND( TARGET aqemu POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different
 		"${CMAKE_SOURCE_DIR}/extras/Inferno/create_septicket.py"
 		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/create_septicket.py"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/force_create_fs_partitions.c"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/force_create_fs_partitions.c"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/patch_idevicerestore_cfs.py"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/patch_idevicerestore_cfs.py"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/build_force_cfs.sh"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/build_force_cfs.sh"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/seed-root-gpt.py"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/seed-root-gpt.py"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/format-seed-apfs.sh"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/format-seed-apfs.sh"
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_SOURCE_DIR}/extras/Inferno/wipe-ios-nvme.ps1"
+		"$<TARGET_FILE_DIR:aqemu>/extras/Inferno/wipe-ios-nvme.ps1"
 	COMMENT "Bundle extras/Inferno scripts, ticket helpers, and iOS install guide"
 )
 # companion-bin (idevice* tools) for optional scp into the Ubuntu companion

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Full walkthrough (including re-install): [`extras/Inferno/iOS_Installation.md`](
 ### How to run iOS
 
 1. **New VM Wizard → Apple → iOS (ARM64)** — Inferno `t8030`, 4 vCPUs, ≥4 GB RAM.
-2. Fill **kernel**, **DeviceTree** (extracted `.dtb` / `.dec`), trustcache, ticket, SEP, restore ramdisk. **File → iOS Firmware Tool** unpacks the IPSW, forges tickets, and can pack SEP firmware (`pyimg4` / `img4` on PATH).
+2. Fill **kernel**, **DeviceTree** (extracted `.dtb` / `.dec`), trustcache, ticket, SEP, restore ramdisk. **File → iOS Firmware Tool** unpacks the IPSW, forges tickets, and packs SEP with **`img4`** (Windows: `.\scripts\build_img4_windows.ps1`) and DeviceTree IM4P with **`pyimg4`**.
 3. USB remote **`127.0.0.1:8030`**. **File → Apple SoC Restore**: start companion, Power On iOS, restore IPSW.
 4. **File → Apply iOS filesystem patches…** on the guest `root` disk (not the companion). Then Power On for Setup / SpringBoard.
 5. Toolbar **Net** or **File → Guest Internet / iOS Device Tools…** → **Enable guest internet** for Safari / App Store.
@@ -338,7 +338,7 @@ Apple Silicon macOS guests on Snapdragon Windows hosts — not this release’s 
 
 iOS on Windows 11 is documented **[above](#ios-on-windows-11)** (screenshots, iOS 14 tested, install steps).
 
-The same Inferno binary can target **macOS Apple Silicon (ARM64)** in the wizard. Do not expect M1/`t8101` unless your `qemu-system-applesoc` lists it in `-machine help`. AQEMU does **not** ship IPSW files, kernels, DeviceTrees, or Apple OS images.
+The same Inferno binary can target **macOS Apple Silicon (ARM64)** in the wizard. Do not expect M1/`t8101` unless your `qemu-system-applesoc` lists it in `-machine help`. AQEMU does **not** ship IPSW files, kernels, DeviceTrees, SHSH/`ticket.shsh2`, or Apple OS images.
 
 ---
 

--- a/extras/Inferno/.gitattributes
+++ b/extras/Inferno/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.c text eol=lf
+*.py text eol=lf

--- a/extras/Inferno/README.txt
+++ b/extras/Inferno/README.txt
@@ -17,6 +17,8 @@ This folder also contains helper files used by that guide:
   apply-fs-patches-wsl.sh
   apply-launchd-only-wsl.sh     (set ROOT_IMG; no personal paths)
   wipe-ios-nvme.ps1
+  patches/img4lib_vfs_file_win.c  (Windows overlay for xerub img4lib;
+                            build with scripts/build_img4_windows.ps1)
 
 ChefKiss:
   https://chefkiss.dev/guides/inferno/file-setup/

--- a/extras/Inferno/build_force_cfs.sh
+++ b/extras/Inferno/build_force_cfs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Install aqemu-idr-wrap.sh. Do NOT LD_PRELOAD aqemu_force_cfs.so:
+# Inferno #219 ramrod prints the same three option keys we see, but CFS=true.
+# The preload rewired libimobiledevice plist_dict_set_item and never logged
+# StartRestore ENTER — it can flip CFS without any diagnostic line.
+set -eu
+OUT=${2:-/usr/local/lib/aqemu_force_cfs.so}
+WRAP=/tmp/aqemu-idr-wrap.sh
+# Ubuntu fs.protected_regular: root cannot overwrite another user's file in /tmp.
+rm -f "$WRAP"
+cat > "$WRAP" << 'WEOF'
+#!/bin/bash
+export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+unset LD_PRELOAD
+echo "AQEMU wrap: vanilla idevicerestore (no LD_PRELOAD)"
+echo "AQEMU wrap argv: $*"
+exec /usr/local/bin/idevicerestore "$@"
+WEOF
+chmod 755 "$WRAP"
+echo "AQEMU: wrap will NOT LD_PRELOAD aqemu_force_cfs.so"
+if [ -s "$OUT" ]; then
+  echo "AQEMU: leaving $OUT in place (not preloaded)"
+fi
+echo "AQEMU: wrap installed (preload disabled)"

--- a/extras/Inferno/force_create_fs_partitions.c
+++ b/extras/Inferno/force_create_fs_partitions.c
@@ -1,0 +1,1133 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <dlfcn.h>
+#include <elf.h>
+#include <errno.h>
+#include <link.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+static void aqemu_log(const char *fmt, ...)
+{
+	va_list ap;
+	FILE *f;
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fflush(stderr);
+	f = fopen("/tmp/aqemu-cfs.log", "a");
+	if( f ) {
+		va_start(ap, fmt);
+		vfprintf(f, fmt, ap);
+		va_end(ap);
+		fflush(f);
+		fclose(f);
+	}
+}
+
+typedef void *plist_t;
+typedef void *restored_client_t;
+typedef int restored_error_t;
+
+void plist_dict_set_item(plist_t dict, const char *key, plist_t value);
+restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version);
+restored_error_t restored_send(restored_client_t client, plist_t plist);
+static int aqemu_mprotect_rwx(void *p, size_t n)
+{
+	long ps = sysconf(_SC_PAGESIZE);
+	uintptr_t start, end;
+	if( ps <= 0 )
+		ps = 4096;
+	start = (uintptr_t)p & ~((uintptr_t)ps - 1);
+	end = ((uintptr_t)p + n + (uintptr_t)ps - 1) & ~((uintptr_t)ps - 1);
+	return mprotect((void *)start, (size_t)( end - start ),
+		PROT_READ | PROT_WRITE | PROT_EXEC);
+}
+
+#define AQEMU_JMP 16
+static unsigned char aqemu_rsr_saved[AQEMU_JMP];
+static void *aqemu_rsr_real;
+static int aqemu_rsr_hooked;
+static unsigned char aqemu_p2b_saved[AQEMU_JMP];
+static void *aqemu_p2b_real;
+static int aqemu_p2b_hooked;
+static unsigned char aqemu_p2x_saved[AQEMU_JMP];
+static void *aqemu_p2x_real;
+static int aqemu_p2x_hooked;
+static unsigned char aqemu_rsd_saved[AQEMU_JMP];
+static void *aqemu_rsd_real;
+static int aqemu_rsd_hooked;
+
+void plist_to_bin(plist_t plist, char **bin, uint32_t *length);
+void plist_to_xml(plist_t plist, char **xml, uint32_t *length);
+
+static void aqemu_install_jmp(void *from, void *to)
+{
+	unsigned char *p = (unsigned char *)from;
+	/* endbr64 so IBT/CET still accepts the original function address */
+	p[0] = 0xF3;
+	p[1] = 0x0F;
+	p[2] = 0x1E;
+	p[3] = 0xFA;
+	p[4] = 0x48;
+	p[5] = 0xB8;
+	memcpy(p + 6, &to, 8);
+	p[14] = 0xFF;
+	p[15] = 0xE0;
+	__builtin___clear_cache((char *)from, (char *)from + AQEMU_JMP);
+}
+
+static restored_error_t aqemu_call_real_rsr(restored_client_t client, plist_t options, uint64_t version)
+{
+	typedef restored_error_t (*fn)(restored_client_t, plist_t, uint64_t);
+	restored_error_t r;
+	memcpy(aqemu_rsr_real, aqemu_rsr_saved, AQEMU_JMP);
+	r = ((fn)aqemu_rsr_real)(client, options, version);
+	aqemu_install_jmp(aqemu_rsr_real, (void *)restored_start_restore);
+	return r;
+}
+
+static void aqemu_inline_hook_rsr(void)
+{
+	aqemu_rsr_real = dlsym(RTLD_NEXT, "restored_start_restore");
+	if( ! aqemu_rsr_real || aqemu_rsr_real == (void *)restored_start_restore ) {
+		fprintf(stderr, "AQEMU: no libimobiledevice restored_start_restore to inline-hook\n");
+		return;
+	}
+	if( aqemu_mprotect_rwx(aqemu_rsr_real, AQEMU_JMP) != 0 ) {
+		fprintf(stderr, "AQEMU: mprotect restored_start_restore failed errno=%d\n", errno);
+		return;
+	}
+	memcpy(aqemu_rsr_saved, aqemu_rsr_real, AQEMU_JMP);
+	aqemu_install_jmp(aqemu_rsr_real, (void *)restored_start_restore);
+	aqemu_rsr_hooked = 1;
+	fprintf(stderr, "AQEMU: inline hooked restored_start_restore at %p bytes %02x %02x %02x %02x\n",
+		aqemu_rsr_real,
+		((unsigned char *)aqemu_rsr_real)[0],
+		((unsigned char *)aqemu_rsr_real)[1],
+		((unsigned char *)aqemu_rsr_real)[2],
+		((unsigned char *)aqemu_rsr_real)[3]);
+}
+
+static void aqemu_inline_hook_p2b(void)
+{
+	aqemu_p2b_real = dlsym(RTLD_NEXT, "plist_to_bin");
+	if( ! aqemu_p2b_real || aqemu_p2b_real == (void *)plist_to_bin ) {
+		fprintf(stderr, "AQEMU: no libplist plist_to_bin to inline-hook\n");
+		return;
+	}
+	if( aqemu_mprotect_rwx(aqemu_p2b_real, AQEMU_JMP) != 0 ) {
+		fprintf(stderr, "AQEMU: mprotect plist_to_bin failed errno=%d\n", errno);
+		return;
+	}
+	memcpy(aqemu_p2b_saved, aqemu_p2b_real, AQEMU_JMP);
+	aqemu_install_jmp(aqemu_p2b_real, (void *)plist_to_bin);
+	aqemu_p2b_hooked = 1;
+	fprintf(stderr, "AQEMU: inline hooked plist_to_bin at %p\n", aqemu_p2b_real);
+}
+
+static void aqemu_inline_hook_p2x(void)
+{
+	aqemu_p2x_real = dlsym(RTLD_NEXT, "plist_to_xml");
+	if( ! aqemu_p2x_real || aqemu_p2x_real == (void *)plist_to_xml ) {
+		aqemu_p2x_real = dlvsym(RTLD_NEXT, "plist_to_xml", "LIBPLIST_2.0");
+		if( ! aqemu_p2x_real || aqemu_p2x_real == (void *)plist_to_xml )
+			fprintf(stderr, "AQEMU: no libplist plist_to_xml to inline-hook\n");
+	}
+	if( ! aqemu_p2x_real || aqemu_p2x_real == (void *)plist_to_xml )
+		return;
+	if( aqemu_mprotect_rwx(aqemu_p2x_real, AQEMU_JMP) != 0 ) {
+		fprintf(stderr, "AQEMU: mprotect plist_to_xml failed errno=%d\n", errno);
+		return;
+	}
+	memcpy(aqemu_p2x_saved, aqemu_p2x_real, AQEMU_JMP);
+	aqemu_install_jmp(aqemu_p2x_real, (void *)plist_to_xml);
+	aqemu_p2x_hooked = 1;
+	fprintf(stderr, "AQEMU: inline hooked plist_to_xml at %p bytes %02x %02x %02x %02x\n",
+		aqemu_p2x_real,
+		((unsigned char *)aqemu_p2x_real)[0],
+		((unsigned char *)aqemu_p2x_real)[1],
+		((unsigned char *)aqemu_p2x_real)[2],
+		((unsigned char *)aqemu_p2x_real)[3]);
+}
+
+static restored_error_t aqemu_call_real_rsd(restored_client_t client, plist_t plist)
+{
+	typedef restored_error_t (*fn)(restored_client_t, plist_t);
+	restored_error_t r;
+	memcpy(aqemu_rsd_real, aqemu_rsd_saved, AQEMU_JMP);
+	r = ((fn)aqemu_rsd_real)(client, plist);
+	aqemu_install_jmp(aqemu_rsd_real, (void *)restored_send);
+	return r;
+}
+
+static void aqemu_inline_hook_rsd(void)
+{
+	aqemu_rsd_real = dlsym(RTLD_NEXT, "restored_send");
+	if( ! aqemu_rsd_real || aqemu_rsd_real == (void *)restored_send ) {
+		aqemu_rsd_real = dlvsym(RTLD_NEXT, "restored_send", "LIBIMOBILEDEVICE_1.0");
+		if( ! aqemu_rsd_real || aqemu_rsd_real == (void *)restored_send )
+			fprintf(stderr, "AQEMU: no libimobiledevice restored_send to inline-hook\n");
+	}
+	if( ! aqemu_rsd_real || aqemu_rsd_real == (void *)restored_send )
+		return;
+	if( aqemu_mprotect_rwx(aqemu_rsd_real, AQEMU_JMP) != 0 ) {
+		fprintf(stderr, "AQEMU: mprotect restored_send failed errno=%d\n", errno);
+		return;
+	}
+	memcpy(aqemu_rsd_saved, aqemu_rsd_real, AQEMU_JMP);
+	aqemu_install_jmp(aqemu_rsd_real, (void *)restored_send);
+	aqemu_rsd_hooked = 1;
+	fprintf(stderr, "AQEMU: inline hooked restored_send at %p\n", aqemu_rsd_real);
+}
+
+static void aqemu_got_rewire(void);
+static void aqemu_patch_exe_got(void);
+
+__attribute__((constructor))
+static void aqemu_cfs_init(void)
+{
+	unlink("/tmp/aqemu-cfs.log");
+	aqemu_log("AQEMU: force_cfs.so loaded (exe GOT + plist_to_xml + restored_start_restore)\n");
+	aqemu_log("AQEMU: our restored_start_restore=%p plist_to_xml=%p plist_dict_set_item=%p restored_send=%p\n",
+		(void *)restored_start_restore, (void *)plist_to_xml, (void *)plist_dict_set_item,
+		(void *)restored_send);
+	aqemu_log("AQEMU: plist_dict_set_item next=%p restored_start_restore next=%p SSL_write next=%p plist_to_xml next=%p restored_send next=%p\n",
+		dlsym(RTLD_NEXT, "plist_dict_set_item"),
+		dlsym(RTLD_NEXT, "restored_start_restore"),
+		dlsym(RTLD_NEXT, "SSL_write"),
+		dlsym(RTLD_NEXT, "plist_to_xml"),
+		dlsym(RTLD_NEXT, "restored_send"));
+	aqemu_got_rewire();
+	aqemu_patch_exe_got();
+	aqemu_inline_hook_rsr();
+	aqemu_inline_hook_rsd();
+	aqemu_inline_hook_p2b();
+	aqemu_inline_hook_p2x();
+}
+
+static void *symver(const char *name)
+{
+	static const char *vers[] = {
+		"LIBPLIST_2.0", "LIBPLIST_2.2", "LIBPLIST_2.3",
+		"LIBIMOBILEDEVICE_1.0", "LIBIMOBILEDEVICE_1.0.6",
+		"OPENSSL_3.0.0", "OPENSSL_3.1.0", "OPENSSL_3.2.0", "OPENSSL_3.3.0",
+		"OPENSSL_3.4.0", "OPENSSL_3.0.2",
+		NULL
+	};
+	void *p = dlsym(RTLD_NEXT, name);
+	int i;
+	if( p )
+		return p;
+	for( i = 0; vers[i]; i++ ) {
+		p = dlvsym(RTLD_NEXT, name, vers[i]);
+		if( p )
+			return p;
+	}
+	return NULL;
+}
+
+static uint64_t rd_be(const unsigned char *p, int n)
+{
+	uint64_t v = 0;
+	int i;
+	for( i = 0; i < n; i++ )
+		v = ( v << 8 ) | p[i];
+	return v;
+}
+
+static int patch_xml(unsigned char *buf, size_t n)
+{
+	unsigned char *key = memmem(buf, n, "CreateFilesystemPartitions", 26);
+	unsigned char *p, *end, *f;
+	if( ! key )
+		return 0;
+	p = key + 26;
+	end = buf + n;
+	if( end - p > 512 )
+		end = p + 512;
+	f = memmem(p, (size_t)( end - p ), "<false", 6);
+	if( ! f )
+		return 0;
+	if( f + 8 <= buf + n && memcmp(f, "<false/>", 8) == 0 )
+		memcpy(f, "<true/> ", 8);
+	else if( f + 15 <= buf + n && memcmp(f, "<false></false>", 15) == 0 )
+		memcpy(f, "<true></true>  ", 15);
+	else
+		memcpy(f + 1, "true ", 5);
+	fprintf(stderr, "AQEMU: patched XML CreateFilesystemPartitions to true\n");
+	return 1;
+}
+
+static int patch_bplist(unsigned char *buf, size_t n)
+{
+	const unsigned char *tr;
+	int off_sz, ref_sz;
+	uint64_t num_obj, top, off_tab, i, k, nent, o, tlen;
+	unsigned char *obj, *p, *end, marker;
+	int low;
+	const char *want = "CreateFilesystemPartitions";
+	const size_t want_len = 26;
+
+	if( n < 40 || memcmp(buf, "bplist00", 8) != 0 )
+		return 0;
+	tr = buf + n - 32;
+	off_sz = tr[6];
+	ref_sz = tr[7];
+	num_obj = rd_be(tr + 8, 8);
+	top = rd_be(tr + 16, 8);
+	off_tab = rd_be(tr + 24, 8);
+	if( off_sz < 1 || off_sz > 8 || ref_sz < 1 || ref_sz > 8 || num_obj < 1 || num_obj > 100000 )
+		return 0;
+	if( off_tab + num_obj * (uint64_t)off_sz > n )
+		return 0;
+	end = buf + n;
+
+	if( top >= num_obj )
+		return 0;
+	o = rd_be(buf + off_tab + top * (uint64_t)off_sz, off_sz);
+	if( o >= n )
+		return 0;
+	obj = buf + o;
+	marker = *obj;
+	if( ( marker & 0xF0 ) != 0xD0 )
+		return 0;
+	p = obj + 1;
+	low = marker & 0x0F;
+	nent = (uint64_t)low;
+	if( low == 0x0F ) {
+		if( p >= end )
+			return 0;
+		marker = *p++;
+		if( ( marker & 0xF0 ) != 0x10 )
+			return 0;
+		tlen = (uint64_t)( 1 << ( marker & 0x0F ) );
+		if( p + tlen > end )
+			return 0;
+		nent = rd_be(p, (int)tlen);
+		p += tlen;
+	}
+	if( nent > 4096 || p + nent * 2 * (uint64_t)ref_sz > end )
+		return 0;
+
+	for( i = 0; i < nent; i++ ) {
+		uint64_t key_i = rd_be(p + i * (uint64_t)ref_sz, ref_sz);
+		uint64_t val_i = rd_be(p + ( nent + i ) * (uint64_t)ref_sz, ref_sz);
+		uint64_t ko, vo;
+		unsigned char *ks, *vs, *sp;
+		uint64_t slen;
+		int slow;
+		if( key_i >= num_obj || val_i >= num_obj )
+			continue;
+		ko = rd_be(buf + off_tab + key_i * (uint64_t)off_sz, off_sz);
+		vo = rd_be(buf + off_tab + val_i * (uint64_t)off_sz, off_sz);
+		if( ko >= n || vo >= n )
+			continue;
+		ks = buf + ko;
+		if( ( *ks & 0xF0 ) != 0x50 )
+			continue;
+		sp = ks + 1;
+		slow = *ks & 0x0F;
+		slen = (uint64_t)slow;
+		if( slow == 0x0F ) {
+			if( sp >= end )
+				continue;
+			marker = *sp++;
+			if( ( marker & 0xF0 ) != 0x10 )
+				continue;
+			tlen = (uint64_t)( 1 << ( marker & 0x0F ) );
+			if( sp + tlen > end )
+				continue;
+			slen = rd_be(sp, (int)tlen);
+			sp += tlen;
+		}
+		if( slen != want_len || sp + slen > end )
+			continue;
+		if( memcmp(sp, want, want_len) != 0 )
+			continue;
+		vs = buf + vo;
+		if( *vs == 0x08 || *vs == 0x09 ) {
+			*vs = 0x09;
+			fprintf(stderr, "AQEMU: patched bplist CreateFilesystemPartitions to true\n");
+			return 1;
+		}
+		for( k = 0; k < 8 && vs + k < end; k++ ) {
+			if( vs[k] == 0x08 ) {
+				vs[k] = 0x09;
+				fprintf(stderr, "AQEMU: patched bplist bool near CreateFilesystemPartitions\n");
+				return 1;
+			}
+		}
+	}
+	return 0;
+}
+
+static void patch_payload(void *buf, size_t n)
+{
+	if( ! buf || n < 20 )
+		return;
+	if( ! memmem(buf, n, "CreateFilesystemPartitions", 26) ) {
+		if( memmem(buf, n, "PersonalizedDuringPreflight", 27) ||
+		    memmem(buf, n, "StartRestore", 12) )
+			fprintf(stderr,
+				"AQEMU: restore plist (%zu bytes) has no CreateFilesystemPartitions key\n",
+				n);
+		return;
+	}
+	if( patch_xml(buf, n) )
+		return;
+	if( patch_bplist(buf, n) )
+		return;
+	fprintf(stderr,
+		"AQEMU: CreateFilesystemPartitions present (%zu bytes) but XML/bplist rewrite missed\n",
+		n);
+}
+
+static int buf_is_restore_wire(const void *buf, size_t n)
+{
+	if( ! buf || n < 12 )
+		return 0;
+	if( memmem(buf, n, "CreateFilesystemPartitions", 26) )
+		return 1;
+	if( memmem(buf, n, "StartRestore", 12) )
+		return 1;
+	if( memmem(buf, n, "PersonalizedDuringPreflight", 27) )
+		return 1;
+	if( memmem(buf, n, "RestoreOptions", 14) )
+		return 1;
+	return 0;
+}
+
+static void notice_restore_plist(const void *buf, size_t n)
+{
+	static int once;
+	if( once || ! buf || n < 40 )
+		return;
+	if( ! memmem(buf, n, "PersonalizedDuringPreflight", 27) &&
+	    ! memmem(buf, n, "StartRestore", 12) &&
+	    ! memmem(buf, n, "CreateFilesystemPartitions", 26) )
+		return;
+	once = 1;
+	fprintf(stderr, "AQEMU: intercept restore-related payload (%zu bytes)\n", n);
+	if( ! memmem(buf, n, "CreateFilesystemPartitions", 26) )
+		fprintf(stderr, "AQEMU: that payload has no CreateFilesystemPartitions key\n");
+}
+
+static void *copy_patch(const void *buf, size_t n)
+{
+	void *copy;
+	notice_restore_plist(buf, n);
+	if( ! buf || n < 20 || ! buf_is_restore_wire(buf, n) )
+		return NULL;
+	copy = malloc(n);
+	if( ! copy )
+		return NULL;
+	memcpy(copy, buf, n);
+	patch_payload(copy, n);
+	return copy;
+}
+
+int SSL_write(void *ssl, const void *buf, int num)
+{
+	static int (*real)(void *, const void *, int);
+	void *copy;
+	int r;
+	if( ! real )
+		real = (int (*)(void *, const void *, int))symver("SSL_write");
+	if( ! real )
+		real = (int (*)(void *, const void *, int))dlsym(RTLD_NEXT, "SSL_write");
+	if( ! real )
+		return -1;
+	{
+		static int nlog;
+		if( nlog < 3 ) {
+			nlog++;
+			fprintf(stderr, "AQEMU: SSL_write payload %d bytes\n", num);
+		}
+	}
+	copy = ( num > 0 ) ? copy_patch(buf, (size_t)num) : NULL;
+	if( copy ) {
+		r = real(ssl, copy, num);
+		free(copy);
+		return r;
+	}
+	return real(ssl, buf, num);
+}
+
+int SSL_write_ex(void *ssl, const void *buf, size_t num, size_t *written)
+{
+	static int (*real)(void *, const void *, size_t, size_t *);
+	void *copy;
+	int r;
+	if( ! real )
+		real = (int (*)(void *, const void *, size_t, size_t *))dlsym(RTLD_NEXT, "SSL_write_ex");
+	if( ! real )
+		return 0;
+	if( num > 64 ) {
+		static int once;
+		if( ! once ) {
+			once = 1;
+			fprintf(stderr, "AQEMU: SSL_write_ex first payload %zu bytes\n", num);
+		}
+	}
+	copy = copy_patch(buf, num);
+	if( copy ) {
+		r = real(ssl, copy, num, written);
+		free(copy);
+		return r;
+	}
+	return real(ssl, buf, num, written);
+}
+
+int idevice_connection_send(void *conn, const char *data, uint32_t len, uint32_t *sent)
+{
+	static int (*real)(void *, const char *, uint32_t, uint32_t *);
+	void *copy;
+	int r;
+	if( ! real )
+		real = (int (*)(void *, const char *, uint32_t, uint32_t *))
+			dlsym(RTLD_NEXT, "idevice_connection_send");
+	if( ! real || real == idevice_connection_send )
+		real = (int (*)(void *, const char *, uint32_t, uint32_t *))
+			dlsym(RTLD_DEFAULT, "idevice_connection_send");
+	if( ! real || real == idevice_connection_send )
+		return -1;
+	if( len > 64 ) {
+		static int once;
+		if( ! once ) {
+			once = 1;
+			fprintf(stderr, "AQEMU: idevice_connection_send first payload %u bytes\n", len);
+		}
+	}
+	copy = copy_patch(data, (size_t)len);
+	if( copy ) {
+		r = real(conn, (const char *)copy, len, sent);
+		free(copy);
+		return r;
+	}
+	return real(conn, data, len, sent);
+}
+
+ssize_t gnutls_record_send(void *session, const void *data, size_t sizeofdata)
+{
+	static ssize_t (*real)(void *, const void *, size_t);
+	void *copy;
+	ssize_t r;
+	if( ! real )
+		real = (ssize_t (*)(void *, const void *, size_t))dlsym(RTLD_NEXT, "gnutls_record_send");
+	if( ! real )
+		return -1;
+	copy = copy_patch(data, sizeofdata);
+	if( copy ) {
+		r = real(session, copy, sizeofdata);
+		free(copy);
+		return r;
+	}
+	return real(session, data, sizeofdata);
+}
+
+static int drop_ios18_key(const char *key)
+{
+	return key && (
+		strcmp(key, "SystemImageFormat") == 0 ||
+		strcmp(key, "HostHasFixFor99053849") == 0 ||
+		strcmp(key, "WaitForDeviceConnectionToFinishStateMachine") == 0 ||
+		strcmp(key, "SupportedAsyncDataTypes") == 0);
+}
+
+static void force_true(plist_t dict)
+{
+	typedef plist_t (*new_bool_fn)(uint8_t);
+	typedef plist_t (*new_str_fn)(const char *);
+	new_bool_fn plist_new_bool = (new_bool_fn)symver("plist_new_bool");
+	new_str_fn plist_new_string;
+	if( ! plist_new_bool )
+		plist_new_bool = (new_bool_fn)dlsym(RTLD_DEFAULT, "plist_new_bool");
+	aqemu_log("AQEMU: force_true dict=%p plist_new_bool=%p\n", dict, (void *)plist_new_bool);
+	if( ! dict || ! plist_new_bool ) {
+		aqemu_log("AQEMU: force_true abort (need dict and plist_new_bool)\n");
+		return;
+	}
+	aqemu_log("AQEMU: forcing CreateFilesystemPartitions=true + AuthInstallRestoreBehavior=Erase\n");
+	plist_dict_set_item(dict, "CreateFilesystemPartitions", plist_new_bool(1));
+	plist_new_string = (new_str_fn)symver("plist_new_string");
+	if( ! plist_new_string )
+		plist_new_string = (new_str_fn)dlsym(RTLD_DEFAULT, "plist_new_string");
+	if( plist_new_string )
+		plist_dict_set_item(dict, "AuthInstallRestoreBehavior", plist_new_string("Erase"));
+}
+
+void plist_dict_set_item(plist_t dict, const char *key, plist_t value)
+{
+	typedef void (*fn)(plist_t, const char *, plist_t);
+	static fn real;
+	if( ! real )
+		real = (fn)dlsym(RTLD_NEXT, "plist_dict_set_item");
+	if( drop_ios18_key(key) ) {
+		fprintf(stderr, "AQEMU: dropping iOS18 restore option %s\n", key);
+		return;
+	}
+	if( key && strcmp(key, "CreateFilesystemPartitions") == 0 ) {
+		typedef plist_t (*new_bool_fn)(uint8_t);
+		new_bool_fn plist_new_bool = (new_bool_fn)symver("plist_new_bool");
+		if( plist_new_bool )
+			value = plist_new_bool(1);
+		fprintf(stderr, "AQEMU: CreateFilesystemPartitions -> true\n");
+	}
+	if( real )
+		real(dict, key, value);
+}
+
+void plist_dict_insert_item(plist_t dict, const char *key, plist_t value)
+{
+	typedef void (*fn)(plist_t, const char *, plist_t);
+	static fn real;
+	if( ! real )
+		real = (fn)dlsym(RTLD_NEXT, "plist_dict_insert_item");
+	if( key && strcmp(key, "CreateFilesystemPartitions") == 0 ) {
+		typedef plist_t (*new_bool_fn)(uint8_t);
+		new_bool_fn plist_new_bool = (new_bool_fn)symver("plist_new_bool");
+		if( plist_new_bool )
+			value = plist_new_bool(1);
+		fprintf(stderr, "AQEMU: CreateFilesystemPartitions (insert) -> true\n");
+	}
+	if( real )
+		real(dict, key, value);
+}
+
+void plist_to_xml(plist_t plist, char **xml, uint32_t *length)
+{
+	typedef void (*fn)(plist_t, char **, uint32_t *);
+	static fn real;
+	static int nlog;
+	if( nlog < 8 ) {
+		nlog++;
+		aqemu_log("AQEMU: plist_to_xml ENTER #%d hooked=%d\n", nlog, aqemu_p2x_hooked);
+	}
+	if( aqemu_p2x_hooked && aqemu_p2x_real ) {
+		memcpy(aqemu_p2x_real, aqemu_p2x_saved, AQEMU_JMP);
+		((fn)aqemu_p2x_real)(plist, xml, length);
+		aqemu_install_jmp(aqemu_p2x_real, (void *)plist_to_xml);
+		if( xml && *xml && length && *length )
+			patch_payload(*xml, *length);
+		return;
+	}
+	if( ! real )
+		real = (fn)symver("plist_to_xml");
+	if( ! real )
+		return;
+	real(plist, xml, length);
+	if( xml && *xml && length && *length )
+		patch_payload(*xml, *length);
+}
+
+void plist_to_bin(plist_t plist, char **bin, uint32_t *length)
+{
+	typedef void (*fn)(plist_t, char **, uint32_t *);
+	static fn real;
+	static int nlog;
+	if( nlog < 8 ) {
+		nlog++;
+		aqemu_log("AQEMU: plist_to_bin ENTER #%d hooked=%d\n", nlog, aqemu_p2b_hooked);
+	}
+	if( aqemu_p2b_hooked && aqemu_p2b_real ) {
+		memcpy(aqemu_p2b_real, aqemu_p2b_saved, AQEMU_JMP);
+		((fn)aqemu_p2b_real)(plist, bin, length);
+		aqemu_install_jmp(aqemu_p2b_real, (void *)plist_to_bin);
+		if( bin && *bin && length && *length )
+			patch_payload(*bin, *length);
+		return;
+	}
+	if( ! real )
+		real = (fn)symver("plist_to_bin");
+	if( ! real )
+		return;
+	real(plist, bin, length);
+	if( bin && *bin && length && *length )
+		patch_payload(*bin, *length);
+}
+
+restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version)
+{
+	typedef restored_error_t (*fn)(restored_client_t, plist_t, uint64_t);
+	static fn real;
+	aqemu_log("AQEMU: restored_start_restore ENTER dict=%p hooked=%d\n",
+		options, aqemu_rsr_hooked);
+	force_true(options);
+	{
+		char *xml = NULL;
+		uint32_t xlen = 0;
+		typedef void (*px)(plist_t, char **, uint32_t *);
+		px real_xml = (px)dlsym(RTLD_NEXT, "plist_to_xml");
+		if( real_xml && options ) {
+			real_xml(options, &xml, &xlen);
+			if( xml ) {
+				fprintf(stderr, "AQEMU: StartRestore options XML (%u bytes)\n", xlen);
+				if( strstr(xml, "CreateFilesystemPartitions") )
+					fprintf(stderr, "%s\n",
+						strstr(xml, "CreateFilesystemPartitions"));
+				else
+					fprintf(stderr, "AQEMU: options XML has no CreateFilesystemPartitions\n");
+				free(xml);
+			}
+		}
+	}
+	if( aqemu_rsr_hooked )
+		return aqemu_call_real_rsr(client, options, version);
+	if( ! real )
+		real = (fn)dlsym(RTLD_NEXT, "restored_start_restore");
+	if( ! real || real == restored_start_restore )
+		return -1;
+	return real(client, options, version);
+}
+
+restored_error_t restored_send(restored_client_t client, plist_t plist)
+{
+	typedef restored_error_t (*fn)(restored_client_t, plist_t);
+	static fn real;
+	static int nlog;
+	if( nlog < 8 ) {
+		nlog++;
+		aqemu_log("AQEMU: restored_send ENTER #%d hooked=%d\n", nlog, aqemu_rsd_hooked);
+	}
+	if( plist ) {
+		typedef plist_t (*get_fn)(plist_t, const char *);
+		get_fn get = (get_fn)dlsym(RTLD_NEXT, "plist_dict_get_item");
+		if( get ) {
+			plist_t req = get(plist, "Request");
+			plist_t opts = get(plist, "Options");
+			if( ! opts )
+				opts = get(plist, "RestoreOptions");
+			if( opts || (req && nlog <= 2) )
+				force_true(opts ? opts : plist);
+		} else
+			force_true(plist);
+	}
+	if( aqemu_rsd_hooked )
+		return aqemu_call_real_rsd(client, plist);
+	if( ! real )
+		real = (fn)dlsym(RTLD_NEXT, "restored_send");
+	if( ! real || real == restored_send )
+		return -1;
+	return real(client, plist);
+}
+
+/* idevicerestore's PLT does not call our plist/restored hooks (bind DEFAULT is
+ * ours, but no hook logs). Restore plist goes to usbmuxd as write/send.
+ * Interpose write/send paths; copy+patch restore plists on the wire.
+ * Skip fd 1/2 (avoid fprintf recursion). */
+static __thread int aqemu_in_io;
+
+ssize_t write(int fd, const void *buf, size_t count)
+{
+	static ssize_t (*real)(int, const void *, size_t);
+	void *copy;
+	ssize_t r;
+	if( ! real )
+		real = (ssize_t (*)(int, const void *, size_t))dlsym(RTLD_NEXT, "write");
+	if( ! real )
+		return -1;
+	if( aqemu_in_io || fd < 3 || ! buf_is_restore_wire(buf, count) )
+		return real(fd, buf, count);
+	aqemu_in_io = 1;
+	fprintf(stderr, "AQEMU: write saw restore plist (%zu bytes)\n", count);
+	copy = copy_patch(buf, count);
+	r = real(fd, copy ? copy : buf, count);
+	free(copy);
+	aqemu_in_io = 0;
+	return r;
+}
+
+ssize_t send(int sockfd, const void *buf, size_t len, int flags)
+{
+	static ssize_t (*real)(int, const void *, size_t, int);
+	void *copy;
+	ssize_t r;
+	if( ! real )
+		real = (ssize_t (*)(int, const void *, size_t, int))dlsym(RTLD_NEXT, "send");
+	if( ! real )
+		return -1;
+	if( aqemu_in_io || sockfd < 3 || ! buf_is_restore_wire(buf, len) )
+		return real(sockfd, buf, len, flags);
+	aqemu_in_io = 1;
+	fprintf(stderr, "AQEMU: send saw restore plist (%zu bytes)\n", len);
+	copy = copy_patch(buf, len);
+	r = real(sockfd, copy ? copy : buf, len, flags);
+	free(copy);
+	aqemu_in_io = 0;
+	return r;
+}
+
+int usbmuxd_send(int sfd, const char *data, uint32_t len, uint32_t *sent)
+{
+	static int (*real)(int, const char *, uint32_t, uint32_t *);
+	void *copy;
+	int r;
+	if( ! real )
+		real = (int (*)(int, const char *, uint32_t, uint32_t *))
+			dlsym(RTLD_NEXT, "usbmuxd_send");
+	if( ! real )
+		return -1;
+	if( aqemu_in_io || ! buf_is_restore_wire(data, (size_t)len) )
+		return real(sfd, data, len, sent);
+	aqemu_in_io = 1;
+	fprintf(stderr, "AQEMU: usbmuxd_send saw restore plist (%u bytes)\n", len);
+	copy = copy_patch(data, (size_t)len);
+	r = real(sfd, copy ? (const char *)copy : data, len, sent);
+	free(copy);
+	aqemu_in_io = 0;
+	return r;
+}
+
+ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
+{
+	static ssize_t (*real)(int, const struct iovec *, int);
+	int i;
+	if( ! real )
+		real = (ssize_t (*)(int, const struct iovec *, int))dlsym(RTLD_NEXT, "writev");
+	if( ! real )
+		return -1;
+	if( aqemu_in_io || fd < 3 || ! iov )
+		return real(fd, iov, iovcnt);
+	for( i = 0; i < iovcnt; i++ ) {
+		if( ! buf_is_restore_wire(iov[i].iov_base, iov[i].iov_len) )
+			continue;
+		aqemu_in_io = 1;
+		fprintf(stderr, "AQEMU: writev[%d] saw restore plist (%zu bytes)\n",
+			i, (size_t)iov[i].iov_len);
+		if( iov[i].iov_base )
+			patch_payload(iov[i].iov_base, iov[i].iov_len);
+		aqemu_in_io = 0;
+		break;
+	}
+	return real(fd, iov, iovcnt);
+}
+
+ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags)
+{
+	static ssize_t (*real)(int, const struct msghdr *, int);
+	size_t i;
+	if( ! real )
+		real = (ssize_t (*)(int, const struct msghdr *, int))dlsym(RTLD_NEXT, "sendmsg");
+	if( ! real )
+		return -1;
+	if( aqemu_in_io || ! msg || ! msg->msg_iov )
+		return real(sockfd, msg, flags);
+	for( i = 0; i < msg->msg_iovlen; i++ ) {
+		if( ! buf_is_restore_wire(msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len) )
+			continue;
+		aqemu_in_io = 1;
+		fprintf(stderr, "AQEMU: sendmsg[%zu] saw restore plist (%zu bytes)\n",
+			i, (size_t)msg->msg_iov[i].iov_len);
+		if( msg->msg_iov[i].iov_base )
+			patch_payload(msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len);
+		aqemu_in_io = 0;
+		break;
+	}
+	return real(sockfd, msg, flags);
+}
+
+static void *dyn_ptr(ElfW(Addr) base, ElfW(Addr) p)
+{
+	if( p == 0 )
+		return NULL;
+	if( p < base )
+		return (void *)(base + p);
+	return (void *)p;
+}
+
+static int got_make_writable(void *slot)
+{
+	long ps = sysconf(_SC_PAGESIZE);
+	uintptr_t pg;
+	if( ps <= 0 )
+		ps = 4096;
+	pg = (uintptr_t)slot & ~((uintptr_t)ps - 1);
+	return mprotect((void *)pg, (size_t)ps, PROT_READ | PROT_WRITE);
+}
+
+static void *got_want(const char *nm)
+{
+	if( strcmp(nm, "restored_start_restore") == 0 )
+		return (void *)restored_start_restore;
+	if( strcmp(nm, "restored_send") == 0 )
+		return (void *)restored_send;
+	if( strcmp(nm, "plist_dict_set_item") == 0 )
+		return (void *)plist_dict_set_item;
+	if( strcmp(nm, "plist_to_bin") == 0 )
+		return (void *)plist_to_bin;
+	if( strcmp(nm, "plist_to_xml") == 0 )
+		return (void *)plist_to_xml;
+	if( strcmp(nm, "SSL_write") == 0 )
+		return (void *)SSL_write;
+	if( strcmp(nm, "SSL_write_ex") == 0 )
+		return (void *)SSL_write_ex;
+	if( strcmp(nm, "usbmuxd_send") == 0 )
+		return (void *)usbmuxd_send;
+	if( strcmp(nm, "idevice_connection_send") == 0 )
+		return (void *)idevice_connection_send;
+	return NULL;
+}
+
+static void rewire_rela_table(ElfW(Addr) base, ElfW(Rela) *rela, size_t n,
+	ElfW(Sym) *symtab, const char *strtab, const char *oname)
+{
+	size_t k;
+	const char *tag = oname[0] ? oname : "exe";
+	for( k = 0; k < n; k++ ) {
+		int type = ELF64_R_TYPE(rela[k].r_info);
+		int symn = (int)ELF64_R_SYM(rela[k].r_info);
+		const char *nm;
+		void **slot;
+		void *want;
+		if( type != R_X86_64_JUMP_SLOT && type != R_X86_64_GLOB_DAT )
+			continue;
+		nm = strtab + symtab[symn].st_name;
+		want = got_want(nm);
+		if( ! want )
+			continue;
+		slot = (void **)(base + rela[k].r_offset);
+		if( got_make_writable(slot) != 0 )
+			slot = (void **)(uintptr_t)rela[k].r_offset;
+		if( got_make_writable(slot) != 0 ) {
+			fprintf(stderr, "AQEMU: GOT mprotect fail %s %s slot=%p\n",
+				tag, nm, (void *)slot);
+			continue;
+		}
+		if( *slot == want )
+			continue;
+		fprintf(stderr, "AQEMU: GOT %s %s %p -> %p\n", tag, nm, *slot, want);
+		*slot = want;
+	}
+}
+
+static int got_rewire_cb(struct dl_phdr_info *info, size_t size, void *data)
+{
+	const ElfW(Phdr) *ph;
+	const ElfW(Dyn) *dyn = NULL;
+	ElfW(Addr) base = info->dlpi_addr;
+	ElfW(Sym) *symtab = NULL;
+	const char *strtab = NULL;
+	ElfW(Rela) *jmp = NULL;
+	ElfW(Rela) *rela = NULL;
+	size_t jmpsz = 0, relasz = 0;
+	const char *oname = info->dlpi_name ? info->dlpi_name : "";
+	int i;
+	(void)size;
+	(void)data;
+	if( strstr(oname, "libimobiledevice-glue") )
+		return 0;
+	if( oname[0] != '\0' &&
+	    ! strstr(oname, "idevicerestore") &&
+	    ! strstr(oname, "libimobiledevice-1") &&
+	    ! strstr(oname, "libusbmuxd") )
+		return 0;
+	for( i = 0; i < info->dlpi_phnum; i++ ) {
+		ph = &info->dlpi_phdr[i];
+		if( ph->p_type == PT_DYNAMIC ) {
+			dyn = (const ElfW(Dyn) *)(base + ph->p_vaddr);
+			break;
+		}
+	}
+	if( ! dyn )
+		return 0;
+	for( ; dyn->d_tag != DT_NULL; dyn++ ) {
+		if( dyn->d_tag == DT_SYMTAB )
+			symtab = dyn_ptr(base, dyn->d_un.d_ptr);
+		else if( dyn->d_tag == DT_STRTAB )
+			strtab = dyn_ptr(base, dyn->d_un.d_ptr);
+		else if( dyn->d_tag == DT_JMPREL )
+			jmp = dyn_ptr(base, dyn->d_un.d_ptr);
+		else if( dyn->d_tag == DT_PLTRELSZ )
+			jmpsz = (size_t)dyn->d_un.d_val;
+		else if( dyn->d_tag == DT_RELA )
+			rela = dyn_ptr(base, dyn->d_un.d_ptr);
+		else if( dyn->d_tag == DT_RELASZ )
+			relasz = (size_t)dyn->d_un.d_val;
+	}
+	fprintf(stderr, "AQEMU: phdr '%s' base=%p pltrel=%zu rela=%zu\n",
+		oname[0] ? oname : "exe", (void *)(uintptr_t)base, jmpsz, relasz);
+	if( ! symtab || ! strtab ) {
+		fprintf(stderr, "AQEMU: no SYMTAB in %s\n", oname[0] ? oname : "exe");
+		return 0;
+	}
+	if( jmp && jmpsz >= sizeof(ElfW(Rela)) )
+		rewire_rela_table(base, jmp, jmpsz / sizeof(ElfW(Rela)),
+			symtab, strtab, oname);
+	if( rela && relasz >= sizeof(ElfW(Rela)) )
+		rewire_rela_table(base, rela, relasz / sizeof(ElfW(Rela)),
+			symtab, strtab, oname);
+	if( ( ! jmp || jmpsz < sizeof(ElfW(Rela)) ) &&
+	    ( ! rela || relasz < sizeof(ElfW(Rela)) ) )
+		fprintf(stderr, "AQEMU: no JMPREL/RELA in %s base=%p\n",
+			oname[0] ? oname : "exe", (void *)(uintptr_t)base);
+	return 0;
+}
+
+static void aqemu_got_rewire(void)
+{
+	dl_iterate_phdr(got_rewire_cb, NULL);
+}
+
+struct aqemu_bias {
+	unsigned long bias;
+	int found;
+};
+
+static int aqemu_bias_cb(struct dl_phdr_info *info, size_t size, void *data)
+{
+	struct aqemu_bias *o = data;
+	const char *n = info->dlpi_name ? info->dlpi_name : "";
+	(void)size;
+	if( n[0] == '\0' ) {
+		o->bias = (unsigned long)info->dlpi_addr;
+		o->found = 1;
+		return 1;
+	}
+	if( strstr(n, "idevicerestore") && ! strstr(n, ".so") ) {
+		o->bias = (unsigned long)info->dlpi_addr;
+		o->found = 1;
+		return 1;
+	}
+	return 0;
+}
+
+static unsigned long aqemu_exe_bias(void)
+{
+	struct aqemu_bias o;
+	o.bias = 0;
+	o.found = 0;
+	dl_iterate_phdr(aqemu_bias_cb, &o);
+	if( o.found )
+		return o.bias;
+	{
+		FILE *f = fopen("/proc/self/maps", "r");
+		char line[640], path[400];
+		unsigned long start = 0;
+		if( ! f )
+			return 0;
+		while( fgets(line, (int)sizeof(line), f) ) {
+			path[0] = 0;
+			if( sscanf(line, "%lx-%*x %*s %*s %*s %*s %399s", &start, path) < 1 )
+				continue;
+			if( strstr(path, "idevicerestore") && ! strstr(path, ".so") ) {
+				fclose(f);
+				return start;
+			}
+		}
+		fclose(f);
+	}
+	return 0;
+}
+
+static void aqemu_patch_one_rela(unsigned long bias, Elf64_Rela *rela, size_t nrela,
+	Elf64_Sym *sym, const char *str, const char *tag)
+{
+	size_t i;
+	for( i = 0; i < nrela; i++ ) {
+		unsigned int type = ELF64_R_TYPE(rela[i].r_info);
+		unsigned int si = (unsigned int)ELF64_R_SYM(rela[i].r_info);
+		const char *nm;
+		void **slot;
+		void *want;
+		if( type != R_X86_64_JUMP_SLOT && type != R_X86_64_GLOB_DAT )
+			continue;
+		nm = str + sym[si].st_name;
+		want = got_want(nm);
+		if( ! want )
+			continue;
+		slot = (void **)( bias + (unsigned long)rela[i].r_offset );
+		if( got_make_writable(slot) != 0 ) {
+			fprintf(stderr, "AQEMU: exe GOT mprotect fail %s %s slot=%p\n",
+				tag, nm, (void *)slot);
+			continue;
+		}
+		fprintf(stderr, "AQEMU: exe GOT (%s) %s %p -> %p\n", tag, nm, *slot, want);
+		*slot = want;
+	}
+}
+
+static void aqemu_patch_exe_got(void)
+{
+	int fd;
+	unsigned char *map;
+	off_t sz;
+	Elf64_Ehdr *eh;
+	Elf64_Shdr *sh;
+	Elf64_Shdr *dynsym = NULL, *dynstr = NULL, *relaplt = NULL, *reladyn = NULL;
+	Elf64_Sym *sym;
+	const char *str;
+	size_t i, shnum;
+	unsigned long bias;
+
+	bias = aqemu_exe_bias();
+	fprintf(stderr, "AQEMU: exe load bias=0x%lx\n", bias);
+	fd = open("/proc/self/exe", O_RDONLY);
+	if( fd < 0 ) {
+		fprintf(stderr, "AQEMU: open /proc/self/exe failed errno=%d\n", errno);
+		return;
+	}
+	sz = lseek(fd, 0, SEEK_END);
+	if( sz < 64 ) {
+		close(fd);
+		return;
+	}
+	map = mmap(NULL, (size_t)sz, PROT_READ, MAP_PRIVATE, fd, 0);
+	close(fd);
+	if( map == MAP_FAILED ) {
+		fprintf(stderr, "AQEMU: mmap exe failed errno=%d\n", errno);
+		return;
+	}
+	eh = (Elf64_Ehdr *)map;
+	if( memcmp(eh->e_ident, ELFMAG, SELFMAG) != 0 || eh->e_ident[EI_CLASS] != ELFCLASS64 ) {
+		munmap(map, (size_t)sz);
+		return;
+	}
+	sh = (Elf64_Shdr *)( map + eh->e_shoff );
+	shnum = eh->e_shnum;
+	{
+		const char *shstr = (const char *)( map + sh[eh->e_shstrndx].sh_offset );
+		for( i = 0; i < shnum; i++ ) {
+			const char *nm = shstr + sh[i].sh_name;
+			if( sh[i].sh_type == SHT_DYNSYM )
+				dynsym = &sh[i];
+			else if( strcmp(nm, ".rela.plt") == 0 )
+				relaplt = &sh[i];
+			else if( strcmp(nm, ".rela.dyn") == 0 )
+				reladyn = &sh[i];
+		}
+	}
+	if( dynsym && dynsym->sh_link < shnum )
+		dynstr = &sh[dynsym->sh_link];
+	if( ! dynsym || ! dynstr || ( eh->e_type == ET_DYN && bias == 0 ) ) {
+		fprintf(stderr, "AQEMU: exe GOT parse type=%d dynsym=%p bias=0x%lx plt=%p dyn=%p\n",
+			(int)eh->e_type, (void *)dynsym, bias, (void *)relaplt, (void *)reladyn);
+		munmap(map, (size_t)sz);
+		return;
+	}
+	sym = (Elf64_Sym *)( map + dynsym->sh_offset );
+	str = (const char *)( map + dynstr->sh_offset );
+	if( relaplt ) {
+		fprintf(stderr, "AQEMU: exe .rela.plt entries=%zu\n",
+			(size_t)( relaplt->sh_size / sizeof(Elf64_Rela) ));
+		aqemu_patch_one_rela(bias, (Elf64_Rela *)( map + relaplt->sh_offset ),
+			relaplt->sh_size / sizeof(Elf64_Rela), sym, str, ".rela.plt");
+	}
+	if( reladyn ) {
+		fprintf(stderr, "AQEMU: exe .rela.dyn entries=%zu\n",
+			(size_t)( reladyn->sh_size / sizeof(Elf64_Rela) ));
+		aqemu_patch_one_rela(bias, (Elf64_Rela *)( map + reladyn->sh_offset ),
+			reladyn->sh_size / sizeof(Elf64_Rela), sym, str, ".rela.dyn");
+	}
+	if( ! relaplt && ! reladyn )
+		fprintf(stderr, "AQEMU: exe has no .rela.plt or .rela.dyn\n");
+	munmap(map, (size_t)sz);
+}

--- a/extras/Inferno/format-seed-apfs.sh
+++ b/extras/Inferno/format-seed-apfs.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Format the AQEMU_SEED APFS partition on Inferno guest root with a Data volume.
+# Usage: format-seed-apfs.sh /path/to/root
+# Run as root (loop devices). First run may clone+build linux-apfs/apfsprogs.
+set -euo pipefail
+
+ROOT="${1:?path to *_inferno/root}"
+if [[ ! -f "$ROOT" ]]; then
+	echo "ERROR: root image not found: $ROOT"
+	exit 1
+fi
+
+LBA=4096
+START_LBA=256
+OFFSET=$((START_LBA * LBA))
+SIZE=$(stat -c%s "$ROOT")
+BACKUP=$((6 * LBA))
+PART_BYTES=$((SIZE - OFFSET - BACKUP))
+if [[ "$PART_BYTES" -lt $((512 * 1024)) ]]; then
+	echo "ERROR: APFS partition too small ($PART_BYTES)"
+	exit 1
+fi
+
+magic() {
+	dd if="$ROOT" bs=1 skip=$((OFFSET + 32)) count=4 status=none 2>/dev/null || true
+}
+
+if [[ "$(magic)" == "NXSB" ]]; then
+	echo "APFS NXSB already present on $ROOT"
+	exit 0
+fi
+
+WORK="${HOME}/aqemu-mkapfs"
+MKAPFS="$WORK/apfsprogs/mkapfs/mkapfs"
+if [[ ! -x "$MKAPFS" ]]; then
+	echo "Building mkapfs once in $WORK ..."
+	mkdir -p "$WORK"
+	if [[ ! -d "$WORK/apfsprogs/.git" ]]; then
+		git clone --depth 1 https://github.com/linux-apfs/apfsprogs.git "$WORK/apfsprogs"
+	fi
+	make -C "$WORK/apfsprogs/mkapfs" -j"$(nproc)"
+fi
+
+modprobe loop 2>/dev/null || true
+LOOP=$(losetup -f --show -o "$OFFSET" --sizelimit "$PART_BYTES" "$ROOT")
+cleanup() { losetup -d "$LOOP" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "mkapfs Data volume on $LOOP (offset $OFFSET, $PART_BYTES bytes)"
+"$MKAPFS" -L Data "$LOOP"
+losetup -d "$LOOP"
+trap - EXIT
+LOOP=""
+
+python3 - "$ROOT" "$OFFSET" <<'PY'
+import struct, sys
+
+ROLE_OFF = 0x3C4
+APFS_VOL_ROLE_DATA = 0x0040
+root, offset = sys.argv[1], int(sys.argv[2])
+offset = int(offset)
+
+def fletcher64(data: bytes) -> int:
+    sum1 = 0
+    sum2 = 0
+    for i in range(0, len(data), 4):
+        v = struct.unpack_from("<I", data, i)[0]
+        sum1 += v
+        sum2 += sum1
+    c1 = sum1 + sum2
+    c1 = 0xFFFFFFFF - (c1 % 0xFFFFFFFF)
+    c2 = sum1 + c1
+    c2 = 0xFFFFFFFF - (c2 % 0xFFFFFFFF)
+    return ((c2 & 0xFFFFFFFF) << 32) | (c1 & 0xFFFFFFFF)
+
+with open(root, "r+b") as f:
+    f.seek(offset)
+    blob = f.read(64 * 1024 * 1024)
+found = None
+for i in range(0, len(blob) - 4096, 4096):
+    if blob[i + 32 : i + 36] == b"APSB":
+        found = i
+        break
+if found is None:
+    sys.exit("APSB not found after mkapfs")
+block = bytearray(blob[found : found + 4096])
+struct.pack_into("<H", block, ROLE_OFF, APFS_VOL_ROLE_DATA)
+block[0:8] = b"\x00" * 8
+struct.pack_into("<Q", block, 0, fletcher64(block))
+with open(root, "r+b") as f:
+    f.seek(offset + found)
+    f.write(block)
+print(f"APSB role=Data at partition offset {found}")
+PY
+
+if [[ "$(magic)" != "NXSB" ]]; then
+	echo "ERROR: NXSB not present after mkapfs"
+	exit 1
+fi
+echo "Seed APFS Data volume ready on $ROOT"

--- a/extras/Inferno/iOS_Installation.md
+++ b/extras/Inferno/iOS_Installation.md
@@ -63,7 +63,7 @@ Toolbar **Net** (or **File → Guest Internet / iOS Device Tools…**) → same 
 
 ### A7. Buttons
 
-Toolbar: Vol− / Vol+ / Home / Side / SOS / Pad / Net. Swipe-home is unreliable — use **Home**.
+Toolbar: Vol− / Vol+ / Home / Side / SOS / Pad / Net. Swipe-home is ignored on Inferno (Face ID MT-SPI). After SpringBoard, use **Home**. On **Welcome to iPhone / Swipe up to get started**, Home often does nothing — use **SOS** (ChefKiss workaround).
 
 ---
 
@@ -112,7 +112,7 @@ Typical files after unpack (names vary by IPSW):
 | Look for | Used as |
 | --- | --- |
 | `BuildManifest.plist` | Filled into Step 2 automatically |
-| `DeviceTree.n104ap.im4p` | Step 3 decrypt/extract → **DeviceTree** `.dtb` / `.dec` |
+| `Firmware/all_flash/DeviceTree.n104ap.im4p` | Step 4 decrypt/extract → MACHINE **DeviceTree** `.dtb` / `.dec` (not the SEP `.im4p`) |
 | `kernelcache.release.*` or research kernel | **Kernel** (decrypted / `.research`) |
 | Restore ramdisk **`.dmg`** (`RestoreRamDisk` in BuildManifest, e.g. `038-44135-124.dmg`) | MACHINE **Restore ramdisk (-initrd)** (suggested if empty). Not the largest IPSW `.dmg` |
 | `Firmware/all_flash/sep-firmware.n104.RELEASE.im4p` | Later pack into **repackaged** SEP `.img4` — not the MACHINE SEP field raw |
@@ -120,6 +120,24 @@ Typical files after unpack (names vary by IPSW):
 | `kernelcache` / firmware folders | Keep the whole extract; do not delete until MACHINE paths work |
 
 **Kernel** is the research/decrypted kernelcache Inferno can `-kernel`, not a random Mach-O from the IPSW payload folder unless ChefKiss says that file is the one.
+
+### The three `.dmg` files in `firmware_extracted`
+
+After unpack you will see **three `.dmg` files** at the root of `firmware_extracted` (names vary by IPSW build; the `18A5351d` example names are below):
+
+| File | Role | Do you use it? |
+| --- | --- | --- |
+| `038-44087-125.dmg` | **UpdateRamdisk** — OTA delta update environment. Not used for a fresh restore | **No** — ignore it |
+| `038-44135-124.dmg` | **RestoreRamdisk** — the recovery-mode environment that `idevicerestore` boots the device into. This is what goes in **MACHINE → Restore ramdisk (-initrd)** | **Yes — this is your `-initrd`** |
+| `038-44337-083.dmg` | **RootFilesystem** — the full iOS APFS/HFS image. `idevicerestore` flashes this to the `root` NVMe image. You never set this field manually; the restore companion handles it automatically from the IPSW | **No** — handled automatically |
+
+`BuildManifest.plist` (`RestoreRamDisk` key) identifies which `.dmg` is which. AQEMU's Firmware Tool reads that key and **pre-fills** the Restore ramdisk field for you, so you should not need to guess.
+
+**How `-initrd` puts the device into recovery:**
+
+When **Restore ramdisk (-initrd)** is set in MACHINE, AQEMU passes `-initrd <path>` to Inferno QEMU. QEMU maps that file as `md0` and appends `rd=md0 nand-enable-reformat=1 -restore` to the kernel boot args, which tells iOS to boot into restore mode instead of SpringBoard. The device is now in a state where `idevicerestore` (running in the companion) can connect over USB/TCP and flash the IPSW.
+
+**After restore succeeds:** the FS-patch step **clears** the Restore ramdisk field automatically. Do not set it again unless you are doing a re-restore.
 
 ---
 
@@ -133,8 +151,11 @@ Unsigned IPSWs need a **forged AP ticket**. A 2-byte placeholder will fail resto
 
 1. **Model** — `n104ap` (iPhone 11 / t8030).
 2. **BuildManifest.plist** — already filled after Unpack.
-3. **ticket.shsh2** — **Browse…** or **ChefKiss extras…** ([ChefKiss extras](https://chefkiss.dev/Extras/Inferno/)). You can drop the file next to the bundled scripts as `extras/Inferno/ticket.shsh2`. AQEMU remembers the path. AQEMU does **not** ship this blob.
-4. **Forge restore + SEP tickets** — AQEMU runs the bundled scripts (installs `pyasn1` via pip if needed). You never type the command.
+3. **ticket.shsh2** — **not in the IPSW.** It is a **SHSH blob** ChefKiss hosts for Inferno’s unsigned-IPSW ticket scripts (contains an Apple **Img4** `ApImg4Ticket`). AQEMU does **not** ship it, download it, or put it in the installer — that would redistribute Apple signing material. You get it from ChefKiss:
+
+   Open [Inferno file setup](https://chefkiss.dev/guides/inferno/file-setup/) → **Creating the AP Ticket** → the sentence *“a ticket shsh is provided here”* (that **here** is their `ticket.shsh2`). Save the file, then **Browse…** in the Firmware Tool. You may keep a local copy as `extras/Inferno/ticket.shsh2` (gitignored). Firmware Tool **How to get this…** opens that same guide page.
+4. **Restore ticket / SEP ticket (.der)** — leave the suggested paths (next to the extract) or **Browse…** to choose where Forge **writes**. You do not hunt for these in the IPSW.
+5. Click **Forge restore + SEP tickets** — that **creates** the `.der` files (installs `pyasn1` via pip if needed). You never type the command.
 
 Outputs (next to the extract by default):
 
@@ -145,15 +166,19 @@ Forge again whenever you **change IPSW build**. Python 3: **File → Configure �
 
 ### DeviceTree / kernel IM4P (Step 4)
 
+Do **not** reuse `sep-firmware.n104.RELEASE.im4p` here — that file is Step 3 only. Step 4 is **DeviceTree** (and optionally kernelcache). Browse to:
+
+`firmware_extracted/Firmware/all_flash/DeviceTree.n104ap.im4p`
+
 IM4P files are still wrapped. Step 4 needs **`pyimg4`** on PATH or `pyimg4.exe` beside `aqemu.exe` (AQEMU does not vendor it).
 
-| Operation | Use |
-| --- | --- |
-| Extract raw payload | Pull payload out of `.im4p` |
-| Decrypt payload | Needs **AES IV** and **AES Key** (hex) from The Apple Wiki for that build/file |
-| Show payload info | Inspect before decrypt |
+| Operation | AES IV / AES Key | Use |
+| --- | --- | --- |
+| Show payload info | Leave blank | Check whether the IM4P is encrypted |
+| Extract raw payload | Leave blank | Only if info shows no encryption |
+| Decrypt payload | **Required** — DeviceTree (or kernel) IV and Key from The Apple Wiki for **this file and this build**. Not the Step 3 SEP IVKEY |
 
-**DeviceTree must not stay `.im4p`.** Start will refuse raw IM4P. Decrypt/extract until you have `.dtb` or `.dec`. Empty MACHINE DeviceTree is filled from a `.dec`/`.dtb` result.
+**DeviceTree must not stay `.im4p`.** Start will refuse raw IM4P. Decrypt until you have `.dtb` or `.dec`. Empty MACHINE DeviceTree is filled from that result. Kernel is usually ChefKiss’s **research** kernel, not a second pass on SEP.
 
 If pyimg4 is missing: **File → Configure → iOS firmware tools → pyimg4**, or copy `pyimg4.exe` next to `aqemu.exe` / on PATH.
 
@@ -164,10 +189,39 @@ Raw `sep-firmware.n104.RELEASE.im4p` is **not** what Inferno `sep-fw=` wants. Wi
 Still in **File → iOS Firmware Tool…**:
 
 1. **SEP .im4p** — filled after Unpack (`Firmware/all_flash/sep-firmware.n104.RELEASE.im4p`).
-2. **IVKEY** — Apple Wiki IV and key **concatenated** (no space) for that file. **Apple Wiki…** opens the keys page.
+2. **IVKEY** — Apple Wiki keys for **this IPSW build** and the file **`sep-firmware.n104.RELEASE.im4p`** only. **Not iBoot, iBEC, iBSS, or LLB.**
+
+   Open [The Apple Wiki firmware keys](https://theapplewiki.com/wiki/Firmware_Keys) (Firmware Tool **Apple Wiki…**). Open the page for **your** build + **iPhone 11 / iPhone12,1** (example GM: [Keys:Azul 18A373 (iPhone12,1)](https://theapplewiki.com/wiki/Keys:Azul_18A373_(iPhone12,1)); ChefKiss sample IPSW is **18A5351d** beta 5: [Keys:AzulSeed 18A5351d (iPhone12,1)](https://theapplewiki.com/wiki/Keys:AzulSeed_18A5351d_(iPhone12,1))).
+
+   Find the heading **SEP-Firmware** / `sep-firmware.n104.RELEASE.im4p`. Copy **IV** then **Key**, lowercase hex, **no spaces, no `0x`, no newlines**:
+
+   `IVKEY` = `IV` + `Key` (IV first, 32 hex chars, then the 64-char key → **96 hex characters**).
+
+   Example from **18A5351d** SEP-Firmware (ChefKiss sample IPSW / iPhone12,1). Use this only if that is your IPSW:
+
+   ```text
+   IV:  017a328b048aab2edcc4cfe043c2d844
+   Key: a55e67143d57938e37ec6b83ba9e181c0d24bd0a6a14f9f39752b967a9c45cfc
+   ```
+
+   Paste as one line:
+
+   ```text
+   017a328b048aab2edcc4cfe043c2d844a55e67143d57938e37ec6b83ba9e181c0d24bd0a6a14f9f39752b967a9c45cfc
+   ```
+
+   Wrong: iBoot keys. Wrong: **18A373 GM keys** on a **18A5351d** IPSW (or the reverse). Wrong: 14.7.1 `18G82` keys on 14.0. The Firmware Tool strips spaces; do not insert commas or `IV:` / `Key:` labels.
 3. **Decrypt + pack SEP firmware** — AQEMU runs `img4` decrypt then wrap with `-T rsep` and the Step 2 SEP ticket. MACHINE **SEP firmware** is set to the `.new.img4`.
 
-Place **`img4.exe`** (xerub [img4lib](https://github.com/xerub/img4lib)) in **File → Configure → iOS firmware tools**, beside `aqemu.exe`, or on PATH. You do not type the ChefKiss `for /f` command.
+Place **`img4.exe`** (xerub [img4lib](https://github.com/xerub/img4lib), not `pyimg4.exe`) in **File → Configure → iOS firmware tools**, beside `aqemu.exe`, or on PATH. You do not type the ChefKiss `for /f` command.
+
+On Windows the upstream tree is Unix-style; AQEMU’s port is:
+
+```text
+.\scripts\build_img4_windows.ps1
+```
+
+That produces `build_win\img4.exe` (MinGW + OpenSSL + in-tree lzfse). Needs MSYS2 UCRT64/MINGW64 `gcc` and OpenSSL.
 
 ### SEP ROM and SecureROM
 
@@ -194,7 +248,7 @@ SEP ROM for t8030 / iPhone 11 is the **Cebu B1** dump from ChefKiss’s ROM coll
 
 | Field | What to set |
 | --- | --- |
-| **DeviceTree (.dtb / .im4p)** | Extracted **`.dtb` or `.dec`**. Not wrapped `.im4p` |
+| **DeviceTree (.dec / .dtb / .im4p)** | Firmware Tool `.dec` (or `.dtb`). Not wrapped `.im4p`. Browse filter includes `.dec` |
 | **Kernel (.research / .elf)** | Decrypted / research kernelcache |
 | **Boot arguments** | Leave Inferno/AQEMU defaults unless ChefKiss says otherwise. Do not paste random `-append` into Additional Args |
 
@@ -204,7 +258,7 @@ SEP ROM for t8030 / iPhone 11 is the **Cebu B1** dump from ChefKiss’s ROM coll
 | --- | --- |
 | **Trustcache** | Trustcache file from IPSW / Inferno recipe |
 | **Restore ticket** | `root_ticket.der` (real, not placeholder) |
-| **SEP firmware** | `sep-firmware.n104.RELEASE.new.img4` (repackaged) |
+| **SEP firmware** | **MACHINE tab → Options → SEP firmware** (same row — there is no second “Machine SEP” box). Packed `sep-firmware.n104.RELEASE.new.img4` from Firmware Tool Step 3. Not raw `.im4p` |
 | **SEP ROM** | Cebu B1 dump |
 | **SecureROM (optional)** | Empty unless you have it |
 | **IPSW (restore)** | The `.ipsw` / `.zip` Restore dialog uploads |
@@ -223,7 +277,7 @@ Save the VM after filling this. Start validates kernel + DeviceTree; missing/wro
 | SSH port | **32222** (hostfwd) |
 | USB remote | Same **127.0.0.1:8030** |
 | **Start companion in WSL** | Boots companion + `usb-tcp-remote` |
-| **Stop companion** | Before wiping disks / resizing `root` if needed |
+| **Wipe Inferno disks…** | After `-256` / partial flash. **File → Wipe Inferno disks…**, MACHINE **Wipe Inferno disks…**, or this Restore button. Shows the selected VM’s `.aqemu` path and `*_inferno` folder (not hardcoded). Power Off iOS first. Does not wipe companion.qcow2 |
 | **Diagnose** | USB / SSH / 8030 checks |
 | **Restore IPSW via SSH…** | Uploads IPSW, runs patched `idevicerestore` **inside** the companion |
 
@@ -241,7 +295,7 @@ Patched `idevicerestore` rewrites Inferno **`N104DEV` → AP**. Without it: `Una
 
 ## B6. Grow `root` (32 GiB)
 
-ChefKiss: `qemu-img create -f raw root 32G`. AQEMU auto-creates **8 GiB** (~9 GB in Settings). Enough for SpringBoard; **not** enough for large IPAs (UTM SE died around **800 MB free** with `PackageExtractionFailed`).
+ChefKiss: `qemu-img create -f raw root 32G`. Pick **NAND (root) size** on MACHINE, Restore, or the New VM disk page: **16 / 32 / 64 / 128 / 256 GiB** or **Custom** (16–2048 GiB). That size is used when `root` is **created**. Growing the file after iOS is installed does **not** change Settings until you **Wipe Inferno disks**, Power On (new `root` at the chosen size), then restore.
 
 Images live in:
 
@@ -284,7 +338,9 @@ Growing the file **after** iOS is installed does **not** change Settings until A
 | Symptom | Fix |
 | --- | --- |
 | `Unable to discover device type` | Companion `idevicerestore` missing DEV→AP patch |
-| `Could not read data (-256)` after NORData | Wrong SEP; need **repackaged** `.new.img4`. Partial flash: wipe NVMe, restore again |
+| `Could not read data (-256)` after NORData | **SEP firmware** on MACHINE is still raw `.im4p`, or Restore IPSW build ≠ ticket/SEP pack. Power Off → **Wipe Inferno disks…** → pack `.new.img4` → Restore the **same** IPSW |
+| `invalid GPT header` / status 78 | Empty zeros, or **Storage with GPT format** (valid empty GPT). Update-path ramrod needs an APFS **Data** volume. Power Off, Power On (AQEMU formats seed APFS via WSL mkapfs). |
+| `Missing data volume` / status 75 | APFS partition exists but has no Data role volume. Same Power On format step. |
 | Tiny / placeholder ticket | Forge `root_ticket.der` for **this** IPSW |
 | Device never appears | Companion + iOS up, **same** 8030, wait, **Diagnose** |
 | Write lock on `root` | Second Inferno QEMU still running |
@@ -315,15 +371,17 @@ Second-pass launchd-only: `apply-launchd-only-wsl.sh` with `ROOT_IMG` set (no ha
 1. MACHINE **Restore ramdisk** empty.  
 2. Companion may stay up (USB / internet / IPA).  
 3. **Power On** — TCG is slow. Setup (“Welcome to iPhone”) then SpringBoard.  
-4. Use **Home**, not swipe-home.
+4. **Do not swipe** from the bottom. Inferno’s touch (MT-SPI) ignores Home / App Switcher swipes ([ChefKiss #53](https://github.com/ChefKissInc/Inferno/issues/53)).  
+5. After you have a Home screen, **Home** (F6) works. On **Welcome to iPhone / Swipe up to get started**, Home is ignored (that screen wants a Face ID swipe, and iPhone12,1 has no Home button). After the display times out to the lock screen, Home may wake/unlock — that is expected.  
+6. To leave Welcome: click toolbar **SOS** (must **hold Vol+ and Side together**). If SOS only shows the volume HUD, the buttons did not overlap — click **Monitor** and run `sendkey f4-f5 2500` (do not Power Off). When slide-to-power-off appears, either tap the **X**, then **double-click Home** (App Switcher) and close Setup, **or** slide to power off, wait for a blank-ish display, then **Power On** / Reset (do not Wipe, do not Restore).
 
 | Toolbar | Inferno |
 | --- | --- |
 | Vol− | F3 |
 | Vol+ | F4 |
 | Side (power) | F5 (hold uses QEMU `sendkey` hold_ms) |
-| Home | F6 (double = App Switcher) |
-| SOS | Hold Vol+, then Side |
+| Home | F6 (double = App Switcher). Does nothing on Welcome swipe-up. |
+| SOS | Hold Vol+, then Side — use this on Welcome |
 | Pad | Floating pad (not an iPhone bezel) |
 | Net | Device Tools / internet |
 
@@ -415,19 +473,13 @@ Screenshot: Device Tools **Screenshot** (file on companion `/tmp/aqemu-ios.png`)
 
 Use when Settings stays ~9 GB after a host resize, restore half-flashed, or SpringBoard never appears.
 
-**A.** Power Off iOS. Stop leftover Inferno QEMU. Optionally stop companion.
+**A.** Power Off iOS. Optionally **Stop companion**.
 
-**B.** Wipe guest NVMe (iOS off):
+**B.** **File → Wipe Inferno disks…** (or Restore dialog **Wipe Inferno disks…**). Confirm. AQEMU uses the **selected** iOS VM’s `.aqemu` file — the dialog shows that path and the `*_inferno` folder next to it. No PowerShell.
 
-```powershell
-powershell -File extras\Inferno\wipe-ios-nvme.ps1 -VmXml "C:\Users\<you>\AQEMU_VM\iOS_ARM64_.aqemu"
-```
+**C.** Power On once (recreates empty images) → Power Off → grow `root` in the GUI if you use 32 GiB ([§6](#b6-grow-root-32-gib)).
 
-Type `YES`. Deletes `root`, `nvram`, `firmware`, … under `*_inferno\`. If `root` is a **symlink**, delete/replace the **target** too.
-
-**C.** Power On once (recreates **8 GiB** empties) → Power Off → sparse-resize `root` to **32 GiB** ([§6](#b6-grow-root-32-gib)).
-
-**D.** Put **Restore ramdisk** back. Save. Start companion. Power On iOS. Confirm restore boot args. **Restore IPSW via SSH…**
+**D.** Put **Restore ramdisk (-initrd)** back. Save. **Start companion**. Power On iOS. Confirm restore boot args. **Restore IPSW via SSH…** (IPSW must match MACHINE **IPSW (restore)** / tickets / SEP pack).
 
 **E.** FS patches → initrd cleared → Power On → SpringBoard. Enable internet again. Reinstall IPAs.
 

--- a/extras/Inferno/patch_idevicerestore_cfs.py
+++ b/extras/Inferno/patch_idevicerestore_cfs.py
@@ -1,0 +1,1033 @@
+#!/usr/bin/env python3
+"""Pin companion idevicerestore to ChefKiss-era 74e3bd9 (once).
+
+Inferno iOS 14 ramrod needs CreateFilesystemPartitions=true. Companion
+1.0.0-271-g45145e9 always arrives at ramrod as CFS=false (GPT 78) even
+with --erase. Working public logs use 74e3bd9. This script clones that
+commit once, applies the ChefKiss N104DEV->AP patch, and installs it.
+Later Restores see 74e3bd9 in --version and skip the rebuild.
+"""
+from __future__ import print_function
+
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+
+MARKER = "/usr/local/etc/aqemu-idr-74e3bd9"
+LIMD_MARKER = "/usr/local/etc/aqemu-limd-c194db38"
+PIN_VER = "74e3bd9"
+PIN_SHA = "74e3bd9286d16fc1290abde061ee00831d5b36f8"
+PIN_SRC = "/tmp/aqemu-idr-74e3bd9"
+IDR_GIT = "https://github.com/libimobiledevice/idevicerestore.git"
+# Same-day stack as idevicerestore 74e3bd9 (2025-11-24). Companion .so files
+# are newer (45145e9 era) and ramrod still sees CFS=false without LD_PRELOAD.
+LIMD_SHA = "c194db388fb7f1f65ef0a08817f26ed0e8d078b3"
+LIMD_GIT = "https://github.com/libimobiledevice/libimobiledevice.git"
+LIMD_SRC = "/tmp/aqemu-limd-c194db38"
+PLIST_SHA = "18e5b22a71f85091127cc063db79c8df687c582c"
+PLIST_GIT = "https://github.com/libimobiledevice/libplist.git"
+PLIST_SRC = "/tmp/aqemu-plist-18e5b22"
+DUMP_TAG = "AQEMU StartRestore options"
+MATCH_TAG = "AQEMU match-219"
+USB_TCP_TAG = "AQEMU USB-TCP v4"
+KEY = b"CreateFilesystemPartitions\x00"
+DEFAULT_BIN = "/usr/local/bin/idevicerestore"
+
+
+def run(cmd, cwd=None):
+	print("AQEMU: run %s" % " ".join(cmd))
+	sys.stdout.flush()
+	env = os.environ.copy()
+	env["GIT_TERMINAL_PROMPT"] = "0"
+	subprocess.check_call(cmd, cwd=cwd, env=env)
+
+
+def idr_version(binary=DEFAULT_BIN):
+	try:
+		out = subprocess.check_output(
+			[binary, "--version"], stderr=subprocess.STDOUT
+		).decode("ascii", "replace")
+		return out
+	except Exception as e:
+		return "(%s)" % e
+
+
+def pkgconfig_env():
+	paths = [
+		"/usr/local/lib/pkgconfig",
+		"/usr/local/share/pkgconfig",
+		"/usr/lib/x86_64-linux-gnu/pkgconfig",
+		"/usr/lib/pkgconfig",
+		"/usr/share/pkgconfig",
+	]
+	old = os.environ.get("PKG_CONFIG_PATH", "")
+	if old:
+		paths.append(old)
+	env = os.environ.copy()
+	env["PKG_CONFIG_PATH"] = ":".join(paths)
+	env.pop("PKG_CONFIG_LIBDIR", None)
+	env["GIT_TERMINAL_PROMPT"] = "0"
+	env["DEBIAN_FRONTEND"] = "noninteractive"
+	return env
+
+
+def ver_tuple(s):
+	parts = []
+	for p in s.split("."):
+		try:
+			parts.append(int(p))
+		except ValueError:
+			parts.append(0)
+	return tuple(parts + [0, 0, 0])[:3]
+
+
+def find_include_root(header_rel):
+	"""Directory to pass as -I so #include <header_rel> works."""
+	header_rel = header_rel.replace("\\", "/")
+	leaf = os.path.basename(header_rel)
+	parent = os.path.dirname(header_rel)
+	for search in ("/usr/local/include", "/usr/include"):
+		direct = os.path.join(search, header_rel)
+		if os.path.isfile(direct):
+			return search
+		if not os.path.isdir(search):
+			continue
+		for dp, _, fns in os.walk(search):
+			if leaf not in fns:
+				continue
+			if parent:
+				if os.path.basename(dp) == os.path.basename(parent):
+					return os.path.dirname(dp)
+			else:
+				return dp
+	return None
+
+
+def copy_tree_contents(src, dst):
+	if not os.path.isdir(dst):
+		os.makedirs(dst)
+	for name in os.listdir(src):
+		s = os.path.join(src, name)
+		d = os.path.join(dst, name)
+		if os.path.isdir(s):
+			copy_tree_contents(s, d)
+		else:
+			shutil.copy2(s, d)
+
+
+HDR_REPOS = (
+	("libplist", "https://github.com/libimobiledevice/libplist.git"),
+	("libimobiledevice-glue",
+		"https://github.com/libimobiledevice/libimobiledevice-glue.git"),
+	("libusbmuxd", "https://github.com/libimobiledevice/libusbmuxd.git"),
+	("libtatsu", "https://github.com/libimobiledevice/libtatsu.git"),
+	("libirecovery", "https://github.com/libimobiledevice/libirecovery.git"),
+	("libimobiledevice",
+		"https://github.com/libimobiledevice/libimobiledevice.git"),
+)
+
+
+def ensure_dev_headers(needed):
+	"""Companion often has /usr/local/lib/*.so but no matching headers."""
+	missing = []
+	for header_rel in needed:
+		root = find_include_root(header_rel)
+		if root:
+			print("AQEMU: header %s via -I%s" % (header_rel, root))
+		else:
+			missing.append(header_rel)
+	if not missing:
+		return True
+	print("AQEMU: missing headers: %s" % ", ".join(missing))
+	print("AQEMU: cloning libimobiledevice include trees into /usr/local/include (once)")
+	inc = "/usr/local/include"
+	if not os.path.isdir(inc):
+		os.makedirs(inc)
+	ok = True
+	for name, url in HDR_REPOS:
+		tmp = "/tmp/aqemu-hdr-" + name
+		try:
+			if os.path.isdir(tmp):
+				shutil.rmtree(tmp)
+			run(["git", "clone", "--depth", "1", url, tmp])
+			src = os.path.join(tmp, "include")
+			if not os.path.isdir(src):
+				print("AQEMU: %s has no include/" % name)
+				ok = False
+				continue
+			copy_tree_contents(src, inc)
+			print("AQEMU: copied %s include/ -> %s" % (name, inc))
+		except (subprocess.CalledProcessError, OSError) as e:
+			print("AQEMU: header clone %s failed: %s" % (name, e))
+			ok = False
+	still = [h for h in needed if not find_include_root(h)]
+	if still:
+		print("AQEMU: still missing headers after clone: %s" % ", ".join(still))
+		return False
+	return ok
+
+
+def pc_needs_rewrite(path, min_version):
+	if not os.path.isfile(path):
+		return True
+	text = open(path, "r").read()
+	if "AQEMU stub" in text:
+		return True
+	for line in text.splitlines():
+		if line.lower().startswith("version:"):
+			got = line.split(":", 1)[1].strip()
+			if ver_tuple(got) < ver_tuple(min_version):
+				print("AQEMU: %s Version %s < %s, rewriting" % (path, got, min_version))
+				return True
+			print("AQEMU: pkg-config %s already Version %s" % (os.path.basename(path), got))
+			return False
+	return True
+
+
+def write_pc(name, lib, version, header_rel):
+	d = "/usr/local/lib/pkgconfig"
+	path = os.path.join(d, name + ".pc")
+	if not pc_needs_rewrite(path, version):
+		return
+	inc = find_include_root(header_rel) or "/usr/local/include"
+	hdr = os.path.join(inc, header_rel)
+	if not os.path.isfile(hdr):
+		print("AQEMU: header missing %s (writing %s.pc Version %s anyway)" % (
+			hdr, name, version))
+	if not os.path.isdir(d):
+		os.makedirs(d)
+	body = (
+		"prefix=/usr/local\n"
+		"exec_prefix=${prefix}\n"
+		"libdir=${prefix}/lib\n"
+		"includedir=%s\n"
+		"\n"
+		"Name: %s\n"
+		"Description: %s (AQEMU stub for 74e3bd9 pin)\n"
+		"Version: %s\n"
+		"Libs: -L${libdir} -l%s\n"
+		"Cflags: -I${includedir}\n"
+	) % (inc, name, name, version, lib)
+	open(path, "w").write(body)
+	print("AQEMU: wrote %s Version %s includedir=%s" % (path, version, inc))
+
+
+def find_lib_dir(lib):
+	"""Directory containing lib<lib>.so* (not a prefix of another lib)."""
+	prefix = "lib%s.so" % lib
+	for d in (
+		"/usr/local/lib",
+		"/usr/lib/x86_64-linux-gnu",
+		"/lib/x86_64-linux-gnu",
+		"/usr/lib",
+	):
+		if not os.path.isdir(d):
+			continue
+		try:
+			names = os.listdir(d)
+		except OSError:
+			continue
+		for fn in names:
+			if fn == prefix or fn.startswith(prefix + "."):
+				return d
+	return None
+
+
+def pc_exists(mod, env):
+	return subprocess.call(
+		["pkg-config", "--exists", mod],
+		env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+	) == 0
+
+
+def write_pc_sys(name, lib, version, header_rel, libdir):
+	d = "/usr/local/lib/pkgconfig"
+	path = os.path.join(d, name + ".pc")
+	if not pc_needs_rewrite(path, version):
+		return
+	inc = find_include_root(header_rel) or "/usr/include"
+	if not os.path.isdir(d):
+		os.makedirs(d)
+	body = (
+		"prefix=/usr\n"
+		"exec_prefix=${prefix}\n"
+		"libdir=%s\n"
+		"includedir=%s\n"
+		"\n"
+		"Name: %s\n"
+		"Description: %s (AQEMU stub for 74e3bd9 pin)\n"
+		"Version: %s\n"
+		"Libs: -L${libdir} -l%s\n"
+		"Cflags: -I${includedir}\n"
+	) % (libdir, inc, name, name, version, lib)
+	open(path, "w").write(body)
+	print("AQEMU: wrote %s Version %s libdir=%s includedir=%s" % (
+		path, version, libdir, inc))
+
+
+def ensure_system_dev():
+	"""libzip/zlib/libcurl are distro .so files; companion often lacks -dev .pc."""
+	env = pkgconfig_env()
+	mods = (
+		("libzip", "zip", "1.7.3", "zip.h", "libzip-dev"),
+		("zlib", "z", "1.2.11", "zlib.h", "zlib1g-dev"),
+		("libcurl", "curl", "7.81.0", "curl/curl.h", "libcurl4-openssl-dev"),
+	)
+	need_apt = []
+	for mod, lib, ver, hdr, pkg in mods:
+		if pc_exists(mod, env) and find_include_root(hdr):
+			print("AQEMU: pkg-config %s already present" % mod)
+			continue
+		need_apt.append(pkg)
+	if need_apt:
+		pkgs = list(dict.fromkeys(need_apt))
+		print("AQEMU: apt-get install %s (for 74e3bd9 configure)" % " ".join(pkgs))
+		cmd = ["apt-get", "install", "-y"] + pkgs
+		try:
+			subprocess.check_call(cmd, env=env)
+		except subprocess.CalledProcessError:
+			print("AQEMU: apt-get install failed; retrying after apt-get update")
+			try:
+				subprocess.check_call(["apt-get", "update", "-qq"], env=env)
+				subprocess.check_call(cmd, env=env)
+			except subprocess.CalledProcessError as e:
+				print("AQEMU: apt-get still failed: %s" % e)
+	env = pkgconfig_env()
+	if not find_include_root("zip.h"):
+		tmp = "/tmp/aqemu-hdr-libzip"
+		try:
+			if os.path.isdir(tmp):
+				shutil.rmtree(tmp)
+			run(["git", "clone", "--depth", "1",
+				"https://github.com/nih-at/libzip.git", tmp])
+			src = os.path.join(tmp, "lib", "zip.h")
+			inc = "/usr/local/include"
+			if not os.path.isdir(inc):
+				os.makedirs(inc)
+			if os.path.isfile(src):
+				shutil.copy2(src, os.path.join(inc, "zip.h"))
+				print("AQEMU: copied zip.h -> %s" % inc)
+			real_conf = os.path.join(tmp, "lib", "zipconf.h")
+			dst_conf = os.path.join(inc, "zipconf.h")
+			if os.path.isfile(real_conf):
+				shutil.copy2(real_conf, dst_conf)
+			elif not os.path.isfile(dst_conf):
+				open(dst_conf, "w").write(
+					"#ifndef _HAD_ZIPCONF_H\n#define _HAD_ZIPCONF_H\n"
+					"#include <stdint.h>\n"
+					"typedef int8_t zip_int8_t;\n"
+					"typedef uint8_t zip_uint8_t;\n"
+					"typedef int16_t zip_int16_t;\n"
+					"typedef uint16_t zip_uint16_t;\n"
+					"typedef int32_t zip_int32_t;\n"
+					"typedef uint32_t zip_uint32_t;\n"
+					"typedef int64_t zip_int64_t;\n"
+					"typedef uint64_t zip_uint64_t;\n"
+					"#define ZIP_LIBZIP_VERSION \"1.7.3\"\n"
+					"#endif\n"
+				)
+				print("AQEMU: wrote minimal zipconf.h")
+		except (subprocess.CalledProcessError, OSError) as e:
+			print("AQEMU: libzip header fallback failed: %s" % e)
+	env = pkgconfig_env()
+	for mod, lib, ver, hdr, pkg in mods:
+		if pc_exists(mod, env):
+			try:
+				out = subprocess.check_output(
+					["pkg-config", "--modversion", mod],
+					stderr=subprocess.STDOUT, env=env
+				).decode("ascii", "replace")
+				print("AQEMU: pkg-config %s => %s" % (mod, out.strip()))
+			except subprocess.CalledProcessError:
+				print("AQEMU: pkg-config %s exists (no version)" % mod)
+			continue
+		libdir = find_lib_dir(lib) or "/usr/lib/x86_64-linux-gnu"
+		print("AQEMU: stubbing %s.pc (lib in %s)" % (mod, libdir))
+		write_pc_sys(mod, lib, ver, hdr, libdir)
+
+
+def ensure_pkgconfig():
+	"""Companion libs live in /usr/local but .pc files are often missing.
+
+	74e3bd9 configure.ac wants libimobiledevice-1.0 >= 1.4.0, libplist-2.0 >= 2.6.0,
+	libimobiledevice-glue-1.0 >= 1.3.0. The installed SONAME (e.g. .so.6) is not
+	the pkg-config Version; a stub of 1.0.6 makes configure fail.
+	"""
+	needed = (
+		"libirecovery.h",
+		"libimobiledevice/libimobiledevice.h",
+		"libimobiledevice-glue/glue.h",
+		"usbmuxd.h",
+		"plist/plist.h",
+		"libtatsu/tatsu.h",
+	)
+	ensure_dev_headers(needed)
+	# Versions must satisfy 74e3bd9 configure.ac (not the .so.N SONAME).
+	write_pc("libirecovery-1.0", "irecovery-1.0", "1.3.1", "libirecovery.h")
+	write_pc("libimobiledevice-1.0", "imobiledevice-1.0", "1.4.0",
+		"libimobiledevice/libimobiledevice.h")
+	write_pc("libimobiledevice-glue-1.0", "imobiledevice-glue-1.0", "1.3.0",
+		"libimobiledevice-glue/glue.h")
+	write_pc("libusbmuxd-2.0", "usbmuxd-2.0", "2.0.2", "usbmuxd.h")
+	write_pc("libplist-2.0", "plist-2.0", "2.6.0", "plist/plist.h")
+	write_pc("libtatsu-1.0", "tatsu", "1.0.5", "libtatsu/tatsu.h")
+	write_pc("libtatsu", "tatsu", "1.0.5", "libtatsu/tatsu.h")
+	ensure_system_dev()
+	env = pkgconfig_env()
+	print("AQEMU: PKG_CONFIG_PATH=%s" % env.get("PKG_CONFIG_PATH", ""))
+	try:
+		out = subprocess.check_output(
+			["ls", "-la", "/usr/local/lib/pkgconfig"],
+			stderr=subprocess.STDOUT, env=env
+		).decode("ascii", "replace")
+		print("AQEMU: /usr/local/lib/pkgconfig:\n%s" % out)
+	except Exception as e:
+		print("AQEMU: ls pkgconfig: %s" % e)
+	for mod in ("libirecovery-1.0", "libimobiledevice-1.0", "libplist-2.0",
+			"libimobiledevice-glue-1.0", "libzip", "zlib", "libcurl"):
+		try:
+			out = subprocess.check_output(
+				["pkg-config", "--modversion", mod],
+				stderr=subprocess.STDOUT, env=env
+			).decode("ascii", "replace")
+			print("AQEMU: pkg-config %s => %s" % (mod, out.strip()))
+		except subprocess.CalledProcessError as e:
+			err = e.output.decode("ascii", "replace") if e.output else str(e)
+			print("AQEMU: pkg-config %s failed: %s" % (mod, err))
+	return env
+
+
+def apply_chefkiss(src_root):
+	path = os.path.join(src_root, "src", "restore.c")
+	text = open(path, "r").read()
+	if "INFO: model is" in text:
+		print("AQEMU: ChefKiss DEV->AP already in restore.c")
+		return True
+	anchor = "restore_get_irecv_device"
+	idx = text.find(anchor)
+	if idx < 0:
+		print("AQEMU: restore_get_irecv_device not in restore.c")
+		return False
+	chunk = text[idx : idx + 4000]
+	needle = "\tplist_get_string_val(node, &model);\n"
+	insert = (
+		needle
+		+ '\tlogger(LL_INFO, "INFO: model is %s\\n", model);\n'
+		+ '\tif (strstr(model, "DEV")) {\n'
+		+ '\t\tstrncpy(strstr(model, "DEV"), "AP\\0", 3);\n'
+		+ "\t}\n"
+	)
+	if needle not in chunk:
+		needle = "        plist_get_string_val(node, &model);\n"
+		insert = (
+			needle
+			+ '        logger(LL_INFO, "INFO: model is %s\\n", model);\n'
+			+ '        if (strstr(model, "DEV")) {\n'
+			+ '                strncpy(strstr(model, "DEV"), "AP\\0", 3);\n'
+			+ "        }\n"
+		)
+	if needle not in chunk:
+		print("AQEMU: cannot find plist_get_string_val(node, &model) near restore_get_irecv_device")
+		return False
+	chunk2 = chunk.replace(needle, insert, 1)
+	open(path, "w").write(text[:idx] + chunk2 + text[idx + len(chunk) :])
+	print("AQEMU: applied ChefKiss N104DEV->AP in restore.c")
+	return True
+
+
+def apply_match_219(src_root):
+	"""Short marker only. Do not dump StartRestore XML (Inferno #219 did not)."""
+	path = os.path.join(src_root, "src", "restore.c")
+	text = open(path, "r").read()
+	if MATCH_TAG in text:
+		print("AQEMU: %s already in restore.c" % MATCH_TAG)
+		return True
+	needle = 'logger(LL_INFO, "INFO: model is %s\\n", model);\n'
+	if needle not in text:
+		print("AQEMU: ChefKiss model log not in restore.c (cannot add %s)" % MATCH_TAG)
+		return False
+	insert = needle + '\tlogger(LL_INFO, "%s\\n");\n' % MATCH_TAG
+	open(path, "w").write(text.replace(needle, insert, 1))
+	print("AQEMU: %s (ChefKiss only, no XML dump / option rewrite)" % MATCH_TAG)
+	return True
+
+
+def apply_usb_tcp_cfs(src_root):
+	"""v4: ramrod ignores RestoreOptions CFS boolean (v2/v3 proved it).
+
+	Send CreateFilesystemPartitions as integer 1 inside RestoreOptions, and
+	also as a boolean on the top-level StartRestore message via restored_send.
+	"""
+	path = os.path.join(src_root, "src", "restore.c")
+	text = open(path, "r").read()
+	if USB_TCP_TAG in text:
+		print("AQEMU: %s already in restore.c" % USB_TCP_TAG)
+		return True
+	needle = "restore_error = restored_start_restore(restore, opts, client->restore->protocol_version);"
+	if needle not in text:
+		print("AQEMU: restored_start_restore call not in restore.c (cannot force CFS)")
+		return False
+	insert = (
+		"\t{\n"
+		"\t\tplist_t aqemu_mini = plist_new_dict();\n"
+		'\t\tplist_t aqemu_uuid = plist_dict_get_item(opts, "UUID");\n'
+		'\t\tplist_dict_set_item(aqemu_mini, "AutoBootDelay", plist_new_uint(0));\n'
+		'\t\tplist_dict_set_item(aqemu_mini, "CreateFilesystemPartitions", plist_new_uint(1));\n'
+		'\t\tplist_dict_set_item(aqemu_mini, "AuthInstallRestoreBehavior", plist_new_string("Erase"));\n'
+		"\t\tif (aqemu_uuid)\n"
+		'\t\t\tplist_dict_set_item(aqemu_mini, "UUID", plist_copy(aqemu_uuid));\n'
+		'\t\tplist_dict_set_item(aqemu_mini, "SystemImage", plist_new_bool(1));\n'
+		'\t\tplist_dict_set_item(aqemu_mini, "FlashNOR", plist_new_bool(1));\n'
+		"\t\tplist_free(opts);\n"
+		"\t\topts = aqemu_mini;\n"
+		"\t}\n"
+		"\t{\n"
+		"\t\tplist_t aqemu_msg = plist_new_dict();\n"
+		'\t\tplist_dict_set_item(aqemu_msg, "Request", plist_new_string("StartRestore"));\n'
+		'\t\tplist_dict_set_item(aqemu_msg, "CreateFilesystemPartitions", plist_new_bool(1));\n'
+		'\t\tplist_dict_set_item(aqemu_msg, "RestoreOptions", plist_copy(opts));\n'
+		'\t\tplist_dict_set_item(aqemu_msg, "RestoreProtocolVersion", plist_new_uint(client->restore->protocol_version));\n'
+		"\t\t{\n"
+		"\t\t\tchar *aqemu_xml = NULL;\n"
+		"\t\t\tuint32_t aqemu_xlen = 0;\n"
+		"\t\t\tplist_to_xml(aqemu_msg, &aqemu_xml, &aqemu_xlen);\n"
+		"\t\t\tif (aqemu_xml) {\n"
+		'\t\t\t\tlogger(LL_INFO, "' + USB_TCP_TAG + ' XML (%u bytes):\\n%s\\n",'
+		" aqemu_xlen, aqemu_xml);\n"
+		"\t\t\t\tfree(aqemu_xml);\n"
+		"\t\t\t}\n"
+		"\t\t}\n"
+		"\t\trestore_error = restored_send(restore, aqemu_msg);\n"
+		"\t\tplist_free(aqemu_msg);\n"
+		"\t}\n"
+	)
+	open(path, "w").write(text.replace(needle, insert, 1))
+	print("AQEMU: %s (top-level CFS bool + RestoreOptions CFS integer 1)" % USB_TCP_TAG)
+	return True
+
+
+def apply_opts_dump(src_root):
+	"""Log StartRestore XML immediately before it is sent."""
+	path = os.path.join(src_root, "src", "restore.c")
+	text = open(path, "r").read()
+	if DUMP_TAG in text:
+		print("AQEMU: StartRestore XML dump already in restore.c")
+		return True
+	needle = "restore_error = restored_start_restore(restore, opts, client->restore->protocol_version);"
+	if needle not in text:
+		print("AQEMU: restored_start_restore call not in restore.c (cannot add XML dump)")
+		return False
+	dump_log = (
+		'\t\t\tlogger(LL_INFO, "%s (%%u bytes):\\n%%s\\n", aqemu_xlen, aqemu_xml);\n'
+		% DUMP_TAG
+	)
+	insert = (
+		"\t{\n"
+		"\t\tchar *aqemu_xml = NULL;\n"
+		"\t\tuint32_t aqemu_xlen = 0;\n"
+		"\t\tplist_to_xml(opts, &aqemu_xml, &aqemu_xlen);\n"
+		"\t\tif (aqemu_xml) {\n"
+		+ dump_log
+		+ "\t\t\tfree(aqemu_xml);\n"
+		+ "\t\t}\n"
+		+ "\t}\n"
+		+ "\t" + needle
+	)
+	open(path, "w").write(text.replace(needle, insert, 1))
+	print("AQEMU: added StartRestore XML dump before restored_start_restore")
+	return True
+
+
+def apply_inferno_ios14_opts(src_root):
+	"""74e3bd9 sends iOS 18 keys. Inferno iOS 14 ramrod then shows CFS=false.
+
+	Host XML dump already has CreateFilesystemPartitions true; ramrod still
+	takes verify_storage_for_update. Strip AEA/iOS18 keys and request Erase.
+	"""
+	path = os.path.join(src_root, "src", "restore.c")
+	text = open(path, "r").read()
+	if "AQEMU CFS-first" in text:
+		print("AQEMU: Inferno iOS14 option strip already in restore.c")
+		return True
+	orig = text
+	for key in (
+		"HostHasFixFor99053849",
+		"SystemImageFormat",
+		"WaitForDeviceConnectionToFinishStateMachine",
+	):
+		text, n = re.subn(
+			r'\n[ \t]*plist_dict_set_item\(opts, "%s", [^;]+;\n' % key,
+			"\n",
+			text,
+			count=1,
+		)
+		if n == 0:
+			print("AQEMU: did not find %s set_item in restore.c" % key)
+	text, n_async = re.subn(
+		r'\n[ \t]*plist_t async_data_types = plist_new_dict\(\);'
+		r'(?:\n[ \t]*plist_dict_set_item\(async_data_types, "[^"]+", plist_new_bool\([01]\)\);){5}'
+		r'\n[ \t]*plist_dict_set_item\(opts, "SupportedAsyncDataTypes", async_data_types\);',
+		"\n\t/* AQEMU Inferno iOS14 opts: stripped iOS18 keys */",
+		text,
+		count=1,
+	)
+	if n_async == 0:
+		print("AQEMU: SupportedAsyncDataTypes block did not match")
+	text, n_auth = re.subn(
+		r'//[ \t]*plist_dict_set_item\(opts, "AuthInstallRestoreBehavior", plist_new_string\("Erase"\)\);',
+		'plist_dict_set_item(opts, "AuthInstallRestoreBehavior", plist_new_string("Erase")); /* AQEMU Inferno iOS14 opts */',
+		text,
+		count=1,
+	)
+	if n_auth == 0:
+		cfs = 'plist_dict_set_item(opts, "CreateFilesystemPartitions", plist_new_bool(1));'
+		if cfs in text:
+			text = text.replace(
+				cfs,
+				cfs + '\n\tplist_dict_set_item(opts, "AuthInstallRestoreBehavior", plist_new_string("Erase")); /* AQEMU Inferno iOS14 opts */',
+				1)
+			print("AQEMU: inserted AuthInstallRestoreBehavior=Erase next to CFS")
+		else:
+			print("AQEMU: could not set AuthInstallRestoreBehavior=Erase")
+			return False
+	# USB-over-TCP can drop the tail of the StartRestore XML. Ramrod parsed
+	# UUID (near the end) but CreateFilesystemPartitions after it as false.
+	# Set CFS first so it lands in the first USB packet. libplist set_item
+	# replaces in place, so the later CFS set_item keeps this position.
+	opts_new = "plist_t opts = plist_new_dict();"
+	if "AQEMU CFS-first" not in text and opts_new in text:
+		text = text.replace(
+			opts_new,
+			opts_new
+			+ '\n\tlogger(LL_INFO, "AQEMU CFS-first\\n");\n'
+			+ '\tplist_dict_set_item(opts, "CreateFilesystemPartitions", plist_new_bool(1));',
+			1)
+	if text == orig:
+		print("AQEMU: Inferno iOS14 option strip made no changes")
+		return False
+	if "AEAWrappedDiskImage" in text:
+		print("AQEMU: AEAWrappedDiskImage still in restore.c after strip")
+		return False
+	open(path, "w").write(text)
+	print("AQEMU: stripped iOS18 keys, AuthInstallRestoreBehavior=Erase, CFS-first")
+	return True
+
+
+def binary_has_aea(binary):
+	try:
+		return b"AEAWrappedDiskImage" in open(binary, "rb").read()
+	except OSError:
+		return True
+
+
+def binary_has_cfs_first(binary):
+	try:
+		return b"AQEMU CFS-first" in open(binary, "rb").read()
+	except OSError:
+		return False
+
+
+def git_checkout_sha(url, dest, sha):
+	if os.path.isdir(dest):
+		shutil.rmtree(dest)
+	os.makedirs(dest)
+	run(["git", "init"], cwd=dest)
+	run(["git", "remote", "add", "origin", url], cwd=dest)
+	try:
+		run(["git", "fetch", "--depth", "1", "origin", sha], cwd=dest)
+	except subprocess.CalledProcessError:
+		print("AQEMU: shallow fetch failed; trying full clone")
+		shutil.rmtree(dest)
+		run(["git", "clone", url, dest])
+		run(["git", "checkout", sha], cwd=dest)
+		return
+	run(["git", "checkout", "FETCH_HEAD"], cwd=dest)
+
+
+def autogen_install(src, env, extra=""):
+	pc = env.get("PKG_CONFIG_PATH", "/usr/local/lib/pkgconfig")
+	autogen = os.path.join(src, "autogen.sh")
+	if os.path.isfile(autogen):
+		subprocess.check_call(
+			["bash", "-c",
+			 "export PKG_CONFIG_PATH='%s'; unset PKG_CONFIG_LIBDIR; ./autogen.sh %s"
+			 % (pc, extra)],
+			cwd=src, env=env)
+	else:
+		subprocess.check_call(["autoreconf", "-fi"], cwd=src, env=env)
+		subprocess.check_call(
+			["bash", "-c",
+			 "export PKG_CONFIG_PATH='%s'; unset PKG_CONFIG_LIBDIR; ./configure %s"
+			 % (pc, extra)],
+			cwd=src, env=env)
+	subprocess.check_call(["make", "-j", str(os.cpu_count() or 2)], cwd=src, env=env)
+	subprocess.check_call(["make", "install"], cwd=src, env=env)
+
+
+def pin_era_libs():
+	"""Install libplist + libimobiledevice from 2025-11-24 (match 74e3bd9)."""
+	if os.path.isfile(LIMD_MARKER):
+		print("AQEMU: already pinned libimobiledevice %s" % LIMD_SHA[:8])
+		return 0
+	print("AQEMU: ONE-TIME libplist+libimobiledevice @ 2025-11-24 (CFS=false on newer .so)")
+	print("AQEMU: later Restores skip this. A few minutes, needs git/autotools/network.")
+	try:
+		env = pkgconfig_env()
+		git_checkout_sha(PLIST_GIT, PLIST_SRC, PLIST_SHA)
+		print("AQEMU: autogen/make libplist %s..." % PLIST_SHA[:8])
+		sys.stdout.flush()
+		autogen_install(PLIST_SRC, env)
+		env = ensure_pkgconfig()
+		git_checkout_sha(LIMD_GIT, LIMD_SRC, LIMD_SHA)
+		print("AQEMU: autogen/make libimobiledevice %s..." % LIMD_SHA[:8])
+		sys.stdout.flush()
+		autogen_install(LIMD_SRC, env, "--without-cython")
+		subprocess.call(["ldconfig"])
+	except (subprocess.CalledProcessError, OSError) as e:
+		print("AQEMU: FATAL: era lib install failed: %s" % e)
+		return 1
+	try:
+		d = os.path.dirname(LIMD_MARKER)
+		if d and not os.path.isdir(d):
+			os.makedirs(d)
+		open(LIMD_MARKER, "w").write(LIMD_SHA + "\n")
+	except OSError:
+		pass
+	print("AQEMU: pinned libimobiledevice %s (ldconfig done)" % LIMD_SHA[:8])
+	return 0
+
+
+def binary_has_dump(binary):
+	try:
+		return DUMP_TAG.encode("ascii") in open(binary, "rb").read()
+	except OSError:
+		return False
+
+
+def pin_74e3bd9(binary):
+	if pin_era_libs() != 0:
+		return 1
+	ver = idr_version(binary)
+	print("AQEMU: current idevicerestore --version:\n%s" % ver.strip())
+	blob = b""
+	if os.path.isfile(binary):
+		blob = open(binary, "rb").read()
+	need_idr = (PIN_VER not in ver
+		or MATCH_TAG.encode("ascii") not in blob
+		or USB_TCP_TAG.encode("ascii") not in blob)
+	if not need_idr:
+		print("AQEMU: already ChefKiss-era %s with %s - not rebuilding" % (PIN_VER, USB_TCP_TAG))
+		return 0
+	if PIN_VER in ver:
+		print("AQEMU: rebuilding 74e3bd9 once (USB-TCP v4: top-level CFS + integer 1)")
+	print("AQEMU: ONE-TIME install of idevicerestore %s (Inferno GPT 78 / CFS=false)" % PIN_VER)
+	print("AQEMU: later Restores skip this. Needs git/autotools/network on companion.")
+	try:
+		if os.path.isdir(PIN_SRC):
+			shutil.rmtree(PIN_SRC)
+		os.makedirs(PIN_SRC)
+		run(["git", "init"], cwd=PIN_SRC)
+		run(["git", "remote", "add", "origin", IDR_GIT], cwd=PIN_SRC)
+		try:
+			run(["git", "fetch", "--depth", "1", "origin", PIN_SHA], cwd=PIN_SRC)
+		except subprocess.CalledProcessError:
+			print("AQEMU: shallow fetch failed; trying full clone")
+			shutil.rmtree(PIN_SRC)
+			run(["git", "clone", IDR_GIT, PIN_SRC])
+			run(["git", "checkout", PIN_SHA], cwd=PIN_SRC)
+		else:
+			run(["git", "checkout", "FETCH_HEAD"], cwd=PIN_SRC)
+		if not apply_chefkiss(PIN_SRC):
+			return 1
+		if not apply_match_219(PIN_SRC):
+			return 1
+		if not apply_usb_tcp_cfs(PIN_SRC):
+			return 1
+		if os.path.isfile(binary):
+			bak_old = binary + ".aqemu-pre-74e3bd9"
+			if not os.path.isfile(bak_old):
+				shutil.copy2(binary, bak_old)
+				print("AQEMU: saved previous binary as %s" % bak_old)
+		cfg_env = ensure_pkgconfig()
+		print("AQEMU: autogen/make (a few minutes, once)...")
+		sys.stdout.flush()
+		autogen = os.path.join(PIN_SRC, "autogen.sh")
+		pc = cfg_env.get("PKG_CONFIG_PATH", "/usr/local/lib/pkgconfig")
+		if os.path.isfile(autogen):
+			subprocess.check_call(
+				["bash", "-c",
+				 "export PKG_CONFIG_PATH='%s'; unset PKG_CONFIG_LIBDIR; ./autogen.sh" % pc],
+				cwd=PIN_SRC, env=cfg_env)
+		else:
+			subprocess.check_call(["autoreconf", "-fi"], cwd=PIN_SRC, env=cfg_env)
+			subprocess.check_call(["./configure"], cwd=PIN_SRC, env=cfg_env)
+		subprocess.check_call(["make", "-j", str(os.cpu_count() or 2)], cwd=PIN_SRC, env=cfg_env)
+		subprocess.check_call(["make", "install"], cwd=PIN_SRC, env=cfg_env)
+		subprocess.call(["ldconfig"])
+	except (subprocess.CalledProcessError, OSError) as e:
+		print("AQEMU: FATAL: 74e3bd9 install failed: %s" % e)
+		print("AQEMU: companion needs git, autotools, and network (github.com).")
+		return 1
+	ver2 = idr_version(binary)
+	print("AQEMU: installed idevicerestore --version:\n%s" % ver2.strip())
+	if PIN_VER not in ver2:
+		print("AQEMU: FATAL: install did not yield %s" % PIN_VER)
+		return 1
+	try:
+		d = os.path.dirname(MARKER)
+		if d and not os.path.isdir(d):
+			os.makedirs(d)
+		open(MARKER, "w").write(PIN_SHA + "\n")
+	except OSError:
+		pass
+	print("AQEMU: pinned %s - this Restore will use it (no rebuild next time)" % PIN_VER)
+	return 0
+
+
+def load_phdrs(data):
+	if data[:4] != b"\x7fELF" or data[4] != 2:
+		return []
+	phoff = struct.unpack_from("<Q", data, 32)[0]
+	phentsize = struct.unpack_from("<H", data, 54)[0]
+	phnum = struct.unpack_from("<H", data, 56)[0]
+	phdrs = []
+	for n in range(phnum):
+		o = phoff + n * phentsize
+		p_type = struct.unpack_from("<I", data, o)[0]
+		if p_type != 1:
+			continue
+		p_offset = struct.unpack_from("<Q", data, o + 8)[0]
+		p_vaddr = struct.unpack_from("<Q", data, o + 16)[0]
+		p_filesz = struct.unpack_from("<Q", data, o + 32)[0]
+		phdrs.append((p_offset, p_vaddr, p_filesz))
+	return phdrs
+
+
+def file_to_va(phdrs, off):
+	for p_offset, p_vaddr, p_filesz in phdrs:
+		if p_offset <= off < p_offset + p_filesz:
+			return p_vaddr + (off - p_offset)
+	return None
+
+
+def va_to_file(phdrs, va):
+	for p_offset, p_vaddr, p_filesz in phdrs:
+		if p_vaddr <= va < p_vaddr + p_filesz:
+			return p_offset + (va - p_vaddr)
+	return None
+
+
+def find_leas(data, target, phdrs):
+	hits = []
+	n = len(data)
+	i = 0
+	while i + 7 <= n:
+		b0 = data[i]
+		if b0 in (0x48, 0x4C) and data[i + 1] == 0x8D and (data[i + 2] & 0xC7) == 0x05:
+			disp = struct.unpack_from("<i", data, i + 3)[0]
+			rip_va = file_to_va(phdrs, i + 7)
+			if rip_va is not None:
+				tf = va_to_file(phdrs, rip_va + disp)
+				if tf == target:
+					hits.append(i)
+			elif i + 7 + disp == target:
+				hits.append(i)
+		i += 1
+	return hits
+
+
+def cfs_bool_at_lea(data, lea):
+	"""Return (state, patch_off) for the plist_new_bool that feeds this LEA."""
+	# mov edi/esi/eax, imm32 ; call rel32 ; lea rsi, CFS
+	if lea >= 10 and data[lea - 5] == 0xE8 and data[lea - 10] in (0xBF, 0xBE, 0xB8):
+		imm = struct.unpack_from("<I", data, lea - 9)[0]
+		if imm == 0:
+			return "false", lea - 10
+		if imm == 1:
+			return "true", lea - 10
+	# xor edi,edi / xor eax,eax ; call ; lea
+	if lea >= 7 and data[lea - 5] == 0xE8:
+		if lea >= 7 and data[lea - 7 : lea - 5] == b"\x31\xff":
+			return "false_xor", lea - 7
+		if lea >= 9 and data[lea - 9 : lea - 5] in (b"\x31\xc0\x89\xc7", b"\x31\xf6\x89\xf7"):
+			return "false_xor", lea - 9
+	# and eax/edi, FLAG_ERASE  (0x01/0x02/0x04/0x08) shortly before the call
+	if lea >= 8 and data[lea - 5] == 0xE8:
+		start = max(0, lea - 24)
+		i = start
+		while i + 3 <= lea - 5:
+			if data[i] == 0x83 and data[i + 1] in (0xE0, 0xE7) and data[i + 2] in (0x01, 0x02, 0x04, 0x08):
+				return "flag_erase_and", i
+			i += 1
+	return "unknown", None
+
+
+def patch_at_lea(data, lea):
+	state, off = cfs_bool_at_lea(data, lea)
+	pre = bytes(data[max(0, lea - 24) : lea + 24])
+	print("AQEMU: LEA 0x%x around %s" % (lea, pre.hex()))
+	if state == "true":
+		print("AQEMU: LEA 0x%x: CFS is mov imm,1 immediately before plist_new_bool" % lea)
+		return 0
+	if state == "false" and off is not None:
+		data[off + 1] = 1
+		print("AQEMU: LEA 0x%x: patched mov imm32,0 -> 1 at 0x%x" % (lea, off))
+		return 1
+	if state == "false_xor" and off is not None:
+		if data[off : off + 2] == b"\x31\xff":
+			data[off] = 0xB0
+			data[off + 1] = 0x01
+			print("AQEMU: LEA 0x%x: patched xor edi,edi -> mov al,1 at 0x%x" % (lea, off))
+			return 1
+		data[off : off + 4] = b"\x6a\x01\x5f\x90"
+		print("AQEMU: LEA 0x%x: patched xor->true at 0x%x" % (lea, off))
+		return 1
+	if state == "flag_erase_and" and off is not None:
+		data[off + 1] = 0xC8
+		data[off + 2] = 0x01
+		print("AQEMU: LEA 0x%x: patched FLAG_ERASE and -> or $1 at 0x%x" % (lea, off))
+		return 1
+	print("AQEMU: LEA 0x%x: CFS bool arg %s (no patch)" % (lea, state))
+	return 0
+
+
+def analyze(data, phdrs, key_off):
+	leas = find_leas(data, key_off, phdrs)
+	if not leas:
+		return "no_lea", leas
+	states = [cfs_bool_at_lea(data, lea)[0] for lea in leas]
+	if all(s == "true" for s in states):
+		return "ok", leas
+	if any(s in ("false", "false_xor", "flag_erase_and") for s in states):
+		return "needs_patch", leas
+	return "unknown", leas
+
+
+def first_call_after(data, lea, limit=24):
+	start = lea + 7
+	end = min(len(data), lea + limit)
+	i = start
+	while i + 5 <= end:
+		if data[i] == 0xE8:
+			return i
+		i += 1
+	return None
+
+
+def nop_first_call_after(data, lea, label):
+	"""NOP only the first call shortly after this key's LEA (that key's set_item).
+
+	The old 'last call in 72 bytes' window overlapped the next keys and NOP'd
+	UUID / CreateFilesystemPartitions. Do not use that.
+	"""
+	off = first_call_after(data, lea, 24)
+	if off is None:
+		print("AQEMU: no nearby call after LEA 0x%x (%s)" % (lea, label))
+		return 0
+	if data[off : off + 5] == b"\x90\x90\x90\x90\x90":
+		print("AQEMU: %s set_item already NOP at 0x%x" % (label, off))
+		return 0
+	data[off : off + 5] = b"\x90\x90\x90\x90\x90"
+	print("AQEMU: NOP first set_item for %s at 0x%x" % (label, off))
+	return 1
+
+
+def uuid_set_item_intact(data, phdrs, cfs_leas):
+	"""True if a UUID LEA near CFS still has a real call (not NOP'd)."""
+	off = 0
+	near = cfs_leas[0] if cfs_leas else 0
+	while True:
+		off = data.find(b"UUID\x00", off)
+		if off < 0:
+			print("AQEMU: UUID string not in binary (cannot verify set_item)")
+			return True
+		leas = find_leas(data, off, phdrs)
+		for lea in leas:
+			if abs(lea - near) > 0x800:
+				continue
+			call = first_call_after(data, lea, 24)
+			if call is None:
+				print("AQEMU: UUID LEA 0x%x has no nearby call" % lea)
+				return False
+			if data[call : call + 5] == b"\x90\x90\x90\x90\x90":
+				print("AQEMU: UUID set_item was NOP'd at 0x%x (refusing this patch)" % call)
+				return False
+			print("AQEMU: UUID set_item still present at 0x%x" % call)
+			return True
+		off += 1
+	return True
+
+
+def strip_ios18_keys(data, phdrs):
+	# SupportedAsyncDataTypes sits immediately before UUID/CFS. Never NOP it.
+	n = 0
+	for label in (
+		b"SystemImageFormat\x00",
+		b"HostHasFixFor99053849\x00",
+		b"WaitForDeviceConnectionToFinishStateMachine\x00",
+	):
+		off = data.find(label)
+		if off < 0:
+			print("AQEMU: %s not in binary (ok)" % label[:-1].decode("ascii"))
+			continue
+		leas = find_leas(data, off, phdrs)
+		print("AQEMU: %s at 0x%x, %d LEA(s)" % (label[:-1].decode("ascii"), off, len(leas)))
+		for lea in leas:
+			n += nop_first_call_after(data, lea, label[:-1].decode("ascii"))
+	print("AQEMU: skipping SupportedAsyncDataTypes NOP (too close to UUID/CFS)")
+	return n
+
+
+def write_marker(tag):
+	try:
+		d = os.path.dirname(MARKER)
+		if d and not os.path.isdir(d):
+			os.makedirs(d)
+		open(MARKER, "w").write(tag + "\n")
+	except OSError as e:
+		print("AQEMU: marker write failed: %s" % e)
+
+
+def main():
+	args = [a for a in sys.argv[1:] if not a.startswith("-")]
+	binary = args[0] if args else DEFAULT_BIN
+
+	# Do NOT restore .aqemu.bak (that was 45145e9 and would undo 74e3bd9).
+	if pin_74e3bd9(binary) != 0:
+		return 5
+
+	if not os.path.isfile(binary):
+		print("AQEMU: missing %s after pin" % binary)
+		return 1
+
+	data = bytearray(open(binary, "rb").read())
+	key_off = data.find(KEY)
+	if key_off < 0:
+		print("AQEMU: CreateFilesystemPartitions string not in %s" % binary)
+		return 1
+
+	phdrs = load_phdrs(data)
+	status, leas = analyze(data, phdrs, key_off)
+	print("AQEMU: CFS string at 0x%x, %d LEA(s), status=%s" % (key_off, len(leas), status))
+	try:
+		out = subprocess.check_output(
+			["nm", "-D", binary], stderr=subprocess.STDOUT
+		).decode("ascii", "replace")
+		for line in out.splitlines():
+			if "plist_dict_set_item" in line or "restored_start_restore" in line:
+				print("AQEMU: nm -D %s" % line.strip())
+	except Exception as e:
+		print("AQEMU: nm -D skipped: %s" % e)
+
+	print("AQEMU: skipping binary CFS/iOS18 NOPs (74e3bd9 is used as-is)")
+	write_marker("pinned-%s" % PIN_VER)
+	# Ubuntu fs.protected_regular: root-owned wrap blocks later scp as bob.
+	subprocess.call(["sudo", "-n", "rm", "-f", "/tmp/aqemu-idr-wrap.sh"])
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/extras/Inferno/patches/img4lib_vfs_file_win.c
+++ b/extras/Inferno/patches/img4lib_vfs_file_win.c
@@ -1,0 +1,152 @@
+/*
+ * Windows overlay for xerub/img4lib libvfs/vfs_file.c
+ * Applied by scripts/build_img4_windows.ps1 after clone.
+ *
+ * Changes vs upstream: O_BINARY on open (no CRLF corruption of IM4P/IMG4),
+ * fsync -> _commit. Rest of img4lib is POSIX enough for MinGW + OpenSSL.
+ */
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#ifdef _WIN32
+#include <io.h>
+#ifndef fsync
+#define fsync _commit
+#endif
+#endif
+#include "vfs.h"
+#include "vfs_internal.h"
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+struct file_ops_file {
+    struct file_ops ops;
+    int fd;
+};
+
+static int
+file_fsync(FHANDLE fd_)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    return fsync(fd->fd);
+}
+
+static int
+file_close(FHANDLE fd_)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    close(fd->fd);
+    free(fd);
+    return 0;
+}
+
+static ssize_t
+file_read(FHANDLE fd_, void *buf, size_t count)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    return read(fd->fd, buf, count);
+}
+
+static ssize_t
+file_write(FHANDLE fd_, const void *buf, size_t count)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    return write(fd->fd, buf, count);
+}
+
+static off_t
+file_lseek(FHANDLE fd_, off_t offset, int whence)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    return lseek(fd->fd, offset, whence);
+}
+
+static int
+file_ioctl(FHANDLE fd_, unsigned long req, ...)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    return -1;
+}
+
+static int
+file_ftruncate(FHANDLE fd_, off_t length)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    if (!fd) {
+        return -1;
+    }
+    return ftruncate(fd->fd, length);
+}
+
+static ssize_t
+file_length(FHANDLE fd_)
+{
+    struct file_ops_file *fd = (struct file_ops_file *)fd_;
+    int rv;
+    struct stat st;
+    if (!fd) {
+        return -1;
+    }
+    rv = fstat(fd->fd, &st);
+    if (rv) {
+        return -1;
+    }
+    return st.st_size;
+}
+
+FHANDLE
+file_open(const char *pathname, int flags, ...)
+{
+    mode_t mode = 0;
+    struct file_ops_file *ops;
+    ops = malloc(sizeof(*ops));
+    if (!ops) {
+        return NULL;
+    }
+    if (flags & O_CREAT) {
+        va_list ap;
+        va_start(ap, flags);
+        mode = va_arg(ap, int);
+        va_end(ap);
+    }
+#ifdef _WIN32
+    flags |= O_BINARY;
+#endif
+    ops->fd = open(pathname, flags, mode);
+    if (ops->fd < 0) {
+        free(ops);
+        return NULL;
+    }
+    ops->ops.flags = flags & O_ACCMODE;
+    ops->ops.read = file_read;
+    ops->ops.write = file_write;
+    ops->ops.lseek = file_lseek;
+    ops->ops.ioctl = file_ioctl;
+    ops->ops.ftruncate = file_ftruncate;
+    ops->ops.fsync = file_fsync;
+    ops->ops.close = file_close;
+    ops->ops.length = file_length;
+    return (FHANDLE)ops;
+}

--- a/extras/Inferno/seed-root-gpt.py
+++ b/extras/Inferno/seed-root-gpt.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Write a 4096-byte-sector GPT + APFS-type partition on Inferno guest `root`.
+
+Ramrod with CreateFilesystemPartitions=false rejects zeros (invalid GPT header)
+and empty GPT (Storage with GPT format). An APFS partition without a Data volume
+fails with status 75. AQEMU Power On runs format-seed-apfs.sh (mkapfs) so the
+seed partition has a Data-role volume.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import zlib
+
+LBA = 4096
+N_ENTRIES = 128
+ENTRY_SIZE = 128
+SEED_NAME = "AQEMU_SEED"
+ROOT_BYTES = 8 * 1024 * 1024 * 1024
+START_LBA = 256
+
+APFS_TYPE = bytes.fromhex("EF57347C0000AA11AA1100306543ECAC")
+DISK_GUID = bytes.fromhex("0100E0A05047415481004151454D5501")
+PART_GUID = bytes.fromhex("0200E0A05047415481004151454D5502")
+
+
+def crc32(data: bytes) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def make_header(
+    my_lba: int,
+    alt_lba: int,
+    first_usable: int,
+    last_usable: int,
+    part_lba: int,
+    part_crc: int,
+) -> bytes:
+    h = bytearray(92)
+    h[0:8] = b"EFI PART"
+    struct.pack_into("<I", h, 8, 0x00010000)
+    struct.pack_into("<I", h, 12, 92)
+    struct.pack_into("<Q", h, 24, my_lba)
+    struct.pack_into("<Q", h, 32, alt_lba)
+    struct.pack_into("<Q", h, 40, first_usable)
+    struct.pack_into("<Q", h, 48, last_usable)
+    h[56:72] = DISK_GUID
+    struct.pack_into("<Q", h, 72, part_lba)
+    struct.pack_into("<I", h, 80, N_ENTRIES)
+    struct.pack_into("<I", h, 84, ENTRY_SIZE)
+    struct.pack_into("<I", h, 88, part_crc)
+    struct.pack_into("<I", h, 16, crc32(h))
+    return bytes(h)
+
+
+def first_part_name(path: str) -> str:
+    with open(path, "rb") as f:
+        sz = os.path.getsize(path)
+        for header_off, lba in ((LBA, LBA), (512, 512)):
+            if header_off + 8 > sz:
+                continue
+            f.seek(header_off)
+            if f.read(8) != b"EFI PART":
+                continue
+            f.seek(header_off + 72)
+            entry_lba = struct.unpack("<Q", f.read(8))[0]
+            f.seek(entry_lba * lba + 56)
+            raw = f.read(72)
+            return raw.decode("utf-16le").split("\x00")[0]
+    return ""
+
+
+def has_efi_part(path: str) -> bool:
+    with open(path, "rb") as f:
+        sz = os.path.getsize(path)
+        for off in (512, LBA):
+            if off + 8 <= sz:
+                f.seek(off)
+                if f.read(8) == b"EFI PART":
+                    return True
+    return False
+
+
+def needs_seed(path: str) -> bool:
+    if not os.path.exists(path) or not has_efi_part(path):
+        return True
+    return first_part_name(path) == SEED_NAME
+
+
+def ensure_sparse_size(path: str, size: int) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    if not os.path.exists(path):
+        open(path, "wb").close()
+        if os.name == "nt":
+            subprocess.run(
+                ["fsutil", "sparse", "setflag", path],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    cur = os.path.getsize(path)
+    if cur < size:
+        with open(path, "r+b") as f:
+            f.truncate(size)
+
+
+def seed(path: str) -> None:
+    ensure_sparse_size(path, ROOT_BYTES)
+    if not needs_seed(path):
+        print(f"Already has a GPT (not AQEMU_SEED), leaving as-is: {path}")
+        return
+    sz = os.path.getsize(path)
+    if sz % LBA:
+        raise SystemExit(f"Size {sz} is not a multiple of {LBA}: {path}")
+    n_lba = sz // LBA
+    array_bytes = N_ENTRIES * ENTRY_SIZE
+    array_lbas = (array_bytes + LBA - 1) // LBA
+    first_usable = 2 + array_lbas
+    last_usable = n_lba - 1 - array_lbas - 1
+    if last_usable < START_LBA:
+        raise SystemExit(f"Image too small for GPT: {path}")
+
+    entries = bytearray(array_bytes)
+    entries[0:16] = APFS_TYPE
+    entries[16:32] = PART_GUID
+    struct.pack_into("<Q", entries, 32, START_LBA)
+    struct.pack_into("<Q", entries, 40, last_usable)
+    name = SEED_NAME.encode("utf-16le")
+    entries[56 : 56 + len(name)] = name
+    part_crc = crc32(entries)
+    backup_hdr = n_lba - 1
+    backup_arr = n_lba - 1 - array_lbas
+    primary = make_header(1, backup_hdr, first_usable, last_usable, 2, part_crc)
+    backup = make_header(
+        backup_hdr, 1, first_usable, last_usable, backup_arr, part_crc
+    )
+
+    mbr = bytearray(LBA)
+    mbr[448] = 0x02
+    mbr[450] = 0xEE
+    mbr[451:454] = b"\xff\xff\xff"
+    struct.pack_into("<I", mbr, 454, 1)
+    struct.pack_into("<I", mbr, 458, min(0xFFFFFFFF, n_lba - 1))
+    mbr[510:512] = b"\x55\xaa"
+
+    def write_lba(f, lba: int, data: bytes) -> None:
+        f.seek(lba * LBA)
+        if len(data) < LBA:
+            f.write(data + bytes(LBA - len(data)))
+        else:
+            f.write(data)
+
+    with open(path, "r+b") as f:
+        write_lba(f, 0, mbr)
+        write_lba(f, 1, primary)
+        f.seek(2 * LBA)
+        f.write(entries)
+        f.seek(backup_arr * LBA)
+        f.write(entries)
+        write_lba(f, backup_hdr, backup)
+
+    print(f"Wrote APFS-type GPT ({SEED_NAME}) on {path}")
+    print("Power On AQEMU to run extras/Inferno/format-seed-apfs.sh (mkapfs Data volume).")
+
+
+def root_from_vm_xml(vm_xml: str) -> str:
+    xml = os.path.abspath(vm_xml)
+    base = os.path.splitext(os.path.basename(xml))[0]
+    return os.path.join(os.path.dirname(xml), f"{base}_inferno", "root")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("root", nargs="?", help="Path to *_inferno/root")
+    p.add_argument("--vm-xml", help="VM .aqemu path (uses <name>_inferno/root)")
+    args = p.parse_args()
+    if args.vm_xml:
+        path = root_from_vm_xml(args.vm_xml)
+    elif args.root:
+        path = args.root
+    else:
+        p.print_help()
+        return 2
+    seed(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/extras/Inferno/wipe-ios-nvme.ps1
+++ b/extras/Inferno/wipe-ios-nvme.ps1
@@ -1,5 +1,7 @@
 # Wipe Inferno NVMe raw images after a partial/failed idevicerestore.
-# AQEMU recreates them on next Power On (same sizes as Apple_SoC_Support.cpp).
+# AQEMU recreates them on next Power On (same sizes as Apple_SoC_Support.cpp)
+# and seeds a placeholder GPT on root (AQEMU_SEED). This script can seed
+# immediately so an older aqemu.exe still presents EFI PART to ramrod.
 param(
     [Parameter(Mandatory = $true)]
     [string]$VmXml
@@ -43,5 +45,12 @@ foreach ($n in $names) {
         Remove-Item -LiteralPath $p -Force
         Write-Host "Removed $n"
     }
+}
+$seed = Join-Path $PSScriptRoot 'seed-root-gpt.py'
+if (Test-Path -LiteralPath $seed) {
+    Write-Host 'Seeding placeholder GPT on root (AQEMU_SEED)...'
+    python $seed --vm-xml $xml.Path
+} else {
+    Write-Host 'seed-root-gpt.py not next to this script; next AQEMU Power On will seed GPT.'
 }
 Write-Host 'Done. Power Off iOS, Stop companion, Start companion, Power On iOS, Restore.'

--- a/scripts/build_img4_windows.ps1
+++ b/scripts/build_img4_windows.ps1
@@ -1,0 +1,71 @@
+# Build xerub/img4lib as img4.exe (MinGW + OpenSSL + in-tree lzfse).
+# Upstream Makefile is Unix-style; this is the Windows port:
+#   - clone img4lib + lzfse submodule
+#   - overlay extras/Inferno/patches/img4lib_vfs_file_win.c (O_BINARY, _commit)
+#   - make with gcc + -lcrypto
+#
+# Prerequisites: MSYS2 UCRT64 or MINGW64 gcc + OpenSSL
+#   pacman -S --needed mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-openssl
+#
+# Usage (PowerShell from repo root):
+#   .\scripts\build_img4_windows.ps1
+#
+# Copies img4.exe (and libcrypto if needed) next to build_win\aqemu.exe.
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent $PSScriptRoot
+$Src = Join-Path $Root "third_party\img4lib"
+$Overlay = Join-Path $Root "extras\Inferno\patches\img4lib_vfs_file_win.c"
+$MingwBin = "C:\msys64\ucrt64\bin"
+if (-not (Test-Path "$MingwBin\gcc.exe")) {
+	$MingwBin = "C:\msys64\mingw64\bin"
+}
+if (-not (Test-Path "$MingwBin\gcc.exe")) {
+	throw "Need MSYS2 ucrt64 or mingw64 gcc (with OpenSSL)."
+}
+if (-not (Test-Path $Overlay)) {
+	throw "Missing Windows vfs overlay: $Overlay"
+}
+
+if (-not (Test-Path (Join-Path $Src ".git"))) {
+	git clone --recurse-submodules https://github.com/xerub/img4lib.git $Src
+} else {
+	Push-Location $Src
+	git submodule update --init --recursive
+	Pop-Location
+}
+
+Copy-Item $Overlay (Join-Path $Src "libvfs\vfs_file.c") -Force
+
+$env:PATH = "$MingwBin;C:\msys64\usr\bin;" + $env:PATH
+$Make = Join-Path $MingwBin "mingw32-make.exe"
+if (-not (Test-Path $Make)) { $Make = "make" }
+
+Push-Location (Join-Path $Src "lzfse")
+& $Make CC=gcc
+if ($LASTEXITCODE -ne 0) { Pop-Location; throw "lzfse build failed" }
+Pop-Location
+
+$Cflags = "-Wall -O2 -I. -Ilzfse/src -DiOS10 -DDER_MULTIBYTE_TAGS=1 -DDER_TAG_SIZE=8 -D__unused=__attribute__((unused)) -Wno-deprecated-declarations -Wno-unused-parameter"
+Push-Location $Src
+& $Make CC=gcc LD=gcc "CFLAGS=$Cflags" "LDFLAGS=-g -Llzfse/build/bin" "LDLIBS=-llzfse -lcrypto"
+if ($LASTEXITCODE -ne 0) { Pop-Location; throw "img4 build failed" }
+Pop-Location
+
+$Exe = Join-Path $Src "img4.exe"
+if (-not (Test-Path $Exe)) { $Exe = Join-Path $Src "img4" }
+if (-not (Test-Path $Exe)) { throw "img4 binary not produced" }
+
+$DestDir = Join-Path $Root "build_win"
+if (Test-Path $DestDir) {
+	Copy-Item $Exe (Join-Path $DestDir "img4.exe") -Force
+	foreach ($dll in @("libcrypto-3-x64.dll", "libssl-3-x64.dll", "libwinpthread-1.dll", "zlib1.dll", "libgcc_s_seh-1.dll")) {
+		$from = Join-Path $MingwBin $dll
+		if (Test-Path $from) {
+			Copy-Item $from (Join-Path $DestDir $dll) -Force
+		}
+	}
+	Write-Host "Installed: $DestDir\img4.exe"
+} else {
+	Write-Host "Built: $Exe (copy next to aqemu.exe)"
+}

--- a/src/Apple_SoC_Button_Pad.cpp
+++ b/src/Apple_SoC_Button_Pad.cpp
@@ -48,11 +48,11 @@ Apple_SoC_Button_Pad::Apple_SoC_Button_Pad( QWidget *parent )
 	Btn_Vol_Down = make_btn( tr( "Vol−" ), tr( "Volume down (Inferno F3)" ) );
 	Btn_Vol_Up = make_btn( tr( "Vol+" ), tr( "Volume up (Inferno F4)" ) );
 	Btn_Home = make_btn( tr( "Home" ),
-		tr( "Home / Menu (Inferno F6)\nClick once: Home screen\nDouble-click: App Switcher" ) );
+		tr( "Home / Menu (Inferno F6)\nClick once: Home screen\nDouble-click: App Switcher\nDoes nothing on Welcome / Swipe up — use SOS" ) );
 	Btn_Power = make_btn( tr( "Side" ),
 		tr( "Power / Side button (Inferno F5)\nClick: sleep/wake\nHold ~2s: power menu" ) );
 	Btn_SOS = make_btn( tr( "SOS" ),
-		tr( "SOS / slide-to-power-off combo\n(Vol up hold, then Side — ChefKiss guide)" ) );
+		tr( "SOS / slide-to-power-off combo\n(Vol up hold, then Side — ChefKiss guide)\nUse this on Welcome / Swipe up to get started" ) );
 
 	lay->addWidget( Btn_Vol_Down );
 	lay->addWidget( Btn_Vol_Up );

--- a/src/Apple_SoC_Device_Tools_Window.cpp
+++ b/src/Apple_SoC_Device_Tools_Window.cpp
@@ -56,6 +56,96 @@ QString Companion_Ensure_Ideviceinstaller()
 		"fi; " );
 }
 
+
+/** Ensure zsign is available on the companion — builds from source if needed. */
+QString Companion_Ensure_Zsign()
+{
+	return QStringLiteral(
+		// Try apt first (some Ubuntu PPAs have zsign)
+		"if ! command -v zsign >/dev/null 2>&1; then "
+		"  sudo -n apt-get install -y -qq zsign 2>/dev/null || true; "
+		"fi; "
+		// Build from source if still missing (zsign uses a plain Makefile, not CMake)
+		"if ! command -v zsign >/dev/null 2>&1; then "
+		"  echo 'zsign not found - building from source (one-time, ~60s)...'; "
+		"  sudo -n apt-get install -y -qq git make g++ libssl-dev libminizip-dev 2>/dev/null || "
+		"    sudo apt-get install -y -qq git make g++ libssl-dev libminizip-dev 2>/dev/null || true; "
+		"  _ZS=$(mktemp -d); "
+		"  git clone --depth 1 https://github.com/zhlynn/zsign.git \"$_ZS/zsign\" 2>&1 | grep -v '^remote:'; "
+		// The Makefile lives in build/linux/, not the repo root
+		"  cd \"$_ZS/zsign/build/linux\"; "
+		"  make -j$(nproc) 2>&1 | grep -vE '^(In file|\\^|note:)' || true; "
+		"  _ZS_BIN=$(find \"$_ZS/zsign\" -name zsign -type f -perm /111 2>/dev/null | head -1); "
+		"  if [ -n \"$_ZS_BIN\" ]; then "
+		"    sudo mv \"$_ZS_BIN\" /usr/local/bin/zsign && echo 'zsign installed'; "
+		"  else "
+		"    echo 'zsign build failed - trying pre-built binary...'; "
+		"    _ARCH=$(uname -m); "
+		"    [ \"$_ARCH\" = 'aarch64' ] && _ARCH='arm64' || _ARCH='amd64'; "
+		"    sudo curl -fsSL \"https://github.com/zhlynn/zsign/releases/latest/download/zsign_linux_${_ARCH}\" "
+		"      -o /usr/local/bin/zsign 2>/dev/null "
+		"      && sudo chmod +x /usr/local/bin/zsign && echo 'zsign binary downloaded' || true; "
+		"  fi; "
+		"  cd / && rm -rf \"$_ZS\"; "
+		"fi; "
+		"if ! command -v zsign >/dev/null 2>&1; then "
+		"  echo ERROR: zsign could not be installed on companion.; "
+		"  echo 'Please install zsign manually: https://github.com/zhlynn/zsign'; "
+		"  exit 127; "
+		"fi; " );
+}
+
+/**
+ * Adhoc-sign an IPA with zsign, producing a proper CMS blob that installd accepts.
+ * zsign generates a self-signed certificate + CMS structure, unlike ldid which only
+ * writes hash data without a CMS wrapper. installd on iOS 14 requires the CMS blob.
+ */
+QString Companion_Zsign_IPA( const QString &remote_ipa )
+{
+	const QString q = Shell_Quote( remote_ipa );
+	return QStringLiteral(
+		"echo 'Signing IPA with zsign (adhoc CMS)...'; "
+		"_CERTDIR=$(mktemp -d); "
+		// Generate self-signed cert + p12
+		"openssl req -x509 -newkey rsa:2048 -keyout \"$_CERTDIR/key.pem\" "
+		"  -out \"$_CERTDIR/cert.pem\" -days 3650 -nodes "
+		"  -subj '/CN=AQEMU Adhoc/O=AQEMU/C=US' 2>/dev/null; "
+		"openssl pkcs12 -export -out \"$_CERTDIR/cert.p12\" "
+		"  -inkey \"$_CERTDIR/key.pem\" -in \"$_CERTDIR/cert.pem\" "
+		"  -passout pass:aqemu 2>/dev/null; "
+		// Write a minimal fake mobileprovision XML that zsign accepts
+		// (zsign only needs it to extract entitlements/team; content doesn't matter for adhoc)
+		"cat > \"$_CERTDIR/fake.mobileprovision\" << 'PROVEOF'\n"
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+		"<plist version=\"1.0\"><dict>\n"
+		"  <key>AppIDName</key><string>AQEMU Adhoc</string>\n"
+		"  <key>ApplicationIdentifierPrefix</key><array><string>AQEMUADHOC</string></array>\n"
+		"  <key>TeamIdentifier</key><array><string>AQEMUADHOC</string></array>\n"
+		"  <key>Entitlements</key><dict>\n"
+		"    <key>application-identifier</key><string>AQEMUADHOC.*</string>\n"
+		"    <key>get-task-allow</key><true/>\n"
+		"  </dict>\n"
+		"  <key>ExpirationDate</key><date>2099-01-01T00:00:00Z</date>\n"
+		"  <key>Name</key><string>AQEMU Adhoc Profile</string>\n"
+		"  <key>UUID</key><string>AQEMU000-0000-0000-0000-AQEMU0000000</string>\n"
+		"  <key>Version</key><integer>1</integer>\n"
+		"</dict></plist>\n"
+		"PROVEOF\n"
+		"_ZS_OUT=$(mktemp /tmp/aqemu-signed-XXXXXX.ipa); "
+		"zsign -k \"$_CERTDIR/cert.p12\" -p aqemu "
+		"  -m \"$_CERTDIR/fake.mobileprovision\" "
+		"  -o \"$_ZS_OUT\" -z 9 '%1' 2>&1; "
+		"if [ -s \"$_ZS_OUT\" ]; then "
+		"  mv \"$_ZS_OUT\" '%1'; "
+		"  echo 'zsign complete.'; "
+		"else "
+		"  rm -f \"$_ZS_OUT\"; "
+		"  echo 'WARNING: zsign could not sign IPA. Proceeding with original (will likely fail installd).'; "
+		"fi; "
+		"rm -rf \"$_CERTDIR\"; " ).arg( q );
+}
+
 } // namespace
 
 void AQ_Show_Apple_SoC_Device_Tools_Window( Virtual_Machine *vm, QWidget *parent,
@@ -160,9 +250,22 @@ Apple_SoC_Device_Tools_Window::Apple_SoC_Device_Tools_Window( Virtual_Machine *v
 	devBtns->addWidget( btnShot );
 	devBtns->addStretch();
 	devLay->addLayout( devBtns );
+
+	Chk_Sign_IPA = new QCheckBox( tr( "Adhoc-sign IPA before install (zsign) — required for unsigned / sideloaded IPAs" ) );
+	Chk_Sign_IPA->setChecked( true );
+	Chk_Sign_IPA->setToolTip( tr(
+		"Uses zsign on the companion to re-sign the IPA with a self-signed adhoc certificate.\n"
+		"zsign produces a proper CMS/PKCS7 code signature that installd accepts on iOS 14.\n"
+		"Unlike ldid, zsign generates the full CMS blob required by MICodeSigningVerifier.\n"
+		"zsign is auto-built on the companion on first use (~60 seconds, one-time).\n"
+		"Required for IPAs without a valid Apple code signature (e.g. UTM, emulators, custom builds).\n"
+		"Safe to leave on — already-signed App Store IPAs are handled transparently." ) );
+	devLay->addWidget( Chk_Sign_IPA );
+
 	devLay->addWidget( new QLabel( tr(
 		"IPA install uses <code>ideviceinstaller</code> on the companion "
 		"(auto-tries <code>apt install ideviceinstaller</code> if missing). "
+		"Signing uses <code>zsign</code> (built from source on first use, ~60s). "
 		"Enable guest internet first if the device is not listed." ) ) );
 	devLay->addStretch();
 	Tabs->addTab( dev, tr( "Device" ) );
@@ -357,9 +460,16 @@ void Apple_SoC_Device_Tools_Window::Run_Install_IPA()
 		return;
 	const QString wsl = Windows_Path_To_WSL( QFileInfo( ipa ).absoluteFilePath() );
 	const QString remote_path = QStringLiteral( "/tmp/aqemu-install.ipa" );
-	const QString remote =
-		Companion_Ensure_Ideviceinstaller() +
-		QStringLiteral( "ideviceinstaller -i " ) + remote_path;
+
+	QString remote = Companion_Ensure_Ideviceinstaller();
+	if( Chk_Sign_IPA && Chk_Sign_IPA->isChecked() )
+	{
+		remote += Companion_Ensure_Zsign();
+		remote += Companion_Zsign_IPA( remote_path );
+	}
+	remote += QStringLiteral( "echo 'Uploading ipa to running uphone'; "
+	                          "ideviceinstaller -i " ) + remote_path;
+
 	Start_Companion_SSH(
 		QStringLiteral(
 			"echo Uploading IPA...; "

--- a/src/Apple_SoC_Device_Tools_Window.h
+++ b/src/Apple_SoC_Device_Tools_Window.h
@@ -1,6 +1,7 @@
 #ifndef APPLE_SOC_DEVICE_TOOLS_WINDOW_H
 #define APPLE_SOC_DEVICE_TOOLS_WINDOW_H
 
+#include <QCheckBox>
 #include <QDialog>
 #include <QLineEdit>
 #include <QTextEdit>
@@ -48,6 +49,7 @@ private:
 	QTextEdit *Text_Log;
 	QLabel *Label_Status;
 	QProcess *Process;
+	QCheckBox *Chk_Sign_IPA;
 };
 
 void AQ_Show_Apple_SoC_Device_Tools_Window( Virtual_Machine *vm, QWidget *parent = nullptr,

--- a/src/Apple_SoC_Restore_Window.cpp
+++ b/src/Apple_SoC_Restore_Window.cpp
@@ -16,6 +16,9 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QApplication>
+#include <QCoreApplication>
+#include <QComboBox>
+#include <QSpinBox>
 #include <QClipboard>
 #include <QSettings>
 #include <QDir>
@@ -73,6 +76,8 @@ Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget
 	, VM( vm )
 	, Process( new QProcess( this ) )
 	, Companion_Process( new QProcess( this ) )
+	, CB_Nand_Size( nullptr )
+	, SB_Nand_Size( nullptr )
 {
 	setWindowTitle( tr( "Apple SoC Restore (Inferno companion)" ) );
 	resize( AQ_Px( 780, this ), AQ_Px( 680, this ) );
@@ -107,6 +112,37 @@ Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget
 	ipswLay->addWidget( Edit_IPSW, 1 );
 	ipswLay->addWidget( btnIpsw );
 	form->addRow( tr( "IPSW:" ), ipswLay );
+
+	CB_Nand_Size = new QComboBox();
+	SB_Nand_Size = new QSpinBox();
+	AQ_Apply_Apple_SoC_Nand_Controls( CB_Nand_Size, SB_Nand_Size,
+		vm ? vm->Get_Apple_Nand_Size_GiB() : AQ_Default_Apple_SoC_Nand_GiB() );
+	CB_Nand_Size->setToolTip( tr(
+		"Size used when `root` is created (Wipe + Power On). "
+		"16–256 GiB presets, or Custom 16–2048 GiB. Does not grow an already-restored iPhone." ) );
+	QHBoxLayout *nandLay = new QHBoxLayout();
+	nandLay->addWidget( CB_Nand_Size );
+	nandLay->addWidget( SB_Nand_Size );
+	form->addRow( tr( "NAND (root) size:" ), nandLay );
+	connect( CB_Nand_Size, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+	         this, [this]( int ) {
+		AQ_On_Apple_SoC_Nand_Combo_Changed( CB_Nand_Size, SB_Nand_Size );
+		if( VM )
+			VM->Set_Apple_Nand_Size_GiB(
+				AQ_Read_Apple_SoC_Nand_Controls( CB_Nand_Size, SB_Nand_Size ) );
+	} );
+	connect( SB_Nand_Size, QOverload<int>::of( &QSpinBox::valueChanged ),
+	         this, [this]( int ) {
+		AQ_On_Apple_SoC_Nand_Spin_Changed( CB_Nand_Size, SB_Nand_Size );
+		if( VM )
+			VM->Set_Apple_Nand_Size_GiB(
+				AQ_Read_Apple_SoC_Nand_Controls( CB_Nand_Size, SB_Nand_Size ) );
+	} );
+
+	Label_VM_File = new QLabel();
+	Label_VM_File->setWordWrap( true );
+	Label_VM_File->setTextInteractionFlags( Qt::TextSelectableByMouse );
+	form->addRow( tr( "iOS VM file:" ), Label_VM_File );
 
 	{
 		QSettings s;
@@ -235,6 +271,11 @@ Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget
 	btnRestore->setToolTip( tr(
 		"Upload the IPSW into the companion over SSH and run idevicerestore there" ) );
 	connect( btnRestore, &QPushButton::clicked, this, &Apple_SoC_Restore_Window::Run_IDeviceRestore );
+	QPushButton *btnWipe = new QPushButton( tr( "Wipe Inferno disks…" ) );
+	btnWipe->setToolTip( tr(
+		"Delete this iOS VM's Inferno NVMe images (root, nvram, …) after -256 / partial flash.\n"
+		"Folder is next to the VM .aqemu file shown above. Power Off iOS first." ) );
+	connect( btnWipe, &QPushButton::clicked, this, &Apple_SoC_Restore_Window::Wipe_Inferno_Disks );
 	QPushButton *btnFsPatch = new QPushButton( tr( "Apply filesystem patches…" ) );
 	btnFsPatch->setToolTip( tr(
 		"After restore completes: patch the iOS guest root disk "
@@ -247,6 +288,7 @@ Apple_SoC_Restore_Window::Apple_SoC_Restore_Window( Virtual_Machine *vm, QWidget
 	btns->addWidget( btnStopCompanion );
 	btns->addWidget( btnDiag );
 	btns->addWidget( btnRestore );
+	btns->addWidget( btnWipe );
 	btns->addWidget( btnFsPatch );
 	btns->addStretch();
 	QPushButton *btnClose = new QPushButton( tr( "Close" ) );
@@ -320,6 +362,9 @@ void Apple_SoC_Restore_Window::Sync_Conn_To_VM()
 	VM->Set_Apple_USB_Conn_Port( Conn_Port() );
 	if( ! Edit_IPSW->text().trimmed().isEmpty() )
 		VM->Set_Apple_IPSW_Path( Edit_IPSW->text().trimmed() );
+	if( CB_Nand_Size || SB_Nand_Size )
+		VM->Set_Apple_Nand_Size_GiB(
+			AQ_Read_Apple_SoC_Nand_Controls( CB_Nand_Size, SB_Nand_Size ) );
 	QSettings s;
 	s.setValue( QStringLiteral( "Apple_SoC_Restore/Companion_Disk" ), Companion_Disk() );
 }
@@ -483,6 +528,19 @@ void Apple_SoC_Restore_Window::Create_Companion_Helper()
 
 void Apple_SoC_Restore_Window::Refresh_Companion_Snippet()
 {
+	if( Label_VM_File )
+	{
+		if( VM )
+		{
+			const QString xml = QDir::toNativeSeparators( VM->Get_VM_XML_File_Path() );
+			const QString disks = QDir::toNativeSeparators( AQ_Apple_SoC_Image_Dir( VM ) );
+			Label_VM_File->setText( tr( "%1\nInferno disks: %2" )
+				.arg( xml.isEmpty() ? tr( "(unsaved VM)" ) : xml, disks ) );
+		}
+		else
+			Label_VM_File->setText( tr( "(no iOS VM selected)" ) );
+	}
+
 	const QString type = Conn_Type();
 	const QString addr = Conn_Addr();
 	const QString disk = Companion_Disk();
@@ -877,9 +935,18 @@ void Apple_SoC_Restore_Window::Set_VM( Virtual_Machine *vm )
 	VM = vm;
 	if( ! vm )
 		return;
-	if( Edit_IPSW && Edit_IPSW->text().trimmed().isEmpty() )
-		Edit_IPSW->setText( vm->Get_Apple_IPSW_Path() );
+	const QString ipsw = vm->Get_Apple_IPSW_Path().trimmed();
+	if( Edit_IPSW && ! ipsw.isEmpty() )
+		Edit_IPSW->setText( QDir::toNativeSeparators( ipsw ) );
+	if( CB_Nand_Size || SB_Nand_Size )
+		AQ_Apply_Apple_SoC_Nand_Controls( CB_Nand_Size, SB_Nand_Size,
+			vm->Get_Apple_Nand_Size_GiB() );
 	Refresh_Companion_Snippet();
+}
+
+void Apple_SoC_Restore_Window::Wipe_Inferno_Disks()
+{
+	AQ_Prompt_Wipe_Apple_SoC_Disks( VM, this );
 }
 
 void Apple_SoC_Restore_Window::Stop_Companion_WSL()
@@ -1022,6 +1089,26 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		return;
 	}
 
+	{
+		const QString base = QFileInfo( ipsw ).fileName();
+		QString extra;
+		if( base.contains( QLatin1String( "18A5351d" ), Qt::CaseInsensitive ) )
+		{
+			extra = tr(
+				"\n\nThis filename is iOS 14.0 beta 5 (18A5351d). "
+				"If Firmware Tool tickets and SEP .new.img4 were made from 18A373 (GM), "
+				"restore will die after NORData with -256. "
+				"Stop companion, browse to the matching IPSW, Start companion, then Restore." );
+		}
+		if( QMessageBox::question( this, tr( "Restore IPSW" ),
+			tr( "idevicerestore will use this file (must match tickets + SEP pack):\n\n%1\n\n"
+			    "If companion was started earlier with a different IPSW folder, "
+			    "Stop companion and Start companion first so the 9p share is restaged." )
+				.arg( QDir::toNativeSeparators( ipsw ) ) + extra,
+			QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok ) != QMessageBox::Ok )
+			return;
+	}
+
 	QSettings s;
 	s.setValue( QStringLiteral( "Apple_SoC_Restore/SSH_User" ), ssh_user );
 
@@ -1051,6 +1138,43 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		return;
 	}
 
+	auto find_inferno_extra = []( const QString &name ) -> QString {
+		QString cpath = AQ_Inferno_Extras_Dir() + QLatin1Char( '/' ) + name;
+		if( QFileInfo::exists( cpath ) )
+			return QFileInfo( cpath ).absoluteFilePath();
+		QDir d( QCoreApplication::applicationDirPath() );
+		for( int i = 0; i < 8; ++i )
+		{
+			const QString t = d.filePath( QStringLiteral( "extras/Inferno/" ) + name );
+			if( QFileInfo::exists( t ) )
+				return QFileInfo( t ).absoluteFilePath();
+			if( ! d.cdUp() )
+				break;
+		}
+		return QString();
+	};
+	QString cfs_wsl;
+	{
+		const QString cpath = find_inferno_extra(
+			QStringLiteral( "force_create_fs_partitions.c" ) );
+		if( ! cpath.isEmpty() )
+			cfs_wsl = Windows_Path_To_WSL( cpath );
+	}
+	QString cfs_py_wsl;
+	{
+		const QString ppath = find_inferno_extra(
+			QStringLiteral( "patch_idevicerestore_cfs.py" ) );
+		if( ! ppath.isEmpty() )
+			cfs_py_wsl = Windows_Path_To_WSL( ppath );
+	}
+	QString cfs_sh_wsl;
+	{
+		const QString spath = find_inferno_extra(
+			QStringLiteral( "build_force_cfs.sh" ) );
+		if( ! spath.isEmpty() )
+			cfs_sh_wsl = Windows_Path_To_WSL( spath );
+	}
+
 	const QByteArray body = QStringLiteral(
 		"#!/usr/bin/env bash\n"
 		"set -euo pipefail\n"
@@ -1070,6 +1194,9 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		"-o NumberOfPasswordPrompts=1 -o ConnectTimeout=15 "
 		"-o LogLevel=ERROR)\n"
 		"GUEST=%1\n"
+		"CFS_C=%2\n"
+		"CFS_PY=%3\n"
+		"CFS_SH=%4\n"
 		"ssh_do() { sshpass -e ssh -p 32222 \"${SSH_OPTS[@]}\" \"$GUEST@127.0.0.1\" \"$@\"; }\n"
 		// Companion image was patched with NOPASSWD for bob. Use only sudo -n and
 		// single-quoted remote commands. Never embed passwords / printf %% formats in
@@ -1132,6 +1259,82 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		"  exit 4\n"
 		"fi\n"
 		"echo 'idevicerestore looks ChefKiss-patched (INFO: model is present).'\n"
+		"echo 'Pinning companion idevicerestore to ChefKiss-era 74e3bd9 if needed (once)...'\n"
+		"if [ -n \"$CFS_PY\" ] && [ -f \"$CFS_PY\" ]; then\n"
+		"  sshpass -e scp -P 32222 \"${SSH_OPTS[@]}\" \"$CFS_PY\" "
+		"\"$GUEST@127.0.0.1:/tmp/aqemu_patch_idr_cfs.py\" || true\n"
+		"  ssh_do 'sed -i \"s/\\r$//\" /tmp/aqemu_patch_idr_cfs.py 2>/dev/null' || true\n"
+		"  ssh_do 'sudo -n /usr/bin/python3 /tmp/aqemu_patch_idr_cfs.py --force /usr/local/bin/idevicerestore' || {\n"
+		"    echo 'FATAL: could not pin idevicerestore to 74e3bd9 (git/autotools/network).'\n"
+		"    echo 'Working Inferno restores use 74e3bd9; 45145e9 sends CFS=false (GPT 78).'\n"
+		"    exit 5; }\n"
+		"else\n"
+		"  echo 'FATAL: patch_idevicerestore_cfs.py not next to aqemu extras/Inferno';\n"
+		"  exit 5\n"
+		"fi\n"
+		"ssh_do 'ldd /usr/local/bin/idevicerestore 2>/dev/null | head -20' || true\n"
+		"rm -f /tmp/aqemu_force_cfs.c\n"
+		"if [ -n \"$CFS_C\" ] && [ -f \"$CFS_C\" ]; then\n"
+		"  cp \"$CFS_C\" /tmp/aqemu_force_cfs.c\n"
+		"  echo \"Using USB plist helper source: $CFS_C\"\n"
+		"else\n"
+		"  echo 'WARNING: force_create_fs_partitions.c not found (checked extras/Inferno next to aqemu.exe and source tree).'\n"
+		"fi\n"
+		"cat > /tmp/aqemu-idr-wrap.sh << 'WEOF'\n"
+		"#!/bin/bash\n"
+		"export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\n"
+		"unset LD_PRELOAD\n"
+		"echo \"AQEMU wrap: vanilla idevicerestore (no LD_PRELOAD)\"\n"
+		"echo \"AQEMU wrap argv: $*\"\n"
+		"exec /usr/local/bin/idevicerestore --erase --restore-mode \"$@\"\n"
+		"WEOF\n"
+		"WRAP_OK=0\n"
+		"if [ -f /tmp/aqemu_force_cfs.c ]; then\n"
+		"  if [ -n \"$CFS_SH\" ] && [ -f \"$CFS_SH\" ]; then\n"
+		"    sed -i 's/\\r$//' \"$CFS_SH\" 2>/dev/null || true\n"
+		"    sshpass -e scp -P 32222 \"${SSH_OPTS[@]}\" /tmp/aqemu_force_cfs.c /tmp/aqemu-idr-wrap.sh \"$CFS_SH\" "
+		"\"$GUEST@127.0.0.1:/tmp/\" || true\n"
+		"  else\n"
+		"    sshpass -e scp -P 32222 \"${SSH_OPTS[@]}\" /tmp/aqemu_force_cfs.c /tmp/aqemu-idr-wrap.sh "
+		"\"$GUEST@127.0.0.1:/tmp/\" || true\n"
+		"  fi\n"
+		"  ssh_do 'sed -i \"s/\\r$//\" /tmp/build_force_cfs.sh /tmp/aqemu_force_cfs.c "
+		"/tmp/aqemu-idr-wrap.sh /tmp/aqemu_patch_idr_cfs.py 2>/dev/null' || true\n"
+		"  if ssh_do 'sudo -n bash /tmp/build_force_cfs.sh /tmp/aqemu_force_cfs.c /usr/local/lib/aqemu_force_cfs.so'; then\n"
+		"    echo 'USB plist helper refreshed (.so; idevicerestore was not rebuilt).'\n"
+		"  else\n"
+		"    echo 'WARNING: could not compile helper into /usr/local/lib (need cc/gcc + sudo).'\n"
+		"  fi\n"
+		"  if ssh_do 'test -s /usr/local/lib/aqemu_force_cfs.so'; then\n"
+		"    ssh_do 'sudo -n cp /tmp/aqemu-idr-wrap.sh /usr/local/bin/aqemu-idr-wrap.sh && "
+		"    sudo -n chmod 755 /usr/local/bin/aqemu-idr-wrap.sh' && WRAP_OK=1\n"
+		"  fi\n"
+		"else\n"
+		"  echo 'WARNING: skipped USB plist helper (source .c missing); ramrod may keep CreateFilesystemPartitions=false.'\n"
+		"fi\n"
+		// MODE=3 is CDC Ethernet (Device Tools reverse-tether). Restore needs
+		// usbmux MODE=1. Restart mux NOW, before iOS USB appears.
+		"echo 'Ensuring companion usbmuxd (MODE=1 for restore, not Device Tools MODE=3)...'\n"
+		"ssh_do 'sudo -n bash -c \""
+		"mkdir -p /etc/systemd/system/usbmuxd.service.d; "
+		"rm -f /etc/systemd/system/usbmuxd.service.d/aqemu-mode3.conf; "
+		"echo [Service] > /etc/systemd/system/usbmuxd.service.d/aqemu-restore-mode1.conf; "
+		"echo Environment=USBMUXD_DEFAULT_DEVICE_MODE=1 >> /etc/systemd/system/usbmuxd.service.d/aqemu-restore-mode1.conf; "
+		"systemctl daemon-reload >/dev/null 2>&1 || true; "
+		"systemctl restart usbmuxd >/dev/null 2>&1 || systemctl start usbmuxd >/dev/null 2>&1 || true; "
+		"sleep 1; "
+		"if ! pgrep -x usbmuxd >/dev/null; then "
+		"  MUX=/usr/sbin/usbmuxd; "
+		"  [ -x /usr/local/sbin/usbmuxd ] && MUX=/usr/local/sbin/usbmuxd; "
+		"  echo systemd usbmuxd missing - starting $MUX; "
+		"  USBMUXD_DEFAULT_DEVICE_MODE=1 $MUX -U usbmux >/tmp/aqemu-usbmuxd.log 2>&1 || "
+		"  USBMUXD_DEFAULT_DEVICE_MODE=1 $MUX -U root >/tmp/aqemu-usbmuxd.log 2>&1 || true; "
+		"  sleep 1; "
+		"fi; "
+		"echo --- usbmuxd ---; "
+		"pgrep -a usbmuxd || echo NONE; "
+		"ls -l /var/run/usbmuxd 2>/dev/null || echo no /var/run/usbmuxd socket; "
+		"systemctl is-active usbmuxd 2>/dev/null || true\"' || true\n"
 		"check_8030() {\n"
 		// Modern ss prints ESTAB (not ESTABLISHED); match either.
 		"  ss -tnp 2>/dev/null | grep -E ':8030\\b' | grep -iE 'estab' || true\n"
@@ -1147,28 +1350,38 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		"  echo 'No ESTABLISHED on :8030 yet (iOS not connected - that is OK, Power On iOS now).'\n"
 		"fi\n"
 		"echo\n"
-		"echo 'Power On the iOS guest NOW (companion SSH is up). Waiting for idevice...'\n"
+		"echo 'Power On the iOS guest NOW (companion SSH is up). Waiting for USB...'\n"
 		"echo 'IMPORTANT: iOS only waits ~120s for restore once the Apple logo appears.'\n"
+		"echo 'lsusb Apple + usbmuxd is enough. idevice_id can still be empty for a moment.'\n"
 		"DEV=\n"
-		"for i in $(seq 1 60); do\n"
-		"  ssh_do 'sudo -n systemctl start usbmuxd' 2>/dev/null || true\n"
+		"for i in $(seq 1 40); do\n"
 		"  LS=$(ssh_do 'lsusb 2>/dev/null' || true)\n"
-		"  DEV=$(ssh_do 'idevice_id -l 2>/dev/null | head -1' || true)\n"
 		"  EST=$(check_8030)\n"
 		"  if echo \"$LS\" | grep -qiE 'Apple|05ac:'; then\n"
 		"    echo \"lsusb Apple device seen (try $i):\"\n"
 		"    echo \"$LS\" | grep -iE 'Apple|05ac:' || true\n"
+		"    if [ -n \"$EST\" ]; then echo \"TCP ESTABLISHED on :8030: $EST\"; fi\n"
+		"    echo 'Waiting 3s for usbmuxd to claim the device...'\n"
+		"    sleep 3\n"
+		"    ssh_do 'echo --- after USB ---; pgrep -a usbmuxd || echo NONE; "
+		"ls -l /var/run/usbmuxd 2>/dev/null || echo no socket; "
+		"idevice_id -l; irecovery -q 2>&1 | head -12' || true\n"
+		"    DEV=$(ssh_do 'idevice_id -l 2>/dev/null | head -1' || true)\n"
+		"    if [ -z \"$DEV\" ]; then\n"
+		"      echo 'idevice_id still empty; starting idevicerestore anyway (it waits 10s for mux/recovery).'\n"
+		"      DEV='00008030-1122334455667788'\n"
+		"    fi\n"
+		"    break\n"
 		"  fi\n"
-		"  if [ -n \"$EST\" ]; then echo \"TCP ESTABLISHED on :8030: $EST\"; fi\n"
-		"  if [ -n \"$DEV\" ]; then break; fi\n"
-		"  echo \"  ($i/60) waiting for idevice...\"\n"
-		"  sleep 3\n"
+		"  if [ -n \"$EST\" ]; then echo \"TCP ESTABLISHED on :8030 (waiting for companion lsusb): $EST\"; fi\n"
+		"  echo \"  ($i/40) waiting for USB (lsusb Apple)...\"\n"
+		"  sleep 2\n"
 		"done\n"
 		"if [ -z \"$DEV\" ]; then\n"
 		"  echo\n"
-		"  echo 'Still no device after waiting.'\n"
+		"  echo 'Still no Apple USB after waiting (lsusb had no 05ac).'\n"
 		"  echo 'Order: Start companion -> wait for SSH -> Power On iOS -> Restore quickly.'\n"
-		"  ssh_do 'lsusb; idevice_id -l' || true\n"
+		"  ssh_do 'lsusb; idevice_id -l; irecovery -q 2>&1 | head -20' || true\n"
 		"  exit 2\n"
 		"fi\n"
 		"echo \"Device: $DEV\"\n"
@@ -1189,27 +1402,41 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		"if [ -n \"$EST\" ]; then echo \"Pre-restore bridge ESTABLISHED: $EST\"; "
 		"else echo 'Pre-restore bridge: no ESTABLISHED on :8030 (check iOS USB remote config)'; fi\n"
 		"echo 'Starting idevicerestore NOW (Inferno ~120s window)...'\n"
+		"if [ \"$WRAP_OK\" = 1 ]; then\n"
+		"  IDR_CMD='/usr/local/bin/aqemu-idr-wrap.sh'\n"
+		"else\n"
+		"  IDR_CMD='idevicerestore'\n"
+		"fi\n"
+		"echo \"Running: sudo -n $IDR_CMD --debug -e --erase --restore-mode -y $ECID_ARG $TICKET_ARG IPSW\"\n"
 		"ok=0\n"
-		"for attempt in 1 2 3 4 5; do\n"
-		"  echo \"=== idevicerestore attempt $attempt/5 ===\"\n"
+		"for attempt in 1 2; do\n"
+		"  echo \"=== idevicerestore attempt $attempt/2 ===\"\n"
 		"  if [ \"$attempt\" != 1 ]; then\n"
-		"    echo 'Retry: Power Off iOS, wait 5s, Power On iOS, then click Restore again...'\n"
-		"    DEV=\n"
-		"    for j in $(seq 1 40); do\n"
-		"      ssh_do 'sudo -n systemctl start usbmuxd' 2>/dev/null || true\n"
-		"      DEV=$(ssh_do 'idevice_id -l 2>/dev/null | head -1' || true)\n"
-		"      [ -n \"$DEV\" ] && break\n"
-		"      sleep 3\n"
-		"    done\n"
-		"    echo 'Restarting usbmuxd (Inferno tip when mode discovery fails)...'\n"
-		"    ssh_do 'sudo -n systemctl restart usbmuxd' 2>/dev/null || true\n"
-		"    sleep 2\n"
+		"    echo 'Retry discovery. Do not restart usbmuxd (that drops USB-TCP).'\n"
+		"    ssh_do 'pgrep -x usbmuxd >/dev/null || sudo -n systemctl start usbmuxd' || true\n"
+		"    sleep 1\n"
 		"  fi\n"
-		"  if sshpass -e ssh -t -p 32222 \"${SSH_OPTS[@]}\" \"$GUEST@127.0.0.1\" "
-		"\"export LD_LIBRARY_PATH=/usr/local/lib:\\${LD_LIBRARY_PATH:-}; "
-		"sudo -n -E idevicerestore -d -y -e -R $ECID_ARG $TICKET_ARG "
-		"/mnt/aqemu_ipsw/aqemu-restore-current.ipsw\"; then\n"
-		"    ok=1; break\n"
+		"  set +e\n"
+		"  set +o pipefail\n"
+		"  sshpass -e ssh -t -p 32222 \"${SSH_OPTS[@]}\" \"$GUEST@127.0.0.1\" "
+		"\"sudo -n $IDR_CMD --debug -e --erase --restore-mode -y "
+		"$ECID_ARG $TICKET_ARG /mnt/aqemu_ipsw/aqemu-restore-current.ipsw\" "
+		"2>&1 | tee /tmp/aqemu-idr-last.log\n"
+		"  idr_ec=${PIPESTATUS[0]}\n"
+		"  set -e\n"
+		"  set -o pipefail\n"
+		"  if [ \"$idr_ec\" = 0 ]; then ok=1; break; fi\n"
+		"  if grep -qiE 'invalid GPT header|Missing data volume|FAILURE:7[58]|FAILURE:47|failed to create APFS Filesystem|format_media' "
+		"/tmp/aqemu-idr-last.log; then\n"
+		"    echo\n"
+		"    echo 'Stopped retries: ramrod storage/format.'\n"
+		"    echo '78 invalid header = zeros. 78 GPT format = empty GPT, need APFS Data volume.'\n"
+		"    echo '75 = APFS partition without Data. Power Off, Power On (formats Data volume).'\n"
+		"    echo '47 format_media / newfs_apfs Resource busy = Update ramdisk (CFS=false).'\n"
+		"    echo '  MACHINE Restore ramdisk must be CustomerRamDisk (e.g. 038-44135), not Update (038-44087).'\n"
+		"    echo '  Trustcache must match that ramdisk. Then Power Off iOS and Restore again.'\n"
+		"    ssh_do 'echo --- /tmp/aqemu-cfs.log ---; cat /tmp/aqemu-cfs.log 2>/dev/null | tail -50' || true\n"
+		"    break\n"
 		"  fi\n"
 		"  echo \"attempt $attempt failed - USB recheck:\"\n"
 		"  ssh_do 'lsusb | grep -iE \"Apple|05ac\" || true; idevice_id -l || true' || true\n"
@@ -1221,6 +1448,8 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		"  echo 'If log said \"Unable to discover device type\" after serial INFERNO_*:'\n"
 		"  echo '  companion idevicerestore lacks ChefKiss N104DEV→AP patch.'\n"
 		"  echo '  https://chefkiss.dev/Extras/Inferno/idevicerestore.patch'\n"
+		"  echo 'If log said \"invalid GPT header\" or \"Storage with GPT format\" (78) or \"Missing data volume\" (75):'\n"
+		"  echo '  Update-path ramrod needs an APFS Data volume. Power Off, Power On, Restore.'\n"
 		"  echo 'If log reached \"Done sending NORData\" then \"Could not read data (-256)\":'\n"
 		"  echo '  USB bridge dropped mid-restore (common). After partial restore you MUST:'\n"
 		"  echo '  1) Power Off iOS guest completely'\n"
@@ -1237,7 +1466,10 @@ void Apple_SoC_Restore_Window::Run_IDeviceRestore()
 		"  exit 1\n"
 		"fi\n"
 		"echo 'idevicerestore finished.'\n" )
-		.arg( Shell_Single_Quote( ssh_user ) )
+		.arg( Shell_Single_Quote( ssh_user ),
+		      Shell_Single_Quote( cfs_wsl ),
+		      Shell_Single_Quote( cfs_py_wsl ),
+		      Shell_Single_Quote( cfs_sh_wsl ) )
 		.toUtf8();
 
 	script_file.write( body );
@@ -1298,14 +1530,11 @@ void Apple_SoC_Restore_Window::On_Process_Finished( int code, QProcess::ExitStat
 	{
 		Append_Log( tr(
 			"\nRestore notes:\n"
-			"  - Companion + IPSW 9p can be fine while USB is still missing.\n"
-			"  - Apple logo with empty bar = waiting for restore host; it times out\n"
-			"    if the USB bridge never attaches (~120s window).\n"
-			"  - \"Unable to discover device type\" (after serial): ChefKiss\n"
-			"    idevicerestore.patch missing (N104DEV→AP). Ticket comes after that.\n"
-			"  - \"Done sending NORData\" then \"Could not read data (-256)\": bridge dropped.\n"
-			"    Wipe *_inferno NVMe images (see extras/Inferno/wipe-ios-nvme.ps1), then retry.\n"
-			"  - See https://chefkiss.dev/guides/inferno/troubleshooting/" ) );
+			"  - Companion SSH must be up before Power On iOS (~120s Apple-logo window).\n"
+			"  - First Restore this session may rebuild companion idevicerestore; Power On\n"
+			"    only when the log says Power On the iOS guest NOW.\n"
+			"  - GPT 78/75: Power Off, Power On (APFS Data seed), Restore once.\n"
+			"  - NORData then read error -256: USB bridge dropped; wipe disks and retry." ) );
 	}
 }
 

--- a/src/Apple_SoC_Restore_Window.h
+++ b/src/Apple_SoC_Restore_Window.h
@@ -28,6 +28,7 @@ private slots:
 	void Stop_Companion_WSL();
 	void Run_Diagnose_WSL();
 	void Run_IDeviceRestore();
+	void Wipe_Inferno_Disks();
 	void On_Process_Output();
 	void On_Process_Finished( int code, QProcess::ExitStatus st );
 	void On_Companion_Finished( int code, QProcess::ExitStatus st );
@@ -46,6 +47,8 @@ private:
 
 	Virtual_Machine *VM;
 	QLineEdit *Edit_IPSW;
+	QComboBox *CB_Nand_Size;
+	QSpinBox *SB_Nand_Size;
 	QLineEdit *Edit_Companion_Disk;
 	QLineEdit *Edit_SSH_User;
 	QLineEdit *Edit_SSH_Password;
@@ -53,6 +56,7 @@ private:
 	QComboBox *CB_Conn_Type;
 	QSpinBox *SB_Conn_Port;
 	QLabel *Label_Status;
+	QLabel *Label_VM_File;
 	QTextEdit *Text_Log;
 	QTextEdit *Text_Companion;
 	QProcess *Process;

--- a/src/Apple_SoC_Support.cpp
+++ b/src/Apple_SoC_Support.cpp
@@ -1,4 +1,5 @@
 #include "Apple_SoC_Support.h"
+#include "Apple_SoC_FS_Patch_Window.h"
 #include "VM.h"
 #include "Utils.h"
 #include "WSL_Launch.h"
@@ -10,6 +11,12 @@
 #include <QStorageInfo>
 #include <QObject>
 #include <QProcess>
+#include <QMessageBox>
+#include <QWidget>
+#include <QComboBox>
+#include <QSpinBox>
+
+#include <cstring>
 
 bool AQ_Is_Apple_SoC_VM( const Virtual_Machine *vm )
 {
@@ -212,7 +219,444 @@ static bool Ensure_Raw_Image( const QString &path, qint64 size_bytes, QString *e
 	return true;
 }
 
+static const char kSeedPartName[] = "AQEMU_SEED";
+static const int kNvmeLba = 4096;
+static const quint64 kSeedPartStartLba = 256;
+
+static quint32 Gpt_Crc32( const char *data, int len )
+{
+	quint32 crc = 0xFFFFFFFFu;
+	for( int i = 0; i < len; ++i )
+	{
+		crc ^= static_cast<quint8>( data[ i ] );
+		for( int b = 0; b < 8; ++b )
+			crc = ( crc >> 1 ) ^ ( ( crc & 1u ) ? 0xEDB88320u : 0u );
+	}
+	return ~crc;
+}
+
+static void Put_Le32( char *p, quint32 v )
+{
+	p[ 0 ] = char( v & 0xFFu );
+	p[ 1 ] = char( ( v >> 8 ) & 0xFFu );
+	p[ 2 ] = char( ( v >> 16 ) & 0xFFu );
+	p[ 3 ] = char( ( v >> 24 ) & 0xFFu );
+}
+
+static void Put_Le64( char *p, quint64 v )
+{
+	for( int i = 0; i < 8; ++i )
+		p[ i ] = char( ( v >> ( 8 * i ) ) & 0xFFu );
+}
+
+static quint64 Get_Le64( const char *p )
+{
+	quint64 v = 0;
+	for( int i = 0; i < 8; ++i )
+		v |= quint64( quint8( p[ i ] ) ) << ( 8 * i );
+	return v;
+}
+
+static void Put_Gpt_Guid( char *dst, const quint8 rfc[ 16 ] )
+{
+	dst[ 0 ] = char( rfc[ 3 ] );
+	dst[ 1 ] = char( rfc[ 2 ] );
+	dst[ 2 ] = char( rfc[ 1 ] );
+	dst[ 3 ] = char( rfc[ 0 ] );
+	dst[ 4 ] = char( rfc[ 5 ] );
+	dst[ 5 ] = char( rfc[ 4 ] );
+	dst[ 6 ] = char( rfc[ 7 ] );
+	dst[ 7 ] = char( rfc[ 6 ] );
+	std::memcpy( dst + 8, rfc + 8, 8 );
+}
+
+static bool Efi_Part_At( QFile &f, qint64 off, qint64 sz )
+{
+	if( off < 0 || off + 8 > sz )
+		return false;
+	if( ! f.seek( off ) )
+		return false;
+	return f.read( 8 ) == QByteArrayLiteral( "EFI PART" );
+}
+
+static QString Gpt_First_Part_Name( QFile &f, qint64 header_off, qint64 lba )
+{
+	if( ! f.seek( header_off + 72 ) )
+		return QString();
+	const QByteArray lb = f.read( 8 );
+	if( lb.size() != 8 )
+		return QString();
+	const qint64 name_off =
+		qint64( Get_Le64( lb.constData() ) ) * lba + 56;
+	if( name_off < 0 || ! f.seek( name_off ) )
+		return QString();
+	const QByteArray nb = f.read( 72 );
+	QString s;
+	for( int i = 0; i + 1 < nb.size(); i += 2 )
+	{
+		const ushort c = ushort( quint8( nb.at( i ) ) ) |
+			ushort( quint8( nb.at( i + 1 ) ) << 8 );
+		if( c == 0 )
+			break;
+		s.append( QChar( c ) );
+	}
+	return s;
+}
+
+static bool Root_Image_Has_Efi_Signature( const QString &path )
+{
+	QFile f( path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return false;
+	const qint64 sz = f.size();
+	return Efi_Part_At( f, 512, sz ) || Efi_Part_At( f, kNvmeLba, sz );
+}
+
+static QString Root_Image_First_Part_Name( const QString &path )
+{
+	QFile f( path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return QString();
+	const qint64 sz = f.size();
+	if( Efi_Part_At( f, kNvmeLba, sz ) )
+		return Gpt_First_Part_Name( f, kNvmeLba, kNvmeLba );
+	if( Efi_Part_At( f, 512, sz ) )
+		return Gpt_First_Part_Name( f, 512, 512 );
+	return QString();
+}
+
+static bool Partition_Has_Nxsb( const QString &path )
+{
+	QFile f( path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return false;
+	const qint64 off = qint64( kSeedPartStartLba ) * kNvmeLba + 32;
+	if( ! f.seek( off ) )
+		return false;
+	return f.read( 4 ) == QByteArrayLiteral( "NXSB" );
+}
+
+static bool Root_Image_Needs_Placeholder_Gpt( const QString &path )
+{
+	if( Partition_Has_Nxsb( path ) )
+		return false;
+	if( ! Root_Image_Has_Efi_Signature( path ) )
+		return true;
+	const QString name = Root_Image_First_Part_Name( path );
+	return name.isEmpty() || name == QLatin1String( kSeedPartName );
+}
+
+#ifdef Q_OS_WIN32
+static bool Format_Seed_Apfs_Via_Wsl( const QString &path, QString *error_out )
+{
+	if( Partition_Has_Nxsb( path ) )
+		return true;
+	const QString extras = AQ_Inferno_Extras_Dir();
+	const QString script = extras + QStringLiteral( "/format-seed-apfs.sh" );
+	if( extras.isEmpty() || ! QFileInfo::exists( script ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr(
+				"Cannot format seed APFS: extras/Inferno/format-seed-apfs.sh not found." );
+		return false;
+	}
+	QSettings s;
+	const QString distro = s.value( QStringLiteral( "WSL_Launch/Distro" ), QString() ).toString();
+	const QString cmd = QStringLiteral( "tr -d '\\r' < '%1' | sh -s -- '%2'" )
+				    .arg( Windows_Path_To_WSL( script ),
+					  Windows_Path_To_WSL( QFileInfo( path ).absoluteFilePath() ) );
+	if( ! WSL_Run_Privileged_Script( distro, cmd, 300000 ) )
+	{
+		AQWarning( "Format_Seed_Apfs_Via_Wsl",
+			   QStringLiteral( "WSL mkapfs skipped or failed for %1" ).arg( path ) );
+		return false;
+	}
+	if( ! Partition_Has_Nxsb( path ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr(
+				"Seed APFS format ran but NXSB was not found on:\n%1" ).arg( path );
+		return false;
+	}
+	return true;
+}
+#endif
+
+// GPT + APFS Data volume so ramrod verify_storage_for_update can pass while
+// CreateFilesystemPartitions stays false. AQEMU_SEED is not a finished restore.
+int AQ_Default_Apple_SoC_Nand_GiB()
+{
+	return 32;
+}
+
+int AQ_Min_Apple_SoC_Nand_GiB()
+{
+	return 16;
+}
+
+int AQ_Max_Apple_SoC_Nand_GiB()
+{
+	return 2048;
+}
+
+int AQ_Clamp_Apple_SoC_Nand_GiB( int gib )
+{
+	if( gib < AQ_Min_Apple_SoC_Nand_GiB() )
+		return AQ_Min_Apple_SoC_Nand_GiB();
+	if( gib > AQ_Max_Apple_SoC_Nand_GiB() )
+		return AQ_Max_Apple_SoC_Nand_GiB();
+	return gib;
+}
+
+qint64 AQ_Apple_SoC_Nand_Bytes( int gib )
+{
+	return qint64( AQ_Clamp_Apple_SoC_Nand_GiB( gib ) ) * 1024LL * 1024LL * 1024LL;
+}
+
+static const int kNandCustom = -1;
+
+static void Fill_Nand_Combo( QComboBox *cb )
+{
+	cb->clear();
+	for( int s : { 16, 32, 64, 128, 256 } )
+		cb->addItem( QObject::tr( "%1 GiB" ).arg( s ), s );
+	cb->addItem( QObject::tr( "Custom…" ), kNandCustom );
+}
+
+void AQ_Setup_Apple_SoC_Nand_Spin( QSpinBox *spin )
+{
+	if( ! spin )
+		return;
+	spin->setRange( AQ_Min_Apple_SoC_Nand_GiB(), AQ_Max_Apple_SoC_Nand_GiB() );
+	spin->setSingleStep( 1 );
+	spin->setSuffix( QObject::tr( " GiB" ) );
+	spin->setToolTip( QObject::tr(
+		"Custom NAND size in GiB (16–2048). Sparse on Windows — logical size, not fully allocated." ) );
+}
+
+void AQ_Populate_Apple_SoC_Nand_Combo( QComboBox *cb, int current_gib )
+{
+	if( ! cb )
+		return;
+	AQ_Apply_Apple_SoC_Nand_Controls( cb, nullptr, current_gib );
+}
+
+void AQ_Apply_Apple_SoC_Nand_Controls( QComboBox *cb, QSpinBox *spin, int gib )
+{
+	const int cur = AQ_Clamp_Apple_SoC_Nand_GiB( gib <= 0 ? AQ_Default_Apple_SoC_Nand_GiB() : gib );
+	if( cb )
+	{
+		cb->blockSignals( true );
+		Fill_Nand_Combo( cb );
+		int idx = cb->findData( cur );
+		if( idx < 0 )
+			idx = cb->findData( kNandCustom );
+		cb->setCurrentIndex( idx >= 0 ? idx : 0 );
+		cb->blockSignals( false );
+	}
+	if( spin )
+	{
+		spin->blockSignals( true );
+		AQ_Setup_Apple_SoC_Nand_Spin( spin );
+		spin->setValue( cur );
+		const bool custom = cb && cb->currentData().toInt() == kNandCustom;
+		spin->setEnabled( custom || ! cb );
+		spin->blockSignals( false );
+	}
+}
+
+int AQ_Read_Apple_SoC_Nand_Controls( const QComboBox *cb, const QSpinBox *spin )
+{
+	if( spin && spin->isEnabled() )
+		return AQ_Clamp_Apple_SoC_Nand_GiB( spin->value() );
+	if( cb )
+	{
+		const int d = cb->currentData().toInt();
+		if( d > 0 )
+			return AQ_Clamp_Apple_SoC_Nand_GiB( d );
+	}
+	if( spin )
+		return AQ_Clamp_Apple_SoC_Nand_GiB( spin->value() );
+	return AQ_Default_Apple_SoC_Nand_GiB();
+}
+
+void AQ_On_Apple_SoC_Nand_Combo_Changed( QComboBox *cb, QSpinBox *spin )
+{
+	if( ! cb || ! spin )
+		return;
+	const int d = cb->currentData().toInt();
+	if( d > 0 )
+	{
+		spin->blockSignals( true );
+		spin->setValue( d );
+		spin->setEnabled( false );
+		spin->blockSignals( false );
+	}
+	else
+	{
+		spin->setEnabled( true );
+		spin->setFocus();
+	}
+}
+
+void AQ_On_Apple_SoC_Nand_Spin_Changed( QComboBox *cb, QSpinBox *spin )
+{
+	if( ! cb || ! spin )
+		return;
+	const int v = AQ_Clamp_Apple_SoC_Nand_GiB( spin->value() );
+	int idx = cb->findData( v );
+	if( idx < 0 )
+		idx = cb->findData( kNandCustom );
+	cb->blockSignals( true );
+	cb->setCurrentIndex( idx >= 0 ? idx : cb->count() - 1 );
+	cb->blockSignals( false );
+	spin->setEnabled( cb->currentData().toInt() == kNandCustom );
+}
+
+static bool Seed_Root_Placeholder_Gpt( const QString &path, QString *error_out, bool force = false )
+{
+	if( ! force && ! Root_Image_Needs_Placeholder_Gpt( path ) )
+		return true;
+
+	QFile f( path );
+	if( ! f.open( QIODevice::ReadWrite ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Cannot write GPT on %1" ).arg( path );
+		return false;
+	}
+	const qint64 sz = f.size();
+	if( sz < qint64( kNvmeLba ) * 64 )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Root image too small to hold a GPT:\n%1" ).arg( path );
+		return false;
+	}
+	if( sz % kNvmeLba != 0 )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Root image size is not a multiple of 4096:\n%1" ).arg( path );
+		return false;
+	}
+
+	const quint64 n_lba = quint64( sz / kNvmeLba );
+	const quint64 array_bytes = 128ull * 128ull;
+	const quint64 array_lbas = ( array_bytes + quint64( kNvmeLba ) - 1 ) / quint64( kNvmeLba );
+	const quint64 first_usable = 2 + array_lbas;
+	const quint64 last_usable = n_lba - 1 - array_lbas - 1;
+	const quint64 start_lba = kSeedPartStartLba;
+	if( last_usable < start_lba )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Root image has no usable GPT space:\n%1" ).arg( path );
+		return false;
+	}
+
+	static const quint8 kApfsRfc[ 16 ] = {
+		0x7C, 0x34, 0x57, 0xEF, 0x00, 0x00, 0x11, 0xAA,
+		0xAA, 0x11, 0x00, 0x30, 0x65, 0x43, 0xEC, 0xAC
+	};
+	static const quint8 kDiskRfc[ 16 ] = {
+		0xA0, 0xE0, 0x00, 0x01, 0x47, 0x50, 0x54, 0x41,
+		0x81, 0x00, 0x41, 0x51, 0x45, 0x4D, 0x55, 0x01
+	};
+	static const quint8 kPartRfc[ 16 ] = {
+		0xA0, 0xE0, 0x00, 0x02, 0x47, 0x50, 0x54, 0x41,
+		0x81, 0x00, 0x41, 0x51, 0x45, 0x4D, 0x55, 0x02
+	};
+
+	QByteArray entries( int( array_bytes ), '\0' );
+	char *e = entries.data();
+	Put_Gpt_Guid( e + 0, kApfsRfc );
+	Put_Gpt_Guid( e + 16, kPartRfc );
+	Put_Le64( e + 32, start_lba );
+	Put_Le64( e + 40, last_usable );
+	const QString name = QString::fromLatin1( kSeedPartName );
+	for( int i = 0; i < name.size() && i < 36; ++i )
+	{
+		const ushort c = name.at( i ).unicode();
+		e[ 56 + i * 2 ] = char( c & 0xFFu );
+		e[ 57 + i * 2 ] = char( ( c >> 8 ) & 0xFFu );
+	}
+	const quint32 part_crc = Gpt_Crc32( entries.constData(), entries.size() );
+
+	char disk_guid[ 16 ];
+	Put_Gpt_Guid( disk_guid, kDiskRfc );
+
+	auto make_hdr = [ & ]( quint64 my, quint64 alt, quint64 part_lba ) -> QByteArray {
+		QByteArray h( 92, '\0' );
+		char *p = h.data();
+		std::memcpy( p, "EFI PART", 8 );
+		Put_Le32( p + 8, 0x00010000u );
+		Put_Le32( p + 12, 92 );
+		Put_Le64( p + 24, my );
+		Put_Le64( p + 32, alt );
+		Put_Le64( p + 40, first_usable );
+		Put_Le64( p + 48, last_usable );
+		std::memcpy( p + 56, disk_guid, 16 );
+		Put_Le64( p + 72, part_lba );
+		Put_Le32( p + 80, 128 );
+		Put_Le32( p + 84, 128 );
+		Put_Le32( p + 88, part_crc );
+		Put_Le32( p + 16, Gpt_Crc32( p, 92 ) );
+		return h;
+	};
+
+	const quint64 backup_hdr_lba = n_lba - 1;
+	const quint64 backup_arr_lba = n_lba - 1 - array_lbas;
+	const QByteArray primary = make_hdr( 1, backup_hdr_lba, 2 );
+	const QByteArray backup = make_hdr( backup_hdr_lba, 1, backup_arr_lba );
+
+	QByteArray mbr( kNvmeLba, '\0' );
+	mbr[ 446 ] = 0;
+	mbr[ 447 ] = 0x00;
+	mbr[ 448 ] = 0x02;
+	mbr[ 449 ] = 0x00;
+	mbr[ 450 ] = char( 0xEE );
+	mbr[ 451 ] = char( 0xFF );
+	mbr[ 452 ] = char( 0xFF );
+	mbr[ 453 ] = char( 0xFF );
+	Put_Le32( mbr.data() + 454, 1 );
+	const quint32 sz32 = quint32( qMin( quint64( 0xFFFFFFFFu ), n_lba - 1 ) );
+	Put_Le32( mbr.data() + 458, sz32 );
+	mbr[ 510 ] = char( 0x55 );
+	mbr[ 511 ] = char( 0xAA );
+
+	QByteArray primary_lba( kNvmeLba, '\0' );
+	std::memcpy( primary_lba.data(), primary.constData(), 92 );
+	QByteArray backup_lba( kNvmeLba, '\0' );
+	std::memcpy( backup_lba.data(), backup.constData(), 92 );
+
+	auto wr = [ & ]( qint64 off, const QByteArray &buf ) -> bool {
+		if( ! f.seek( off ) )
+			return false;
+		return f.write( buf ) == buf.size();
+	};
+	if( ! wr( 0, mbr ) ||
+	    ! wr( kNvmeLba, primary_lba ) ||
+	    ! wr( qint64( 2 ) * kNvmeLba, entries ) ||
+	    ! wr( qint64( backup_arr_lba ) * kNvmeLba, entries ) ||
+	    ! wr( qint64( backup_hdr_lba ) * kNvmeLba, backup_lba ) )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "Failed to write placeholder GPT to %1" ).arg( path );
+		return false;
+	}
+	f.close();
+#ifdef Q_OS_WIN32
+	// mkapfs is best-effort. Never block Power On if WSL/git/loop fails.
+	Format_Seed_Apfs_Via_Wsl( path, nullptr );
+#endif
+	return true;
+}
+
 bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &image_dir, QString *error_out )
+{
+	return AQ_Ensure_Apple_SoC_Disk_Images( image_dir,
+		AQ_Apple_SoC_Nand_Bytes( AQ_Default_Apple_SoC_Nand_GiB() ), error_out );
+}
+
+bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &image_dir, qint64 root_bytes, QString *error_out )
 {
 	if( ! QDir().mkpath( image_dir ) )
 	{
@@ -221,12 +665,39 @@ bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &image_dir, QString *error_o
 		return false;
 	}
 
+	const qint64 nand = root_bytes >= AQ_Apple_SoC_Nand_Bytes( AQ_Min_Apple_SoC_Nand_GiB() )
+		? root_bytes
+		: AQ_Apple_SoC_Nand_Bytes( AQ_Default_Apple_SoC_Nand_GiB() );
+	const QString root = QDir( image_dir ).filePath( QStringLiteral( "root" ) );
+	qint64 root_target = nand;
+	bool restore_gpt = false;
+	const qint64 old_root = QFileInfo( root ).exists() ? QFileInfo( root ).size() : 0;
+	if( old_root > 0 )
+	{
+		QFile f( root );
+		if( f.open( QIODevice::ReadOnly ) )
+		{
+			const qint64 sz = f.size();
+			auto real_gpt = [ &f, sz ]( qint64 header_off, qint64 lba ) -> bool
+			{
+				if( ! Efi_Part_At( f, header_off, sz ) )
+					return false;
+				const QString name = Gpt_First_Part_Name( f, header_off, lba );
+				if( name.isEmpty() || name == QLatin1String( kSeedPartName ) )
+					return false;
+				return true;
+			};
+			restore_gpt = real_gpt( kNvmeLba, kNvmeLba ) || real_gpt( 512, 512 );
+		}
+		if( restore_gpt )
+			root_target = old_root;
+	}
+
 	struct Spec { const char *name; qint64 bytes; };
-	// Modest defaults so Windows hosts with limited free space can still boot research kernels.
 	const Spec specs[] = {
 		{ "sep_nvram", 64 * 1024 },
 		{ "sep_ssc", 128 * 1024 },
-		{ "root", 8LL * 1024 * 1024 * 1024 },
+		{ "root", root_target },
 		{ "firmware", 256LL * 1024 * 1024 },
 		{ "syscfg", 1 * 1024 * 1024 },
 		{ "ctrl_bits", 1 * 1024 * 1024 },
@@ -266,7 +737,127 @@ bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &image_dir, QString *error_o
 		if( ! Ensure_Raw_Image( path, s.bytes, error_out ) )
 			return false;
 	}
+
+	if( restore_gpt )
+		return true;
+	const qint64 new_root = QFileInfo( root ).size();
+	const bool grew = ( old_root > 0 && new_root != old_root );
+	return Seed_Root_Placeholder_Gpt( root, error_out, grew );
+}
+
+static const char *Apple_SoC_Disk_Names[] = {
+	"sep_nvram", "sep_ssc", "root", "firmware", "syscfg",
+	"ctrl_bits", "nvram", "effaceable", "panic_log"
+};
+
+bool AQ_Wipe_Apple_SoC_Disk_Images( const Virtual_Machine *vm, QString *error_out )
+{
+	if( ! vm )
+	{
+		if( error_out )
+			*error_out = QObject::tr( "No VM selected." );
+		return false;
+	}
+	const QString dir = AQ_Apple_SoC_Image_Dir( vm );
+	if( ! QDir( dir ).exists() )
+		return true;
+	for( const char *name : Apple_SoC_Disk_Names )
+	{
+		const QString path = QDir( dir ).filePath( QString::fromLatin1( name ) );
+		if( ! QFile::exists( path ) )
+			continue;
+		if( ! QFile::remove( path ) )
+		{
+			if( error_out )
+				*error_out = QObject::tr( "Could not delete %1 (is iOS still Powered On?)" ).arg( path );
+			return false;
+		}
+	}
 	return true;
+}
+
+bool AQ_Apple_SoC_Root_Has_GPT( const Virtual_Machine *vm )
+{
+	if( ! vm )
+		return false;
+	const QString path = QDir( AQ_Apple_SoC_Image_Dir( vm ) ).filePath( QStringLiteral( "root" ) );
+	QFile f( path );
+	if( ! f.open( QIODevice::ReadOnly ) )
+		return false;
+	const qint64 sz = f.size();
+	auto real_gpt = [ &f, sz ]( qint64 header_off, qint64 lba ) -> bool
+	{
+		if( ! Efi_Part_At( f, header_off, sz ) )
+			return false;
+		const QString name = Gpt_First_Part_Name( f, header_off, lba );
+		if( name.isEmpty() || name == QLatin1String( kSeedPartName ) )
+			return false;
+		return true;
+	};
+	// Placeholder AQEMU_SEED GPT is not a finished restore.
+	return real_gpt( kNvmeLba, kNvmeLba ) || real_gpt( 512, 512 );
+}
+
+void AQ_Prompt_Wipe_Apple_SoC_Disks( Virtual_Machine *vm, QWidget *parent )
+{
+	if( ! vm || ! AQ_Is_Apple_SoC_VM( vm ) )
+	{
+		QMessageBox::warning( parent, QObject::tr( "Wipe Inferno disks" ),
+			QObject::tr( "Select the iOS (Apple SoC) VM in the list first." ) );
+		return;
+	}
+	if( vm->Get_State() == VM::VMS_Running || vm->Get_State() == VM::VMS_Pause )
+	{
+		QMessageBox::warning( parent, QObject::tr( "Wipe Inferno disks" ),
+			QObject::tr( "Power Off the iOS guest first.\n\nVM file:\n%1" )
+				.arg( QDir::toNativeSeparators( vm->Get_VM_XML_File_Path() ) ) );
+		return;
+	}
+
+	const QString xml = QDir::toNativeSeparators( vm->Get_VM_XML_File_Path() );
+	const QString dir = QDir::toNativeSeparators( AQ_Apple_SoC_Image_Dir( vm ) );
+	QStringList present;
+	for( const char *name : Apple_SoC_Disk_Names )
+	{
+		const QString path = QDir( AQ_Apple_SoC_Image_Dir( vm ) ).filePath( QString::fromLatin1( name ) );
+		if( QFile::exists( path ) )
+			present << QString::fromLatin1( name );
+	}
+
+	const QString body = QObject::tr(
+		"<p>This deletes Inferno NVMe images for the <b>selected iOS VM</b> "
+		"(after a failed restore / <code>-256</code>). Next Power On recreates them at the "
+		"MACHINE <b>NAND (root) size</b> (%1 GiB); "
+		"<code>root</code> gets a placeholder GPT (not a finished iOS install) so ramrod "
+		"can pass the header check when CreateFilesystemPartitions stays false.</p>"
+		"<p><b>VM:</b> %2</p>"
+		"<p><b>VM file (.aqemu):</b><br><code>%3</code></p>"
+		"<p><b>Disks folder:</b><br><code>%4</code></p>"
+		"<p><b>Will remove:</b> %5</p>"
+		"<p>Does <b>not</b> delete the VM file, IPSW, firmware extract, or companion.qcow2.</p>" )
+		.arg( AQ_Clamp_Apple_SoC_Nand_GiB( vm->Get_Apple_Nand_Size_GiB() ) )
+		.arg( vm->Get_Machine_Name().toHtmlEscaped(),
+		      xml.toHtmlEscaped(),
+		      dir.toHtmlEscaped(),
+		      present.isEmpty()
+			      ? QObject::tr( "(folder empty — nothing to delete)" )
+			      : present.join( QStringLiteral( ", " ) ) );
+
+	if( QMessageBox::question( parent, QObject::tr( "Wipe Inferno disks" ), body,
+		QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+		return;
+
+	QString err;
+	if( ! AQ_Wipe_Apple_SoC_Disk_Images( vm, &err ) )
+	{
+		QMessageBox::warning( parent, QObject::tr( "Wipe Inferno disks" ), err );
+		return;
+	}
+	QMessageBox::information( parent, QObject::tr( "Wipe Inferno disks" ),
+		QObject::tr(
+			"Done.\n\nStart companion (if needed), Power On iOS "
+			"(that writes the placeholder GPT on root), then Restore IPSW via SSH.\n"
+			"Do not apply filesystem patches until restore rewrites that GPT." ) );
 }
 
 static QString Quote_Drive( const QString &path, bool script )
@@ -292,7 +883,8 @@ QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
 	if( create_missing_images )
 	{
 		QString err;
-		if( ! AQ_Ensure_Apple_SoC_Disk_Images( image_dir, &err ) )
+		if( ! AQ_Ensure_Apple_SoC_Disk_Images( image_dir,
+			AQ_Apple_SoC_Nand_Bytes( vm->Get_Apple_Nand_Size_GiB() ), &err ) )
 		{
 			if( error_out )
 				*error_out = err;
@@ -356,6 +948,28 @@ QStringList AQ_Build_Apple_SoC_Extra_Args( const Virtual_Machine *vm,
 
 QStringList AQ_Filter_Apple_SoC_Additional_Args( const QStringList &args )
 {
+	auto skip_drive = []( const QString &opt ) -> bool {
+		if( opt.contains( QLatin1String( "if=pflash" ), Qt::CaseInsensitive ) )
+			return true;
+		static const char *ids[] = {
+			"id=root", "id=firmware", "id=syscfg", "id=ctrl_bits",
+			"id=nvram", "id=effaceable", "id=panic_log"
+		};
+		for( const char *id : ids )
+		{
+			if( opt.contains( QLatin1String( id ), Qt::CaseInsensitive ) )
+				return true;
+		}
+		return false;
+	};
+	auto skip_device = []( const QString &opt ) -> bool {
+		if( opt.startsWith( QLatin1String( "nvme-ns" ), Qt::CaseInsensitive ) )
+			return true;
+		if( opt.startsWith( QLatin1String( "apple-nvram" ), Qt::CaseInsensitive ) )
+			return true;
+		return false;
+	};
+
 	QStringList out;
 	out.reserve( args.size() );
 	for( int i = 0; i < args.size(); ++i )
@@ -373,6 +987,20 @@ QStringList AQ_Filter_Apple_SoC_Additional_Args( const QStringList &args )
 				++i;
 			continue;
 		}
+		if( a == QLatin1String( "-drive" ) && i + 1 < args.size() && skip_drive( args.at( i + 1 ) ) )
+		{
+			++i;
+			continue;
+		}
+		if( a.startsWith( QLatin1String( "-drive=" ) ) && skip_drive( a.mid( 7 ) ) )
+			continue;
+		if( a == QLatin1String( "-device" ) && i + 1 < args.size() && skip_device( args.at( i + 1 ) ) )
+		{
+			++i;
+			continue;
+		}
+		if( a.startsWith( QLatin1String( "-device=" ) ) && skip_device( a.mid( 8 ) ) )
+			continue;
 		out << a;
 	}
 	return out;

--- a/src/Apple_SoC_Support.h
+++ b/src/Apple_SoC_Support.h
@@ -5,6 +5,9 @@
 #include <QStringList>
 
 class Virtual_Machine;
+class QWidget;
+class QComboBox;
+class QSpinBox;
 
 /** True when this VM should use the Inferno Apple SoC launch profile. */
 bool AQ_Is_Apple_SoC_VM( const Virtual_Machine *vm );
@@ -30,11 +33,41 @@ QString AQ_Apple_SoC_QEMU_Log_Path( const Virtual_Machine *vm );
  */
 bool AQ_Validate_Apple_SoC_Boot_Files( const Virtual_Machine *vm, QString *error_out = nullptr );
 
+/** Default NAND size (GiB). Presets: 16, 32, 64, 128, 256, plus Custom (16–2048). */
+int AQ_Default_Apple_SoC_Nand_GiB();
+int AQ_Min_Apple_SoC_Nand_GiB();
+int AQ_Max_Apple_SoC_Nand_GiB();
+int AQ_Clamp_Apple_SoC_Nand_GiB( int gib );
+qint64 AQ_Apple_SoC_Nand_Bytes( int gib );
+void AQ_Setup_Apple_SoC_Nand_Spin( QSpinBox *spin );
+void AQ_Populate_Apple_SoC_Nand_Combo( QComboBox *cb, int current_gib );
+void AQ_Apply_Apple_SoC_Nand_Controls( QComboBox *cb, QSpinBox *spin, int gib );
+int AQ_Read_Apple_SoC_Nand_Controls( const QComboBox *cb, const QSpinBox *spin );
+void AQ_On_Apple_SoC_Nand_Combo_Changed( QComboBox *cb, QSpinBox *spin );
+void AQ_On_Apple_SoC_Nand_Spin_Changed( QComboBox *cb, QSpinBox *spin );
+
 /**
  * Ensure the standard raw image set exists under image_dir.
- * Creates/grows missing or undersized files. Returns false on I/O / disk-space failure.
+ * `root_bytes` is NAND size used when creating `root` (or growing a seed).
+ * A finished restore GPT is never resized — Settings stays at the restore size
+ * until Wipe + recreate + restore. Empty `root` gets a GPT APFS seed volume.
  */
 bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &image_dir, QString *error_out = nullptr );
+bool AQ_Ensure_Apple_SoC_Disk_Images( const QString &image_dir, qint64 root_bytes,
+                                      QString *error_out = nullptr );
+
+/**
+ * Delete Inferno NVMe raw images for this VM (root, nvram, firmware, …).
+ * Image dir is derived from vm->Get_VM_XML_File_Path() (never a hardcoded .aqemu).
+ * Does not delete the .aqemu file or companion.qcow2.
+ */
+bool AQ_Wipe_Apple_SoC_Disk_Images( const Virtual_Machine *vm, QString *error_out = nullptr );
+
+/** True if guest root has a real restore GPT (not the AQEMU_SEED placeholder). */
+bool AQ_Apple_SoC_Root_Has_GPT( const Virtual_Machine *vm );
+
+/** Confirm + wipe in the GUI. Refuses while the iOS guest is running. */
+void AQ_Prompt_Wipe_Apple_SoC_Disks( Virtual_Machine *vm, QWidget *parent );
 
 /**
  * Build Inferno-specific argv pieces that AQEMU would not emit from generic UI:

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -142,6 +142,9 @@ Main_Window::Main_Window( QWidget *parent )
 	, Edit_Apple_SecureROM( nullptr )
 	, Edit_Apple_IPSW( nullptr )
 	, Edit_Apple_Initrd( nullptr )
+	, CB_Apple_Nand_Size( nullptr )
+	, SB_Apple_Nand_Size( nullptr )
+	, Label_Apple_Nand_On_Disk( nullptr )
 	, Edit_Apple_USB_Conn_Addr( nullptr )
 	, CB_Apple_USB_Conn_Type( nullptr )
 	, SB_Apple_USB_Conn_Port( nullptr )
@@ -250,6 +253,16 @@ Main_Window::Main_Window( QWidget *parent )
 		connect( actFs, &QAction::triggered, this, &Main_Window::slot_Apple_SoC_FS_Patch_triggered );
 		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actFs );
 		ui.menuVM->insertAction( ui.actionManage_Snapshots, actFs );
+	}
+	{
+		QAction *actWipe = new QAction( QIcon( QStringLiteral( ":/default_mac.png" ) ),
+			tr( "&Wipe Inferno disks…" ), this );
+		actWipe->setStatusTip( tr(
+			"Delete the selected iOS VM's Inferno NVMe images (after -256 / partial restore). "
+			"Path comes from that VM's .aqemu file." ) );
+		connect( actWipe, &QAction::triggered, this, &Main_Window::slot_Apple_SoC_Wipe_Disks_triggered );
+		ui.menuFile->insertAction( ui.actionCreate_HDD_Image, actWipe );
+		ui.menuVM->insertAction( ui.actionManage_Snapshots, actWipe );
 	}
 	// File → Guest Internet / iOS Device Tools (companion reverse-tether + idevice*)
 	{
@@ -6334,6 +6347,11 @@ void Main_Window::slot_iOS_Firmware_Tool_triggered()
 	connect( &dlg, &iOS_Firmware_Tool_Window::Restore_Ramdisk_Suggested,
 	         this, [this, fill_if]( const QString &path ) {
 		fill_if( Edit_Apple_Initrd, path, false );
+		const QFileInfo fi( path );
+		const QString tc = fi.absolutePath() + QStringLiteral( "/Firmware/" )
+			+ fi.fileName() + QStringLiteral( ".trustcache" );
+		if( QFile::exists( tc ) && Edit_Apple_Trustcache )
+			fill_if( Edit_Apple_Trustcache, QDir::toNativeSeparators( tc ), true );
 	} );
 	connect( &dlg, &iOS_Firmware_Tool_Window::Sep_Firmware_Suggested,
 	         this, [this, fill_if]( const QString &path ) {
@@ -6415,6 +6433,18 @@ void Main_Window::slot_Apple_SoC_FS_Patch_triggered()
 	    ( Get_Current_VM() && Uses_Apple_SoC_Boot_UI( Get_Current_VM() ) ) )
 		Apply_Apple_SoC_Fields_To_VM( vm );
 	AQ_Show_Apple_SoC_FS_Patch_Window( vm, this );
+}
+
+void Main_Window::slot_Apple_SoC_Wipe_Disks_triggered()
+{
+	Virtual_Machine *vm = Resolve_Apple_SoC_VM();
+	if( ! vm )
+	{
+		AQGraphic_Warning( tr( "Wipe Inferno disks" ),
+			tr( "Select the iOS (Apple SoC) VM in the list first." ) );
+		return;
+	}
+	AQ_Prompt_Wipe_Apple_SoC_Disks( vm, this );
 }
 
 void Main_Window::slot_Apple_SoC_Device_Tools_triggered()
@@ -6502,7 +6532,15 @@ void Main_Window::Build_Apple_SoC_Inferno_Ui()
 	add_path_row( tr( "Restore ticket:" ), &Edit_Apple_Ticket,
 		tr( "Ticket (*);;All (*)" ) );
 	add_path_row( tr( "SEP firmware:" ), &Edit_Apple_SEP_FW,
-		tr( "SEP FW (*);;All (*)" ) );
+		tr( "SEP IMG4 (*.img4);;IM4P (*.im4p);;All (*)" ) );
+	if( Edit_Apple_SEP_FW )
+	{
+		Edit_Apple_SEP_FW->setToolTip( tr(
+			"MACHINE tab → Options → SEP firmware.\n"
+			"Use the packed file from Firmware Tool Step 3:\n"
+			"sep-firmware.n104.RELEASE.new.img4\n"
+			"Not the raw IPSW .im4p (that causes restore -256 after NORData)." ) );
+	}
 	add_path_row( tr( "SEP ROM:" ), &Edit_Apple_SEP_ROM,
 		tr( "SEP ROM (*);;All (*)" ) );
 	add_path_row( tr( "SecureROM (optional):" ), &Edit_Apple_SecureROM,
@@ -6522,6 +6560,34 @@ void Main_Window::Build_Apple_SoC_Inferno_Ui()
 			"SpringBoard boot (File → Apply iOS filesystem patches clears it).\n"
 			"Typical: …/firmware_extracted/038-44135-124.dmg" ) );
 	}
+
+	QHBoxLayout *nandRow = new QHBoxLayout();
+	nandRow->addWidget( new QLabel( tr( "NAND (root) size:" ) ) );
+	CB_Apple_Nand_Size = new QComboBox();
+	SB_Apple_Nand_Size = new QSpinBox();
+	AQ_Apply_Apple_SoC_Nand_Controls( CB_Apple_Nand_Size, SB_Apple_Nand_Size,
+		AQ_Default_Apple_SoC_Nand_GiB() );
+	CB_Apple_Nand_Size->setToolTip( tr(
+		"Size of Inferno NAND file `root` when it is created (first Power On or after Wipe).\n"
+		"Presets 16–256 GiB, or Custom (16–2048 GiB). ChefKiss uses 32 GiB.\n"
+		"Changing this does not grow an already-restored iPhone — "
+		"Wipe Inferno disks, Power On, then Restore IPSW." ) );
+	nandRow->addWidget( CB_Apple_Nand_Size );
+	nandRow->addWidget( SB_Apple_Nand_Size );
+	Label_Apple_Nand_On_Disk = new QLabel();
+	Label_Apple_Nand_On_Disk->setWordWrap( true );
+	nandRow->addWidget( Label_Apple_Nand_On_Disk, 1 );
+	lay->addLayout( nandRow );
+	connect( CB_Apple_Nand_Size, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+	         this, [this]( int ) {
+		AQ_On_Apple_SoC_Nand_Combo_Changed( CB_Apple_Nand_Size, SB_Apple_Nand_Size );
+		VM_Changed();
+	} );
+	connect( SB_Apple_Nand_Size, QOverload<int>::of( &QSpinBox::valueChanged ),
+	         this, [this]( int ) {
+		AQ_On_Apple_SoC_Nand_Spin_Changed( CB_Apple_Nand_Size, SB_Apple_Nand_Size );
+		VM_Changed();
+	} );
 
 	CH_Apple_KASLR_Off = new QCheckBox( tr( "Disable KASLR (kaslr-off)" ) );
 	CH_Apple_KASLR_Off->setChecked( true );
@@ -6591,6 +6657,12 @@ void Main_Window::Build_Apple_SoC_Inferno_Ui()
 	connect( Btn_Apple_SoC_Restore, &QPushButton::clicked,
 	         this, &Main_Window::slot_Apple_SoC_Restore_triggered );
 	btnRow->addWidget( Btn_Apple_SoC_Restore );
+	QPushButton *btnWipeNvme = new QPushButton( tr( "Wipe Inferno disks…" ) );
+	btnWipeNvme->setToolTip( tr(
+		"Delete this VM's Inferno NVMe images (root, nvram, …) after a failed restore.\n"
+		"Uses the selected VM's .aqemu path — nothing hardcoded." ) );
+	connect( btnWipeNvme, &QPushButton::clicked, this, &Main_Window::slot_Apple_SoC_Wipe_Disks_triggered );
+	btnRow->addWidget( btnWipeNvme );
 	QPushButton *btnFsPatch = new QPushButton( tr( "Apply filesystem patches…" ) );
 	btnFsPatch->setToolTip( tr(
 		"After restore: patch the iOS guest root NVMe (dyld cache + LaunchDaemons). "
@@ -6627,6 +6699,9 @@ void Main_Window::Apply_Apple_SoC_Fields_To_VM( Virtual_Machine *vm )
 		vm->Set_Apple_IPSW_Path( Edit_Apple_IPSW->text() );
 	if( Edit_Apple_Initrd )
 		vm->Set_Apple_Initrd_Path( Edit_Apple_Initrd->text() );
+	if( CB_Apple_Nand_Size || SB_Apple_Nand_Size )
+		vm->Set_Apple_Nand_Size_GiB(
+			AQ_Read_Apple_SoC_Nand_Controls( CB_Apple_Nand_Size, SB_Apple_Nand_Size ) );
 	if( CH_Apple_KASLR_Off )
 		vm->Use_Apple_KASLR_Off( CH_Apple_KASLR_Off->isChecked() );
 	if( CB_Apple_USB_Conn_Type )
@@ -6659,6 +6734,10 @@ void Main_Window::Load_Apple_SoC_Fields_From_VM( const Virtual_Machine *vm )
 		Edit_Apple_IPSW->setText( vm->Get_Apple_IPSW_Path() );
 	if( Edit_Apple_Initrd )
 		Edit_Apple_Initrd->setText( vm->Get_Apple_Initrd_Path() );
+	if( CB_Apple_Nand_Size || SB_Apple_Nand_Size )
+		AQ_Apply_Apple_SoC_Nand_Controls( CB_Apple_Nand_Size, SB_Apple_Nand_Size,
+			vm->Get_Apple_Nand_Size_GiB() );
+	Refresh_Apple_Nand_On_Disk_Label( vm );
 	if( CH_Apple_KASLR_Off )
 		CH_Apple_KASLR_Off->setChecked( vm->Use_Apple_KASLR_Off() );
 	if( CB_Apple_USB_Conn_Type )
@@ -6676,6 +6755,27 @@ void Main_Window::Load_Apple_SoC_Fields_From_VM( const Virtual_Machine *vm )
 		Edit_Apple_USB_Conn_Addr->setText( vm->Get_Apple_USB_Conn_Addr() );
 	if( SB_Apple_USB_Conn_Port )
 		SB_Apple_USB_Conn_Port->setValue( vm->Get_Apple_USB_Conn_Port() > 0 ? vm->Get_Apple_USB_Conn_Port() : 8030 );
+}
+
+void Main_Window::Refresh_Apple_Nand_On_Disk_Label( const Virtual_Machine *vm )
+{
+	if( ! Label_Apple_Nand_On_Disk )
+		return;
+	if( ! vm )
+	{
+		Label_Apple_Nand_On_Disk->clear();
+		return;
+	}
+	const QString root = QDir( AQ_Apple_SoC_Image_Dir( vm ) ).filePath( QStringLiteral( "root" ) );
+	const QFileInfo fi( root );
+	if( ! fi.exists() || fi.size() <= 0 )
+	{
+		Label_Apple_Nand_On_Disk->setText( tr( "Not created yet — Power On or Wipe+Power On builds `root` at the size above." ) );
+		return;
+	}
+	const double gib = double( fi.size() ) / ( 1024.0 * 1024.0 * 1024.0 );
+	Label_Apple_Nand_On_Disk->setText( tr( "On disk now: %1 GiB (Settings follows restore, not this combo)." )
+		.arg( gib, 0, 'f', 1 ) );
 }
 
 void Main_Window::Update_Machine_Accelerators()
@@ -8120,9 +8220,9 @@ void Main_Window::on_TB_Linux_Initrd_SetPath_clicked()
 
 void Main_Window::on_TB_DeviceTree_SetPath_clicked()
 {
-	QString dtb = QFileDialog::getOpenFileName( this, tr("Select DeviceTree File (.dtb / .im4p)"),
+	QString dtb = QFileDialog::getOpenFileName( this, tr("Select DeviceTree File"),
 												Get_Last_Dir_Path(ui.Edit_DeviceTree_Path->text()),
-												tr("DeviceTree Files (*.dtb *.im4p);;All Files (*)") );
+												tr("DeviceTree (*.dec *.dtb);;IM4P wrapped (*.im4p);;All Files (*)") );
 
 	if( ! dtb.isEmpty() )
 		ui.Edit_DeviceTree_Path->setText( QDir::toNativeSeparators(dtb) );

--- a/src/Main_Window.h
+++ b/src/Main_Window.h
@@ -52,6 +52,9 @@ class VM_Session_Widget;
 class QStackedWidget;
 class QTimer;
 class QCheckBox;
+class QComboBox;
+class QLabel;
+class QSpinBox;
 
 class Main_Window: public QMainWindow
 {
@@ -143,11 +146,13 @@ class Main_Window: public QMainWindow
 		void slot_iOS_Firmware_Tool_triggered();
 		void slot_Apple_SoC_Restore_triggered();
 		void slot_Apple_SoC_FS_Patch_triggered();
+		void slot_Apple_SoC_Wipe_Disks_triggered();
 		void slot_Apple_SoC_Device_Tools_triggered();
 		void Maybe_Prompt_WSL_Config_On_Boot();
 		void Build_Apple_SoC_Inferno_Ui();
 		void Apply_Apple_SoC_Fields_To_VM( Virtual_Machine *vm );
 		void Load_Apple_SoC_Fields_From_VM( const Virtual_Machine *vm );
+		void Refresh_Apple_Nand_On_Disk_Label( const Virtual_Machine *vm );
 		Virtual_Machine *Resolve_Apple_SoC_VM();
 		
 		void on_Tabs_currentChanged( int index );
@@ -392,6 +397,9 @@ class Main_Window: public QMainWindow
 		QLineEdit *Edit_Apple_SecureROM;
 		QLineEdit *Edit_Apple_IPSW;
 		QLineEdit *Edit_Apple_Initrd;
+		QComboBox *CB_Apple_Nand_Size;
+		QSpinBox *SB_Apple_Nand_Size;
+		QLabel *Label_Apple_Nand_On_Disk;
 		QLineEdit *Edit_Apple_USB_Conn_Addr;
 		QComboBox *CB_Apple_USB_Conn_Type;
 		QSpinBox *SB_Apple_USB_Conn_Port;

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -2136,7 +2136,7 @@
                      <item>
                       <widget class="QLabel" name="Label_DeviceTree_Main">
                        <property name="text">
-                        <string>DeviceTree (.dtb / .im4p):</string>
+                        <string>DeviceTree (.dec / .dtb / .im4p):</string>
                        </property>
                       </widget>
                      </item>
@@ -2146,7 +2146,7 @@
                         <string>DeviceTree payload for Apple Silicon / iOS QEMU boot (-dtb)</string>
                        </property>
                        <property name="placeholderText">
-                        <string>/path/to/DeviceTree.n104ap.im4p or .dtb</string>
+                        <string>…/DeviceTree.n104ap.im4p.dec (Firmware Tool Step 4)</string>
                        </property>
                       </widget>
                      </item>

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -323,6 +323,7 @@ Virtual_Machine::Virtual_Machine( const Virtual_Machine &vm )
 	this->Apple_SecureROM_Path = vm.Get_Apple_SecureROM_Path();
 	this->Apple_IPSW_Path = vm.Get_Apple_IPSW_Path();
 	this->Apple_Initrd_Path = vm.Get_Apple_Initrd_Path();
+	this->Apple_Nand_Size_GiB = vm.Get_Apple_Nand_Size_GiB();
 	this->Apple_KASLR_Off = vm.Use_Apple_KASLR_Off();
 	this->Apple_USB_Conn_Type = vm.Get_Apple_USB_Conn_Type();
 	this->Apple_USB_Conn_Addr = vm.Get_Apple_USB_Conn_Addr();
@@ -616,6 +617,7 @@ void Virtual_Machine::Shared_Constructor()
 	Apple_SecureROM_Path.clear();
 	Apple_IPSW_Path.clear();
 	Apple_Initrd_Path.clear();
+	Apple_Nand_Size_GiB = 32;
 	Apple_KASLR_Off = true;
 	Apple_USB_Conn_Type.clear();
 	Apple_USB_Conn_Addr.clear();
@@ -798,6 +800,7 @@ bool Virtual_Machine::operator==( const Virtual_Machine &vm ) const
 		this->Apple_SecureROM_Path == vm.Get_Apple_SecureROM_Path() &&
 		this->Apple_IPSW_Path == vm.Get_Apple_IPSW_Path() &&
 		this->Apple_Initrd_Path == vm.Get_Apple_Initrd_Path() &&
+		this->Apple_Nand_Size_GiB == vm.Get_Apple_Nand_Size_GiB() &&
 		this->Apple_KASLR_Off == vm.Use_Apple_KASLR_Off() &&
 		this->Apple_USB_Conn_Type == vm.Get_Apple_USB_Conn_Type() &&
 		this->Apple_USB_Conn_Addr == vm.Get_Apple_USB_Conn_Addr() &&
@@ -1127,6 +1130,7 @@ Virtual_Machine &Virtual_Machine::operator=( const Virtual_Machine &vm )
 	Apple_SecureROM_Path = vm.Get_Apple_SecureROM_Path();
 	Apple_IPSW_Path = vm.Get_Apple_IPSW_Path();
 	Apple_Initrd_Path = vm.Get_Apple_Initrd_Path();
+	Apple_Nand_Size_GiB = vm.Get_Apple_Nand_Size_GiB();
 	Apple_KASLR_Off = vm.Use_Apple_KASLR_Off();
 	Apple_USB_Conn_Type = vm.Get_Apple_USB_Conn_Type();
 	Apple_USB_Conn_Addr = vm.Get_Apple_USB_Conn_Addr();
@@ -3649,6 +3653,10 @@ bool Virtual_Machine::Create_VM_File( const QString &file_name, bool template_mo
 	VM_Element.appendChild( Dom_Element );
 	Dom_Text = New_Dom_Document.createTextNode( Apple_Initrd_Path );
 	Dom_Element.appendChild( Dom_Text );
+	Dom_Element = New_Dom_Document.createElement( "Apple_Nand_Size_GiB" );
+	VM_Element.appendChild( Dom_Element );
+	Dom_Text = New_Dom_Document.createTextNode( QString::number( Apple_Nand_Size_GiB ) );
+	Dom_Element.appendChild( Dom_Text );
 	Dom_Element = New_Dom_Document.createElement( "Apple_KASLR_Off" );
 	VM_Element.appendChild( Dom_Element );
 	Dom_Text = New_Dom_Document.createTextNode( Apple_KASLR_Off ? "true" : "false" );
@@ -5529,6 +5537,23 @@ bool Virtual_Machine::Load_VM( const QString &file_name )
 			Apple_IPSW_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_IPSW_Path" ).text() );
 			Apple_Initrd_Path = AQ_Normalize_File_Path( Child_Element.firstChildElement( "Apple_Initrd_Path" ).text() );
 			{
+				const QString nand = Child_Element.firstChildElement( "Apple_Nand_Size_GiB" ).text().trimmed();
+				bool ok = false;
+				const int g = nand.toInt( &ok );
+				if( ok && g > 0 )
+					Apple_Nand_Size_GiB = AQ_Clamp_Apple_SoC_Nand_GiB( g );
+				else
+				{
+					const QString root = QDir( AQ_Apple_SoC_Image_Dir( this ) )
+						.filePath( QStringLiteral( "root" ) );
+					const qint64 b = QFileInfo( root ).exists() ? QFileInfo( root ).size() : 0;
+					Apple_Nand_Size_GiB = ( b > 0 )
+						? AQ_Clamp_Apple_SoC_Nand_GiB( int( ( b + ( 1024LL * 1024 * 1024 / 2 ) )
+							/ ( 1024LL * 1024 * 1024 ) ) )
+						: AQ_Default_Apple_SoC_Nand_GiB();
+				}
+			}
+			{
 				const QString kaslr = Child_Element.firstChildElement( "Apple_KASLR_Off" ).text();
 				// Preserve prior launch behavior for older VMs that always forced kaslr-off.
 				Apple_KASLR_Off = ( kaslr.isEmpty() || kaslr == QLatin1String( "true" ) );
@@ -6664,8 +6689,8 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	else if( AQ_Is_Apple_SoC_VM( this ) )
 	{
 		// Inferno with SEP FW/ROM requires smp.cpus >= 2. Never drop -smp because a
-		// probed PSO_SMP_Count (often 1) is lower than the MACHINE-tab CPU count ù
-		// that left QEMU at default 1 CPU and produced "Too few CPU coresù SEP".
+		// probed PSO_SMP_Count (often 1) is lower than the MACHINE-tab CPU count ¬ù
+		// that left QEMU at default 1 CPU and produced "Too few CPU cores¬ù SEP".
 		int apple_smp = smp_count;
 		if( apple_smp < 2 &&
 		    ( ! Get_Apple_SEP_FW_Path().trimmed().isEmpty() ||
@@ -6950,7 +6975,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// Reims architecture always presents via reims-vgpu-pci (-vga none), never cirrus/std.
 	if( is_reims_vgpu )
 		effective_video = QStringLiteral( "reims-vgpu-pci" );
-	// Inferno Apple SoC: no PC VGA device ù display is onboard (SDL/VNC host window only).
+	// Inferno Apple SoC: no PC VGA device ¬ù display is onboard (SDL/VNC host window only).
 	if( is_apple_soc_video )
 		effective_video.clear();
 	if( effective_video == QLatin1String( "vmware" ) )
@@ -7444,7 +7469,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	const bool mac_recovery_active = Intel_MacOS_Profile && ! mac_recovery_norm.isEmpty() &&
 		( QFile::exists( mac_recovery_norm ) || Build_QEMU_Args_for_Tab_Info );
 
-	// Inferno storage is multi-NS NVMe from AQ_Build_Apple_SoC_Extra_Args ù never IDE/floppy/CD.
+	// Inferno storage is multi-NS NVMe from AQ_Build_Apple_SoC_Extra_Args ¬ù never IDE/floppy/CD.
 	if( is_apple_soc_storage )
 		attach_cdrom = false;
 
@@ -7744,7 +7769,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 		}
 	}
 
-	// HDA ù Inferno uses AQ_Build_Apple_SoC_Extra_Args NVMe namespaces instead.
+	// HDA ¬ù Inferno uses AQ_Build_Apple_SoC_Extra_Args NVMe namespaces instead.
 	if( HDA.Get_Enabled() && ! is_apple_soc_storage )
 	{
 		// Intel macOS: OpenCore cannot see VirtIO disks without guest kexts.
@@ -8051,7 +8076,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 #endif
 	}
 	
-	// Network Cards ù Inferno t8030/s8000 do not support e1000/virtio-net PCI NICs.
+	// Network Cards ¬ù Inferno t8030/s8000 do not support e1000/virtio-net PCI NICs.
 	if( AQ_Is_Apple_SoC_VM( this ) ||
 	    (Use_Native_Network() == false && Network_Cards.count() < 1) ||
 	    (Use_Native_Network() == true  && Network_Cards_Nativ.count() < 1) ||
@@ -9231,17 +9256,6 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			else
 				Args << "-append" << Kernel_ComLine;
 		}
-		else if( AQ_Is_Apple_SoC_VM( this ) )
-		{
-			Args << "-append" << AQ_Apple_SoC_Default_Append();
-		}
-	}
-
-	if( AQ_Is_Apple_SoC_VM( this ) )
-	{
-		// Preview/script must not create 32GiB images; Start_impl ensures them first.
-		Args << AQ_Build_Apple_SoC_Extra_Args(
-			this, Build_QEMU_Args_for_Script_Mode, Launch_Via_WSL, false, nullptr );
 	}
 
 	if( AQ_Is_Apple_SoC_VM( this ) )
@@ -9326,7 +9340,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << "-pflash" << PFlash_File;
 	}
 	
-	// UEFI dual pflash (AAVMF / EDK2) ù for Windows 11 ARM / aarch64 virt.
+	// UEFI dual pflash (AAVMF / EDK2) ¬ù for Windows 11 ARM / aarch64 virt.
 	// Inferno Apple SoC already uses SEP pflash (sep_nvram / sep_ssc) on unit 0/1;
 	// stacking edk2-aarch64-code.fd causes: "drive with bus=0, unit=0 exists".
 	if( UEFI && ! UEFI_CODE_File.isEmpty() && ! AQ_Is_Apple_SoC_VM( this ) )
@@ -9415,7 +9429,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	// Recovery / installer is attached earlier with OpenCore on AHCI
 	// (ide-hd for MIST APM+HFS; ide-cd for true ISO9660).
 	
-	// VirtIO RNG ù skip on Inferno (no usable PCI slot layout for virtio-*-pci).
+	// VirtIO RNG ¬ù skip on Inferno (no usable PCI slot layout for virtio-*-pci).
 	if( VirtIO_RNG && ! AQ_Is_Apple_SoC_VM( this ) )
 	{
 		// Windows QEMU builds do not provide rng-random (/dev/urandom); use rng-builtin
@@ -9435,11 +9449,11 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 	if( win11_post_install )
 		Args << "-device" << "virtio-serial-pci";
 	
-	// VirtIO Keyboard ù Inferno PCI root only accepts slot 0; skip for Apple SoC.
+	// VirtIO Keyboard ¬ù Inferno PCI root only accepts slot 0; skip for Apple SoC.
 	if( VirtIO_Keyboard && ! win11_post_install && ! AQ_Is_Apple_SoC_VM( this ) )
 		Args << "-device" << "virtio-keyboard-pci";
 
-	// Pointer / mouse (QEMU input devices). Inferno has onboard USB ù do not add PCI xhci.
+	// Pointer / mouse (QEMU input devices). Inferno has onboard USB ¬ù do not add PCI xhci.
 	if( ! AQ_Is_Apple_SoC_VM( this ) )
 	{
 		const QString mt = Mouse_Type.trimmed().toLower();
@@ -9526,7 +9540,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			added_xhci = true;
 			usb_bus = QStringLiteral( "aqemu_usb_hub.0" );
 			// Very old configs with USB_Hub but Mouse_Type still ps2 after a bad load:
-			// do not auto-add a second tablet here ù Mouse_Type is authoritative.
+			// do not auto-add a second tablet here ¬ù Mouse_Type is authoritative.
 		}
 
 		// aarch64/virt has no PS/2; Win11 installer needs usb-kbd before virtio drivers.
@@ -9992,7 +10006,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			ad_args = AQ_Filter_Apple_SoC_Additional_Args( ad_args );
 
 		// Drop #-comment lines / tokens. Notes mistakenly pasted into Additional Args
-		// (e.g. "# After Ubuntuù") become positional disk paths and clash with -hda.
+		// (e.g. "# After Ubuntu¬ù") become positional disk paths and clash with -hda.
 		{
 			QStringList cleaned;
 			cleaned.reserve( ad_args.size() );
@@ -10016,7 +10030,7 @@ QStringList Virtual_Machine::Build_QEMU_Args()
 			Args << ad_args[ ix ];
 	}
 
-	// Apple SoC restore ramdisk: dedicated field (not Additional Args ù UI often overwrites that).
+	// Apple SoC restore ramdisk: dedicated field (not Additional Args ¬ù UI often overwrites that).
 	if( AQ_Is_Apple_SoC_VM( this ) )
 	{
 		const QString initrd = Get_Apple_Initrd_Path().trimmed();
@@ -10484,7 +10498,8 @@ bool Virtual_Machine::Start_impl()
 		}
 		const QString image_dir = AQ_Apple_SoC_Image_Dir( this );
 		QString img_err;
-		if( ! AQ_Ensure_Apple_SoC_Disk_Images( image_dir, &img_err ) )
+		if( ! AQ_Ensure_Apple_SoC_Disk_Images( image_dir,
+			AQ_Apple_SoC_Nand_Bytes( Get_Apple_Nand_Size_GiB() ), &img_err ) )
 		{
 			AQGraphic_Error( "bool Virtual_Machine::Start()", tr( "Error!" ),
 				img_err.isEmpty()
@@ -10566,12 +10581,12 @@ bool Virtual_Machine::Start_impl()
 								? tr( "OpenCore and early boot text appear in AQEMU's embedded viewer.\n"
 								      "You enabled the experimental WSLg Reims host window "
 								      "(Advanced Settings). On some Dozen/NVIDIA WSLg stacks that "
-								      "path can crash QEMU during Vulkan device create ù if the VM "
+								      "path can crash QEMU during Vulkan device create ¬ù if the VM "
 								      "exits immediately, turn the option off." )
 								: tr( "OpenCore and early boot text appear in AQEMU's embedded viewer.\n\n"
 								      "The separate WSLg Reims host window is off by default: Mesa Dozen "
 								      "on WSLg (NVIDIA) can segfault inside vkCreateDevice and kill QEMU.\n"
-								      "Early boot uses VNC/GOP; enable ùReims WSLg host windowù under "
+								      "Early boot uses VNC/GOP; enable ¬ùReims WSLg host window¬ù under "
 								      "Advanced Settings only when you want to try accelerated present." ) );
 						s.setValue( QStringLiteral( "Reims/Shown_WSLg_Window_Hint_v2" ), true );
 					}
@@ -11403,7 +11418,7 @@ void Virtual_Machine::Kill_Orphan_QEMU_Using_Disks()
 	}
 
 	// Launch-via-WSL: Linux qemu-system often survives after wsl.exe / AQEMU die.
-	// Always try WSL cleanup on Windows when WSL is available ù orphans may remain
+	// Always try WSL cleanup on Windows when WSL is available ¬ù orphans may remain
 	// even if this VM's Launch_Via_WSL flag was flipped off later.
 	// Match on file basenames (paths differ: C:\ vs /mnt/c/).
 	QStringList basenames;
@@ -13634,6 +13649,14 @@ const QString &Virtual_Machine::Get_Apple_IPSW_Path() const { return Apple_IPSW_
 void Virtual_Machine::Set_Apple_IPSW_Path( const QString &path ) { Apple_IPSW_Path = AQ_Normalize_File_Path( path ); }
 const QString &Virtual_Machine::Get_Apple_Initrd_Path() const { return Apple_Initrd_Path; }
 void Virtual_Machine::Set_Apple_Initrd_Path( const QString &path ) { Apple_Initrd_Path = AQ_Normalize_File_Path( path ); }
+int Virtual_Machine::Get_Apple_Nand_Size_GiB() const
+{
+	return Apple_Nand_Size_GiB > 0 ? Apple_Nand_Size_GiB : AQ_Default_Apple_SoC_Nand_GiB();
+}
+void Virtual_Machine::Set_Apple_Nand_Size_GiB( int gib )
+{
+	Apple_Nand_Size_GiB = AQ_Clamp_Apple_SoC_Nand_GiB( gib );
+}
 bool Virtual_Machine::Use_Apple_KASLR_Off() const { return Apple_KASLR_Off; }
 void Virtual_Machine::Use_Apple_KASLR_Off( bool use ) { Apple_KASLR_Off = use; }
 const QString &Virtual_Machine::Get_Apple_USB_Conn_Type() const { return Apple_USB_Conn_Type; }
@@ -14232,6 +14255,7 @@ void Virtual_Machine::QEMU_Finished( int exitCode, QProcess::ExitStatus exitStat
 		( QEMU_Stderr_History + QLatin1Char( '\n' ) + QEMU_Stdout_History );
 	const bool restore_done_exit =
 		unexpected_apple &&
+		AQ_Apple_SoC_Root_Has_GPT( this ) &&
 		( apple_out.contains( QLatin1String( "Detected potentially-completed restore" ),
 		                      Qt::CaseInsensitive ) ||
 		  ( apple_out.contains( QLatin1String( "Auto Boot: false" ), Qt::CaseInsensitive ) &&
@@ -14239,7 +14263,18 @@ void Virtual_Machine::QEMU_Finished( int exitCode, QProcess::ExitStatus exitStat
 		    apple_out.contains( QLatin1String( "Boot Mode: 1" ), Qt::CaseInsensitive ) &&
 		    apple_out.contains( QLatin1String( "Boot Mode: 0" ), Qt::CaseInsensitive ) ) );
 
-	if( restore_done_exit )
+	const bool restore_ramdisk_exit =
+		unexpected_apple &&
+		! Get_Apple_Initrd_Path().trimmed().isEmpty() &&
+		! AQ_Apple_SoC_Root_Has_GPT( this );
+
+	if( restore_ramdisk_exit )
+	{
+		AQDebug( "void Virtual_Machine::QEMU_Finished",
+			 "Inferno exited after a restore ramdisk boot without a GPT on root "
+			 "(restore did not finish). Not treating this as a QEMU crash." );
+	}
+	else if( restore_done_exit )
 	{
 		const QString root_path = QDir::toNativeSeparators(
 			QFileInfo( Get_VM_XML_File_Path() ).absolutePath() +
@@ -14313,7 +14348,7 @@ void Virtual_Machine::QEMU_Finished( int exitCode, QProcess::ExitStatus exitStat
 			AQError( exitStatus == QProcess::CrashExit ? "QEMU Crashed!"
 			                                           : "QEMU return value != 0",
 			         summary );
-			// Short modal FIRST (never dump raw_out ù that freezes Error Log clicks).
+			// Short modal FIRST (never dump raw_out ¬ù that freezes Error Log clicks).
 			AQGraphic_Warning( tr( "iOS / Apple SoC stopped" ), summary );
 			if( ! raw_out.isEmpty() )
 				Show_QEMU_Error(

--- a/src/VM.h
+++ b/src/VM.h
@@ -643,6 +643,9 @@ class Virtual_Machine: public QObject
 		/** Restore ramdisk (-initrd). Empty = normal OS boot after restore. */
 		const QString &Get_Apple_Initrd_Path() const;
 		void Set_Apple_Initrd_Path( const QString &path );
+		/** Inferno NAND (`root`) size in GiB. Used only when creating/recreating root. */
+		int Get_Apple_Nand_Size_GiB() const;
+		void Set_Apple_Nand_Size_GiB( int gib );
 		bool Use_Apple_KASLR_Off() const;
 		void Use_Apple_KASLR_Off( bool use );
 		const QString &Get_Apple_USB_Conn_Type() const;
@@ -1002,6 +1005,7 @@ class Virtual_Machine: public QObject
 		QString Apple_SecureROM_Path;
 		QString Apple_IPSW_Path;
 		QString Apple_Initrd_Path;
+		int Apple_Nand_Size_GiB;
 		bool Apple_KASLR_Off;
 		QString Apple_USB_Conn_Type;
 		QString Apple_USB_Conn_Addr;

--- a/src/VM_Session_Widget.cpp
+++ b/src/VM_Session_Widget.cpp
@@ -14,6 +14,7 @@
 #include <QStyle>
 #include <QSizePolicy>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QJsonValue>
 #include <QMainWindow>
 #include <QMenuBar>
@@ -120,6 +121,7 @@ VM_Session_Widget::VM_Session_Widget( QWidget *parent )
 	, TB_USB( nullptr )
 	, Menu_USB( nullptr )
 	, USB_Enum_Busy( false )
+	, Apple_SOS_Busy( false )
 	, Serial_Win( nullptr )
 	, Button_Pad( nullptr )
 	, Light_FD0( nullptr )
@@ -235,11 +237,14 @@ void VM_Session_Widget::Build_Toolbar()
 	Act_Apple_Home = Toolbar->addAction( tr( "Home" ), this, SLOT(On_Apple_Home()) );
 	Act_Apple_Home->setToolTip( tr(
 		"Home / Menu (Inferno F6)\n"
-		"Click: Home screen  |  Use More… for App Switcher (double Home)" ) );
+		"Click: Home screen  |  Use More… for App Switcher (double Home)\n"
+		"Does nothing on Welcome / Swipe up to get started — use SOS" ) );
 	Act_Apple_Power = Toolbar->addAction( tr( "Side" ), this, SLOT(On_Apple_Power()) );
 	Act_Apple_Power->setToolTip( tr( "Power / Side button (Inferno F5). More… for hold." ) );
 	Act_Apple_SOS = Toolbar->addAction( tr( "SOS" ), this, SLOT(On_Apple_SOS()) );
-	Act_Apple_SOS->setToolTip( tr( "SOS / slide-to-power-off (Vol up, then Side)" ) );
+	Act_Apple_SOS->setToolTip( tr(
+		"SOS / slide-to-power-off (Vol up, then Side).\n"
+		"Use this to leave Welcome / Swipe up to get started (Home will not)" ) );
 	Act_Apple_More = Toolbar->addAction( tr( "More…" ), this, SLOT(On_Apple_More_Buttons()) );
 	Act_Apple_More->setToolTip( tr( "App Switcher, Power hold, Ringer, Force shutdown…" ) );
 	Act_Button_Pad = Toolbar->addAction( tr( "Pad" ), this, SLOT(On_Toggle_Button_Pad()) );
@@ -1538,13 +1543,49 @@ void VM_Session_Widget::Send_Apple_Key_Double( const QString &key_name )
 	} );
 }
 
+bool VM_Session_Widget::Send_Qmp_Key( const QString &qcode, bool down )
+{
+	QMP_Client *q = Active_QMP();
+	if( ! q || ! q->Is_Connected() || qcode.isEmpty() )
+		return false;
+
+	QJsonObject key;
+	key.insert( QStringLiteral( "type" ), QStringLiteral( "qcode" ) );
+	key.insert( QStringLiteral( "data" ), qcode );
+	QJsonObject data;
+	data.insert( QStringLiteral( "down" ), down );
+	data.insert( QStringLiteral( "key" ), key );
+	QJsonObject ev;
+	ev.insert( QStringLiteral( "type" ), QStringLiteral( "key" ) );
+	ev.insert( QStringLiteral( "data" ), data );
+	QJsonObject args;
+	args.insert( QStringLiteral( "events" ), QJsonArray{ ev } );
+	return q->Send_Command( QStringLiteral( "input-send-event" ), args );
+}
+
 void VM_Session_Widget::Send_Apple_SOS_Combo()
 {
-	// ChefKiss: hold volume up, then side (not both at once).
-	Send_Apple_Key( QStringLiteral( "f4" ), 2000 );
-	QTimer::singleShot( 500, this, [this]() {
-		Send_Apple_Key( QStringLiteral( "f5" ), 1500 );
-	} );
+	// ChefKiss: hold Vol+, then Side after ~0.5s (overlap, not two separate taps).
+	// Two HMP sendkey commands never overlap — QEMU's kbd queue is serial, so the
+	// old "sendkey f4 2000" then "sendkey f5" only changed volume.
+	if( Apple_SOS_Busy )
+		return;
+
+	if( Send_Qmp_Key( QStringLiteral( "f4" ), true ) )
+	{
+		Apple_SOS_Busy = true;
+		QTimer::singleShot( 500, this, [this]() {
+			Send_Qmp_Key( QStringLiteral( "f5" ), true );
+			QTimer::singleShot( 2000, this, [this]() {
+				Send_Qmp_Key( QStringLiteral( "f5" ), false );
+				Send_Qmp_Key( QStringLiteral( "f4" ), false );
+				Apple_SOS_Busy = false;
+			} );
+		} );
+		return;
+	}
+
+	Send_Monitor( QStringLiteral( "sendkey f4-f5 2500" ) );
 }
 
 void VM_Session_Widget::Update_Apple_Controls_Visibility()

--- a/src/VM_Session_Widget.h
+++ b/src/VM_Session_Widget.h
@@ -134,6 +134,7 @@ class VM_Session_Widget : public QWidget
 		void Send_Apple_Key( const QString &key_name, int hold_ms = 0 );
 		void Send_Apple_Key_Double( const QString &key_name );
 		void Send_Apple_SOS_Combo();
+		bool Send_Qmp_Key( const QString &qcode, bool down );
 		void Update_Apple_Controls_Visibility();
 		void Ensure_Button_Pad();
 		void Position_Button_Pad();
@@ -192,6 +193,7 @@ class VM_Session_Widget : public QWidget
 		QMenu *Menu_USB;
 		QHash<QString, QString> Connected_USB_Ids; // instance key -> qemu device id
 		bool USB_Enum_Busy;
+		bool Apple_SOS_Busy;
 		QPointer<QThread> USB_Scan_Thread;
 		Serial_Console_Window *Serial_Win;
 		Apple_SoC_Button_Pad *Button_Pad;

--- a/src/VM_Wizard_Window.cpp
+++ b/src/VM_Wizard_Window.cpp
@@ -46,6 +46,7 @@
 #include <QSizePolicy>
 #include <QFrame>
 #include <QComboBox>
+#include <QSpinBox>
 #include <QProcess>
 #include <QSet>
 #include <QCoreApplication>
@@ -87,6 +88,8 @@ VM_Wizard_Window::VM_Wizard_Window( QWidget *parent )
 	Edit_Typical_Disk_Path = nullptr;
 	TB_Typical_Disk_Browse = nullptr;
 	Widget_Typical_Size_Row = nullptr;
+	CB_Wizard_Nand = nullptr;
+	SB_Wizard_Nand = nullptr;
 	Edit_Install_ISO = nullptr;
 	TB_Install_ISO_Browse = nullptr;
 	TB_Install_ISO_Storage = nullptr;
@@ -2925,7 +2928,22 @@ void VM_Wizard_Window::Enhance_Typical_HDD_Page()
 	QHBoxLayout *sizeLay = new QHBoxLayout( Widget_Typical_Size_Row );
 	sizeLay->setContentsMargins( 20, 0, 0, 0 );
 	sizeLay->addWidget( ui.Label_HDD_Size );
+	CB_Wizard_Nand = new QComboBox( Widget_Typical_Size_Row );
+	SB_Wizard_Nand = new QSpinBox( Widget_Typical_Size_Row );
+	AQ_Apply_Apple_SoC_Nand_Controls( CB_Wizard_Nand, SB_Wizard_Nand, AQ_Default_Apple_SoC_Nand_GiB() );
+	CB_Wizard_Nand->setVisible( false );
+	SB_Wizard_Nand->setVisible( false );
+	sizeLay->addWidget( CB_Wizard_Nand );
+	sizeLay->addWidget( SB_Wizard_Nand );
 	sizeLay->addWidget( ui.SB_HDD_Size );
+	connect( CB_Wizard_Nand, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+	         this, [this]( int ) {
+		AQ_On_Apple_SoC_Nand_Combo_Changed( CB_Wizard_Nand, SB_Wizard_Nand );
+	} );
+	connect( SB_Wizard_Nand, QOverload<int>::of( &QSpinBox::valueChanged ),
+	         this, [this]( int ) {
+		AQ_On_Apple_SoC_Nand_Spin_Changed( CB_Wizard_Nand, SB_Wizard_Nand );
+	} );
 	sizeLay->addStretch( 1 );
 	lay->addWidget( Widget_Typical_Size_Row );
 
@@ -3114,6 +3132,71 @@ void VM_Wizard_Window::Typical_New_Disk_Toggled( bool on )
 	}
 	if( on )
 		Refresh_Typical_HDD_Defaults();
+}
+
+void VM_Wizard_Window::Apply_Apple_Nand_HDD_Page_Mode()
+{
+	const bool apple = Is_Apple_Silicon_Or_iOS_Template();
+	if( ui.Label_HDD_Size )
+	{
+		ui.Label_HDD_Size->setText( apple
+			? tr( "NAND (root) size:" )
+			: tr( "Disk Size in GB (Gigabytes):" ) );
+	}
+	if( CB_Wizard_Nand )
+		CB_Wizard_Nand->setVisible( apple );
+	if( SB_Wizard_Nand )
+		SB_Wizard_Nand->setVisible( apple );
+	if( ui.SB_HDD_Size )
+	{
+		ui.SB_HDD_Size->setVisible( ! apple );
+		if( apple )
+		{
+			int want = AQ_Default_Apple_SoC_Nand_GiB();
+			if( Guest_HDD_GB >= 16.0 )
+				want = AQ_Clamp_Apple_SoC_Nand_GiB( qRound( Guest_HDD_GB ) );
+			AQ_Apply_Apple_SoC_Nand_Controls( CB_Wizard_Nand, SB_Wizard_Nand, want );
+		}
+		else
+		{
+			ui.SB_HDD_Size->setDecimals( 1 );
+			ui.SB_HDD_Size->setMinimum( 0.1 );
+			ui.SB_HDD_Size->setMaximum( 500.0 );
+			ui.SB_HDD_Size->setSingleStep( 1.0 );
+			ui.SB_HDD_Size->setToolTip( QString() );
+		}
+	}
+	if( RB_Typical_New_Disk )
+		RB_Typical_New_Disk->setVisible( ! apple );
+	if( RB_Typical_Existing_Disk )
+		RB_Typical_Existing_Disk->setVisible( ! apple );
+	if( Edit_Typical_Disk_Path )
+		Edit_Typical_Disk_Path->setVisible( ! apple );
+	if( TB_Typical_Disk_Browse )
+		TB_Typical_Disk_Browse->setVisible( ! apple );
+	if( Widget_Typical_Size_Row )
+		Widget_Typical_Size_Row->setVisible( true );
+	if( RB_Install_Local )
+		RB_Install_Local->setVisible( ! apple );
+	if( RB_Install_URL_ISO )
+		RB_Install_URL_ISO->setVisible( ! apple );
+	if( RB_Install_Network_Kernel )
+		RB_Install_Network_Kernel->setVisible( ! apple );
+	if( Widget_Install_Local_Row )
+		Widget_Install_Local_Row->setVisible( ! apple );
+	if( Widget_Install_URL_Row )
+		Widget_Install_URL_Row->setVisible( ! apple );
+	if( Widget_Install_Kernel_Row )
+		Widget_Install_Kernel_Row->setVisible( ! apple );
+}
+
+void VM_Wizard_Window::Show_Typical_HDD_Page()
+{
+	Apply_Apple_Nand_HDD_Page_Mode();
+	ui.Wizard_Pages->setCurrentWidget( ui.Typical_HDD_Page );
+	ui.Label_Page->setText( Is_Apple_Silicon_Or_iOS_Template()
+		? tr( "NAND (root) size" )
+		: tr( "Virtual Hard Disk" ) );
 }
 
 void VM_Wizard_Window::Typical_Disk_Browse_Clicked()
@@ -3311,6 +3394,17 @@ void VM_Wizard_Window::Download_Network_Initrd_Clicked()
 
 bool VM_Wizard_Window::Validate_Typical_HDD_Page()
 {
+	if( Is_Apple_Silicon_Or_iOS_Template() )
+	{
+		if( AQ_Read_Apple_SoC_Nand_Controls( CB_Wizard_Nand, SB_Wizard_Nand )
+		    < AQ_Min_Apple_SoC_Nand_GiB() )
+		{
+			AQGraphic_Warning( tr( "NAND (root)" ),
+				tr( "Pick at least 16 GiB. ChefKiss recommends 32 GiB. Custom allows up to 2048 GiB." ) );
+			return false;
+		}
+		return true;
+	}
 	if( ! Edit_Typical_Disk_Path )
 		return true;
 	const QString path = QDir::toNativeSeparators( Edit_Typical_Disk_Path->text().trimmed() );
@@ -4004,8 +4098,7 @@ void VM_Wizard_Window::on_Button_Back_clicked()
 		if( ui.RB_Typical->isChecked() )
 		{
 			Refresh_Typical_HDD_Defaults();
-			ui.Wizard_Pages->setCurrentWidget( ui.Typical_HDD_Page );
-			ui.Label_Page->setText( tr("Virtual Hard Disk") );
+			Show_Typical_HDD_Page();
 		}
 		else
 		{
@@ -4018,8 +4111,7 @@ void VM_Wizard_Window::on_Button_Back_clicked()
 		if( ui.RB_Typical->isChecked() )
 		{
 			Refresh_Typical_HDD_Defaults();
-			ui.Wizard_Pages->setCurrentWidget( ui.Typical_HDD_Page );
-			ui.Label_Page->setText( tr("Virtual Hard Disk") );
+			Show_Typical_HDD_Page();
 		}
 		else
 		{
@@ -4055,8 +4147,7 @@ void VM_Wizard_Window::on_Button_Back_clicked()
 		else if( ui.RB_Typical->isChecked() ) // typical or custom mode
 		{
 			Refresh_Typical_HDD_Defaults();
-			ui.Wizard_Pages->setCurrentWidget( ui.Typical_HDD_Page );
-			ui.Label_Page->setText( tr("Virtual Hard Disk") );
+			Show_Typical_HDD_Page();
 		}
 		else
 		{
@@ -4078,8 +4169,7 @@ void VM_Wizard_Window::on_Button_Back_clicked()
 		else if( ui.RB_Typical->isChecked() )
 		{
 			Refresh_Typical_HDD_Defaults();
-			ui.Wizard_Pages->setCurrentWidget( ui.Typical_HDD_Page );
-			ui.Label_Page->setText( tr("Virtual Hard Disk") );
+			Show_Typical_HDD_Page();
 		}
 		else
 		{
@@ -4384,8 +4474,7 @@ void VM_Wizard_Window::on_Button_Next_clicked()
 			else
 			{
 				Refresh_Typical_HDD_Defaults();
-				ui.Wizard_Pages->setCurrentWidget( ui.Typical_HDD_Page );
-				ui.Label_Page->setText( tr("Virtual Hard Disk") );
+				Show_Typical_HDD_Page();
 			}
 		}
 		else
@@ -4855,6 +4944,10 @@ bool VM_Wizard_Window::Create_New_VM(bool simulate)
 		{
 			New_VM->Set_HDA( VM_HDD(true, Edit_Intel_Mac_Existing_Disk->text()) );
 		}
+		else if( Is_Apple_Silicon_Or_iOS_Template() )
+		{
+			New_VM->Set_HDA( VM_HDD( false, QString() ) );
+		}
 		else if( RB_Typical_Existing_Disk && RB_Typical_Existing_Disk->isChecked()
 		         && Edit_Typical_Disk_Path
 		         && ! Edit_Typical_Disk_Path->text().trimmed().isEmpty() )
@@ -5137,8 +5230,8 @@ void VM_Wizard_Window::Update_Finish_Page_Guidance()
 		help = tr( "<p><b>Apple SoC / iOS (Inferno) — AQEMU 1.3.0</b></p><ul>"
 			"<li>Uses Linux <code>qemu-system-applesoc</code> (ChefKiss Inferno). "
 			"On Windows this is forced through <b>WSL</b> (UNIX sockets / companion restore).</li>"
-			"<li>Set kernelcache, DeviceTree, trustcache, restore ticket, and SEP firmware "
-			"on the VM page. AQEMU creates the Inferno NVMe image set under the VM folder.</li>"
+			"<li>The wizard <b>NAND (root) size</b> page: 16 / 32 / 64 / 128 / 256 GiB "
+			"or Custom (16–2048 GiB). Default 32 GiB. Same control as MACHINE.</li>"
 			"<li>Create the companion first: Guest OS → Apple → "
 			"<b>iPhone IPSW Restore Companion</b>, then "
 			"<b>File → Apple SoC Restore</b>.</li>"
@@ -5379,11 +5472,14 @@ void VM_Wizard_Window::Apply_Apple_SoC_Profile( bool simulate )
 	New_VM->Set_Apple_USB_Conn_Addr( QStringLiteral( "/tmp/InfernoUSBRemote" ) );
 #endif
 	New_VM->Set_Apple_USB_Conn_Port( 8030 );
+	New_VM->Set_Apple_Nand_Size_GiB( AQ_Read_Apple_SoC_Nand_Controls(
+		CB_Wizard_Nand, SB_Wizard_Nand ) );
 
 	if( ! simulate )
 	{
 		QString err;
-		if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_folder, &err ) )
+		if( ! AQ_Ensure_Apple_SoC_Disk_Images( vm_folder,
+			AQ_Apple_SoC_Nand_Bytes( New_VM->Get_Apple_Nand_Size_GiB() ), &err ) )
 			AQWarning( "VM_Wizard_Window::Apply_Apple_SoC_Profile", err );
 	}
 }

--- a/src/VM_Wizard_Window.h
+++ b/src/VM_Wizard_Window.h
@@ -39,6 +39,7 @@
 #include <QTreeWidget>
 #include <QListWidget>
 #include <QComboBox>
+#include <QSpinBox>
 #include <QJsonObject>
 
 #include "VM.h"
@@ -101,6 +102,8 @@ class VM_Wizard_Window: public QDialog
 		void Typical_New_Disk_Toggled( bool on );
 		void Typical_Disk_Browse_Clicked();
 		void Refresh_Typical_HDD_Defaults();
+		void Apply_Apple_Nand_HDD_Page_Mode();
+		void Show_Typical_HDD_Page();
 		bool Validate_Typical_HDD_Page();
 		QString Default_Typical_HDA_Path() const;
 		void Install_ISO_Browse_Clicked();
@@ -201,6 +204,8 @@ class VM_Wizard_Window: public QDialog
 		QLineEdit *Edit_Typical_Disk_Path;
 		QToolButton *TB_Typical_Disk_Browse;
 		QWidget *Widget_Typical_Size_Row;
+		QComboBox *CB_Wizard_Nand;
+		QSpinBox *SB_Wizard_Nand;
 		QLineEdit *Edit_Install_ISO;
 		QToolButton *TB_Install_ISO_Browse;
 		QToolButton *TB_Install_ISO_Storage;

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -511,31 +511,88 @@ QString iOS_Firmware_Tool_Window::Restore_Ramdisk_From_Manifest( const QString &
 	if( ! f.open( QIODevice::ReadOnly ) )
 		return QString();
 	const QByteArray data = f.readAll();
-	const QString text = QString::fromUtf8( data );
-	QRegularExpression xml_re(
-		QStringLiteral( "RestoreRamDisk</key>\\s*<string>([^<]+\\.dmg)</string>" ),
+	f.close();
+
+	const QString model = CB_Ticket_Model
+		? CB_Ticket_Model->currentData().toString() : QString();
+	const QRegularExpression path_xml(
+		QStringLiteral( "<key>Path</key>\\s*<string>([^<]+\\.dmg)</string>" ),
 		QRegularExpression::CaseInsensitiveOption );
-	const QRegularExpressionMatch xml = xml_re.match( text );
-	QString name;
-	if( xml.hasMatch() )
-		name = QFileInfo( xml.captured( 1 ).trimmed() ).fileName();
-	if( name.isEmpty() )
+	const QRegularExpression numbered_dmg( QStringLiteral( "([0-9]{3}-[0-9]+-[0-9]+\\.dmg)" ) );
+
+	QString best_path;
+	int best_score = -1;
+	int pos = 0;
+	const QByteArray needle( "RestoreRamDisk" );
+	while( ( pos = data.indexOf( needle, pos ) ) >= 0 )
 	{
-		const int key = data.indexOf( "RestoreRamDisk" );
-		if( key >= 0 )
+		const QString ahead = QString::fromUtf8( data.mid( pos, 4096 ) );
+		if( ahead.contains( QLatin1String( "CustomerRamDisk" ), Qt::CaseInsensitive )
+		    && ! ahead.contains( QLatin1String( ".dmg" ), Qt::CaseInsensitive ) )
 		{
-			const QString slice = QString::fromLatin1( data.mid( key, 512 ) );
-			QRegularExpression dmg_re( QStringLiteral( "([0-9A-Za-z._-]+\\.dmg)" ) );
-			const QRegularExpressionMatch dmg = dmg_re.match( slice );
+			pos += needle.size();
+			continue;
+		}
+
+		QString name;
+		const QRegularExpressionMatch xml = path_xml.match( ahead );
+		if( xml.hasMatch() )
+			name = QFileInfo( xml.captured( 1 ).trimmed() ).fileName();
+		if( name.isEmpty() )
+		{
+			const QRegularExpressionMatch dmg = numbered_dmg.match( ahead );
 			if( dmg.hasMatch() )
 				name = dmg.captured( 1 );
 		}
+		if( name.isEmpty() || ! name.endsWith( QLatin1String( ".dmg" ), Qt::CaseInsensitive ) )
+		{
+			pos += needle.size();
+			continue;
+		}
+
+		const QString cand = QDir( extract_dir ).filePath( name );
+		if( ! QFile::exists( cand ) )
+		{
+			pos += needle.size();
+			continue;
+		}
+
+		const QString back = QString::fromUtf8( data.mid( qMax( 0, pos - 8000 ), 8000 ) );
+		int score = 1;
+		if( ! model.isEmpty() && back.contains( model, Qt::CaseInsensitive ) )
+			score += 10;
+		if( back.contains( QLatin1String( "Erase" ), Qt::CaseInsensitive ) )
+			score += 5;
+		if( back.contains( QLatin1String( "Customer" ), Qt::CaseInsensitive ) )
+			score += 2;
+		if( score > best_score )
+		{
+			best_score = score;
+			best_path = cand;
+		}
+		pos += needle.size();
 	}
-	if( name.isEmpty() )
-		return QString();
-	const QString path = QDir( extract_dir ).filePath( name );
-	if( QFile::exists( path ) )
-		return path;
+
+	if( ! best_path.isEmpty() )
+		return best_path;
+
+	const QString restore_plist = QDir( extract_dir ).filePath( QStringLiteral( "Restore.plist" ) );
+	QFile rf( restore_plist );
+	if( rf.open( QIODevice::ReadOnly ) )
+	{
+		const QString rtext = QString::fromUtf8( rf.readAll() );
+		QRegularExpression user_re(
+			QStringLiteral( "RestoreRamDisks</key>\\s*<dict>[\\s\\S]{0,400}?<key>User</key>\\s*<string>([^<]+\\.dmg)</string>" ),
+			QRegularExpression::CaseInsensitiveOption );
+		const QRegularExpressionMatch um = user_re.match( rtext );
+		if( um.hasMatch() )
+		{
+			const QString cand = QDir( extract_dir ).filePath(
+				QFileInfo( um.captured( 1 ).trimmed() ).fileName() );
+			if( QFile::exists( cand ) )
+				return cand;
+		}
+	}
 	return QString();
 }
 

--- a/src/iOS_Firmware_Tool_Window.cpp
+++ b/src/iOS_Firmware_Tool_Window.cpp
@@ -139,7 +139,9 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 	QGridLayout *gridT = new QGridLayout( gb_tick );
 	gridT->addWidget( new QLabel( tr(
 		"Uses bundled extras/Inferno scripts. Needs Python 3 with pyasn1 "
-		"(AQEMU will pip-install if missing). ticket.shsh2 comes from ChefKiss extras." ) ),
+		"(AQEMU will pip-install if missing). "
+		"ticket.shsh2 is not in the IPSW and is not shipped by AQEMU — "
+		"get it from ChefKiss Inferno file setup, then Browse…" ) ),
 		0, 0, 1, 3 );
 
 	gridT->addWidget( new QLabel( tr( "Model:" ) ), 1, 0 );
@@ -157,14 +159,18 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 
 	gridT->addWidget( new QLabel( tr( "ticket.shsh2:" ) ), 3, 0 );
 	Edit_SHSH = new QLineEdit();
+	Edit_SHSH->setPlaceholderText( tr( "Not in the IPSW — Browse after you save ChefKiss’s file" ) );
 	gridT->addWidget( Edit_SHSH, 3, 1 );
 	auto *shshRow = new QHBoxLayout();
 	auto *btnShsh = new QPushButton( tr( "Browse..." ) );
 	connect( btnShsh, &QPushButton::clicked, this, &iOS_Firmware_Tool_Window::Browse_SHSH );
-	auto *btnShshWeb = new QPushButton( tr( "ChefKiss extras…" ) );
+	auto *btnShshWeb = new QPushButton( tr( "How to get this…" ) );
+	btnShshWeb->setToolTip( tr(
+		"Opens ChefKiss Inferno file setup. They host ticket.shsh2 for the unsigned IPSW flow. "
+		"AQEMU does not download or ship that blob (Apple Img4 ticket data)." ) );
 	connect( btnShshWeb, &QPushButton::clicked, this, []() {
 		QDesktopServices::openUrl( QUrl( QStringLiteral(
-			"https://chefkiss.dev/Extras/Inferno/" ) ) );
+			"https://chefkiss.dev/guides/inferno/file-setup/" ) ) );
 	} );
 	shshRow->addWidget( btnShsh );
 	shshRow->addWidget( btnShshWeb );
@@ -174,11 +180,37 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 
 	gridT->addWidget( new QLabel( tr( "Restore ticket (.der):" ) ), 4, 0 );
 	Edit_Ticket_Out = new QLineEdit();
-	gridT->addWidget( Edit_Ticket_Out, 4, 1, 1, 2 );
+	Edit_Ticket_Out->setPlaceholderText( tr( "Forge writes here — Browse to choose path" ) );
+	gridT->addWidget( Edit_Ticket_Out, 4, 1 );
+	auto *btnTicketOut = new QPushButton( tr( "Browse..." ) );
+	connect( btnTicketOut, &QPushButton::clicked, this, [this]() {
+		QString start = Edit_Ticket_Out->text().trimmed();
+		if( start.isEmpty() )
+			start = QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "root_ticket.der" ) );
+		const QString file = QFileDialog::getSaveFileName(
+			this, tr( "Restore ticket (.der)" ), start,
+			tr( "Ticket (*.der);;All (*)" ) );
+		if( ! file.isEmpty() )
+			Edit_Ticket_Out->setText( QDir::toNativeSeparators( file ) );
+	} );
+	gridT->addWidget( btnTicketOut, 4, 2 );
 
 	gridT->addWidget( new QLabel( tr( "SEP ticket (.der):" ) ), 5, 0 );
 	Edit_Sep_Ticket_Out = new QLineEdit();
-	gridT->addWidget( Edit_Sep_Ticket_Out, 5, 1, 1, 2 );
+	Edit_Sep_Ticket_Out->setPlaceholderText( tr( "Forge writes here — Browse to choose path" ) );
+	gridT->addWidget( Edit_Sep_Ticket_Out, 5, 1 );
+	auto *btnSepTicketOut = new QPushButton( tr( "Browse..." ) );
+	connect( btnSepTicketOut, &QPushButton::clicked, this, [this]() {
+		QString start = Edit_Sep_Ticket_Out->text().trimmed();
+		if( start.isEmpty() )
+			start = QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "sep_root_ticket.der" ) );
+		const QString file = QFileDialog::getSaveFileName(
+			this, tr( "SEP ticket (.der)" ), start,
+			tr( "Ticket (*.der);;All (*)" ) );
+		if( ! file.isEmpty() )
+			Edit_Sep_Ticket_Out->setText( QDir::toNativeSeparators( file ) );
+	} );
+	gridT->addWidget( btnSepTicketOut, 5, 2 );
 
 	Btn_Forge_Tickets = new QPushButton( tr( "Forge restore + SEP tickets" ) );
 	Btn_Forge_Tickets->setToolTip( tr(
@@ -216,7 +248,12 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 
 	gridS->addWidget( new QLabel( tr( "IVKEY (IV then key, no space):" ) ), 2, 0 );
 	Edit_SEP_IVKEY = new QLineEdit();
-	Edit_SEP_IVKEY->setPlaceholderText( tr( "Paste Apple Wiki IV+key for this build" ) );
+	Edit_SEP_IVKEY->setPlaceholderText( tr(
+		"SEP-Firmware only: 32-char IV then 64-char Key, no spaces (96 hex)" ) );
+	Edit_SEP_IVKEY->setToolTip( tr(
+		"Apple Wiki → your IPSW build → iPhone12,1 → heading SEP-Firmware "
+		"(sep-firmware.n104.RELEASE.im4p). Paste IV immediately followed by Key. "
+		"Do not use iBoot/iBEC keys. Build 18A373 keys do not decrypt 18A5351d." ) );
 	gridS->addWidget( Edit_SEP_IVKEY, 2, 1 );
 	auto *btnWiki = new QPushButton( tr( "Apple Wiki…" ) );
 	connect( btnWiki, &QPushButton::clicked, this, []() {
@@ -227,11 +264,37 @@ void iOS_Firmware_Tool_Window::Setup_Ui()
 
 	gridS->addWidget( new QLabel( tr( "Decrypted SEP:" ) ), 3, 0 );
 	Edit_SEP_Dec = new QLineEdit();
-	gridS->addWidget( Edit_SEP_Dec, 3, 1, 1, 2 );
+	Edit_SEP_Dec->setPlaceholderText( tr( "img4 decrypt output" ) );
+	gridS->addWidget( Edit_SEP_Dec, 3, 1 );
+	auto *btnSepDec = new QPushButton( tr( "Browse..." ) );
+	connect( btnSepDec, &QPushButton::clicked, this, [this]() {
+		QString start = Edit_SEP_Dec->text().trimmed();
+		if( start.isEmpty() )
+			start = QDir( Edit_Output_Dir->text() ).filePath( QStringLiteral( "sep-firmware.n104.RELEASE" ) );
+		const QString file = QFileDialog::getSaveFileName(
+			this, tr( "Decrypted SEP" ), start, tr( "All (*)" ) );
+		if( ! file.isEmpty() )
+			Edit_SEP_Dec->setText( QDir::toNativeSeparators( file ) );
+	} );
+	gridS->addWidget( btnSepDec, 3, 2 );
 
 	gridS->addWidget( new QLabel( tr( "Packed SEP (.img4):" ) ), 4, 0 );
 	Edit_SEP_Out = new QLineEdit();
-	gridS->addWidget( Edit_SEP_Out, 4, 1, 1, 2 );
+	Edit_SEP_Out->setPlaceholderText( tr( "MACHINE → SEP firmware" ) );
+	gridS->addWidget( Edit_SEP_Out, 4, 1 );
+	auto *btnSepOut = new QPushButton( tr( "Browse..." ) );
+	connect( btnSepOut, &QPushButton::clicked, this, [this]() {
+		QString start = Edit_SEP_Out->text().trimmed();
+		if( start.isEmpty() )
+			start = QDir( Edit_Output_Dir->text() ).filePath(
+				QStringLiteral( "sep-firmware.n104.RELEASE.new.img4" ) );
+		const QString file = QFileDialog::getSaveFileName(
+			this, tr( "Packed SEP firmware" ), start,
+			tr( "IMG4 (*.img4);;All (*)" ) );
+		if( ! file.isEmpty() )
+			Edit_SEP_Out->setText( QDir::toNativeSeparators( file ) );
+	} );
+	gridS->addWidget( btnSepOut, 4, 2 );
 
 	Btn_Pack_SEP = new QPushButton( tr( "Decrypt + pack SEP firmware" ) );
 	Btn_Pack_SEP->setToolTip( tr(
@@ -564,7 +627,12 @@ QString iOS_Firmware_Tool_Window::Restore_Ramdisk_From_Manifest( const QString &
 		if( back.contains( QLatin1String( "Erase" ), Qt::CaseInsensitive ) )
 			score += 5;
 		if( back.contains( QLatin1String( "Customer" ), Qt::CaseInsensitive ) )
-			score += 2;
+			score += 8;
+		// Update ramdisk takes verify_storage_for_update + newfs_apfs System.
+		// Inferno GUI restore needs Customer/Erase (038-44135 on 18A5351d).
+		if( back.contains( QLatin1String( "Update" ), Qt::CaseInsensitive )
+		    && ! back.contains( QLatin1String( "Erase" ), Qt::CaseInsensitive ) )
+			score -= 20;
 		if( score > best_score )
 		{
 			best_score = score;
@@ -668,7 +736,10 @@ void iOS_Firmware_Tool_Window::Run_Forge_Tickets()
 	if( shsh.isEmpty() || ! QFile::exists( shsh ) )
 	{
 		QMessageBox::warning( this, tr( "ticket.shsh2" ),
-			tr( "Select ChefKiss ticket.shsh2 (ChefKiss extras… or extras/Inferno/ticket.shsh2)." ) );
+			tr( "ticket.shsh2 is not inside the IPSW and AQEMU does not ship it.\n\n"
+			    "On ChefKiss Inferno file setup, download the ticket SHSH they provide "
+			    "for this flow, save it, then Browse… to that file.\n"
+			    "https://chefkiss.dev/guides/inferno/file-setup/" ) );
 		return;
 	}
 	QSettings s;
@@ -719,7 +790,11 @@ void iOS_Firmware_Tool_Window::Run_Pack_SEP()
 	if( ! Ensure_Img4_Available() )
 		return;
 	const QString im4p = Edit_SEP_IM4P->text().trimmed();
-	const QString ivkey = Edit_SEP_IVKEY->text().trimmed().remove( QLatin1Char( ' ' ) );
+	QString ivkey = Edit_SEP_IVKEY->text();
+	ivkey.replace( QRegularExpression( QStringLiteral( "(?i)\\biv\\s*:" ) ), QString() );
+	ivkey.replace( QRegularExpression( QStringLiteral( "(?i)\\bkey\\s*:" ) ), QString() );
+	ivkey.replace( QRegularExpression( QStringLiteral( "[^0-9A-Fa-f]" ) ), QString() );
+	ivkey = ivkey.toLower();
 	const QString ticket = Edit_Sep_Ticket_Out->text().trimmed();
 	if( im4p.isEmpty() || ! QFile::exists( im4p ) )
 	{
@@ -727,10 +802,12 @@ void iOS_Firmware_Tool_Window::Run_Pack_SEP()
 			tr( "Unpack the IPSW first, or browse to sep-firmware.n104.RELEASE.im4p." ) );
 		return;
 	}
-	if( ivkey.isEmpty() )
+	if( ivkey.size() != 96 )
 	{
 		QMessageBox::warning( this, tr( "IVKEY" ),
-			tr( "Paste the Apple Wiki IV and key concatenated (no space) for this SEP file." ) );
+			tr( "Need the SEP-Firmware IV (32 hex) immediately followed by its Key (64 hex), "
+			    "96 characters total. Not iBoot. Must match this IPSW build.\n\n"
+			    "You pasted %1 hex character(s)." ).arg( ivkey.size() ) );
 		return;
 	}
 	if( ticket.isEmpty() || ! QFile::exists( ticket ) )

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -42,4 +42,12 @@ Install dirs `qemu-build*` / `qemu-install` are gitignored.
 
 ## Optional: pyimg4 (iOS firmware tool)
 
-AQEMU’s **File → iOS Firmware Tool** unpacks IPSWs, forges restore/SEP tickets (bundled Python scripts), packs SEP firmware with external **`img4`**, and processes IM4P with **`pyimg4`**. AQEMU does **not** vendor `img4lib` / `pyimg4` under `third_party/` — put `img4.exe` / `pyimg4.exe` next to `aqemu.exe` or on PATH. Python 3 is only started from the GUI (pip-installs pyasn1 if needed).
+AQEMU’s **File → iOS Firmware Tool** unpacks IPSWs, forges restore/SEP tickets (bundled Python scripts), packs SEP firmware with external **`img4`**, and processes IM4P with **`pyimg4`**. AQEMU does **not** vendor [xerub/img4lib](https://github.com/xerub/img4lib) or `pyimg4` in git.
+
+**Windows `img4.exe`:** MSYS2 gcc + OpenSSL, then from the repo root:
+
+```
+.\scripts\build_img4_windows.ps1
+```
+
+That clones `third_party/img4lib` (gitignored), overlays `extras/Inferno/patches/img4lib_vfs_file_win.c` (`O_BINARY` / `_commit`), and copies `img4.exe` next to `build_win\aqemu.exe`. Point **File → Configure → iOS firmware tools → img4** at that binary, or leave it beside AQEMU. `pyimg4.exe` is Step 4 only — do not use it as `img4`. Python 3 is only started from the GUI (pip-installs pyasn1 if needed).


### PR DESCRIPTION
## Summary

This PR bundles the latest Inferno iOS-on-Windows improvements from recent AQEMU work:

- **Configurable NAND size** — pick 16 / 32 / 64 / 128 / 256 GiB or a custom size (16–2048 GiB) when creating the \oot\ NVMe image. Controls are on the **Machine** tab, **New VM Wizard** disk page, and **Apple SoC Restore** dialog. Default is 32 GiB (replacing the old 8 GiB default). Changing size requires **Wipe Inferno disks** + re-restore.
- **SOS button fix** — sends simultaneous QMP \input-send-event\ key presses (Vol up + Side) instead of sequential \sendkey\, matching the ChefKiss workaround for the **Welcome / Swipe up to get started** screen where Home and swipe gestures do not work on Face ID Inferno devices.
- **Unsigned IPA install (zsign)** — **Device Tools → Install IPA** can adhoc-sign IPAs on the companion with **zsign** (auto-built on first use). Generates a self-signed cert + fake mobileprovision so \installd\ gets a proper CMS/PKCS7 blob instead of bare ldid hashes.
- **Firmware Tool UX** — clearer \	icket.shsh2\ sourcing (ChefKiss guide link, not shipped by AQEMU), Browse buttons for forge output paths, RestoreRamdisk auto-fill from \BuildManifest.plist\ (\Path\ key), and improved SEP IVKEY guidance.
- **iOS Installation guide** — documents the three \irmware_extracted\ \.dmg\ files, how \-initrd\ puts the guest into recovery, SOS vs Home on setup, ticket/SEP/DeviceTree steps, and Windows \img4\ build via \scripts/build_img4_windows.ps1\.
- **Inferno restore helpers** — bundle GPT seeding / APFS placeholder scripts (\seed-root-gpt.py\, \ormat-seed-apfs.sh\, \orce_create_fs_partitions.c\, \patch_idevicerestore_cfs.py\, \uild_force_cfs.sh\) and Windows \img4lib\ vfs overlay.

## Commits

1. \ix: parse RestoreRamDisk Path from IPSW BuildManifest\
2. \eat(ios): NAND sizing, SOS workaround, zsign IPA install, and install docs\

## Test plan

- [ ] New VM Wizard → Apple iOS: NAND combo shows 16/32/64/128/256 + Custom; custom spinbox clamps 16–2048 GiB
- [ ] Machine tab: NAND size persists in VM config; label shows on-disk \oot\ size after wipe/power-on
- [ ] Apple SoC Restore dialog: NAND size syncs with VM; wipe + restore at 32 GiB shows ~32 GiB in iOS Settings
- [ ] On **Welcome / Swipe up** screen: **SOS** triggers slide-to-power-off path; **Home** tooltip explains limitation
- [ ] Firmware Tool: unpack IPSW → Restore ramdisk field auto-fills from BuildManifest; forge tickets with ChefKiss \	icket.shsh2\
- [ ] Device Tools → Install IPA with zsign enabled: companion builds zsign once, signs IPA, runs \ideviceinstaller\
- [ ] \.\scripts\build_img4_windows.ps1\ produces \img4.exe\ on Windows (MSYS2 gcc + OpenSSL)
- [ ] Read through \xtras/Inferno/iOS_Installation.md\ — three \.dmg\ table and \-initrd\ recovery section are accurate

Made with [Cursor](https://cursor.com)